### PR TITLE
Fix dependency injection error in FeaturedContentService

### DIFF
--- a/webroot/modules/custom/saho_featured_articles/saho_featured_articles.services.yml
+++ b/webroot/modules/custom/saho_featured_articles/saho_featured_articles.services.yml
@@ -1,10 +1,9 @@
 services:
   saho_featured_articles.content_service:
     class: Drupal\saho_featured_articles\Service\FeaturedContentService
-    arguments: 
+    arguments:
       - '@entity_type.manager'
       - '@database'
-      - '@logger.factory'
       - '@config.factory'
     
   saho_featured_articles.statistics_service:


### PR DESCRIPTION
Remove extra @logger.factory argument from service definition that was causing TypeError. Service constructor expects 3 arguments but definition was providing 4, causing ConfigFactoryInterface to receive wrong service.