### PR TITLE
SAHO: Fix CSP violations for Google Analytics regional domains

### DIFF
--- a/config/sync/seckit.settings.yml
+++ b/config/sync/seckit.settings.yml
@@ -17,7 +17,7 @@ seckit_xss:
     frame-ancestors: "'self'"
     child-src: "'self'"
     font-src: "'self' fonts.gstatic.com data:"
-    connect-src: "'self' www.google-analytics.com"
+    connect-src: "'self' *.google-analytics.com www.google-analytics.com"
     report-uri: /report-csp-violation
     upgrade-req: true
     policy-uri: ''


### PR DESCRIPTION
Update SecKit CSP connect-src directive to allow *.google-analytics.com to support GA4 regional endpoints (region1.google-analytics.com, etc.) and prevent CSP violation log spam.