### PR TITLE
SAHO: Add Google Tag Manager and HTTP v1 subdomain variants to CSP

### DIFF
--- a/config/sync/seckit.settings.yml
+++ b/config/sync/seckit.settings.yml
@@ -11,13 +11,13 @@ seckit_xss:
     script-src: "'self' 'unsafe-inline' 'unsafe-eval' www.google-analytics.com www.googletagmanager.com *.googleapis.com static.cloudflareinsights.com unpkg.com"
     object-src: "'self'"
     style-src: "'self' 'unsafe-inline' fonts.googleapis.com"
-    img-src: "'self' data: www.google-analytics.com www.googletagmanager.com v1.sahistory.org.za *.tile.openstreetmap.org unpkg.com"
+    img-src: "'self' data: www.google-analytics.com www.googletagmanager.com v1.sahistory.org.za http://v1.sahistory.org.za http://www.v1.sahistory.org.za https://v1.sahistory.org.za *.tile.openstreetmap.org unpkg.com"
     media-src: "'self'"
     frame-src: "'self' www.youtube.com youtube.com"
     frame-ancestors: "'self'"
     child-src: "'self'"
     font-src: "'self' fonts.gstatic.com data:"
-    connect-src: "'self' *.google-analytics.com www.google-analytics.com"
+    connect-src: "'self' *.google-analytics.com www.google-analytics.com www.googletagmanager.com"
     report-uri: /report-csp-violation
     upgrade-req: true
     policy-uri: ''


### PR DESCRIPTION
- Add www.googletagmanager.com to connect-src for GTM data collection
- Add HTTP and www variants of v1.sahistory.org.za to img-src for legacy content