### PR TITLE
Bugfix: Use vendor/bin/drush universally in image cleanup scripts

### DIFF
--- a/fix_remaining_borders.sh
+++ b/fix_remaining_borders.sh
@@ -36,5 +36,5 @@ for img in "${IMAGES_TO_FIX[@]}"; do
 done
 
 echo "Done! Now run:"
-echo "  ddev drush image-flush --all"
-echo "  ddev drush cr"
+echo "  vendor/bin/drush image-flush --all"
+echo "  vendor/bin/drush cr"

--- a/trim_place_images.sh
+++ b/trim_place_images.sh
@@ -59,15 +59,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Detect if we're in DDEV or production
-if command -v ddev &> /dev/null && ddev describe &> /dev/null 2>&1; then
-    DRUSH="ddev drush"
-    ENVIRONMENT="DDEV"
-elif command -v drush &> /dev/null; then
-    DRUSH="drush"
-    ENVIRONMENT="production"
-else
-    echo "❌ Error: Neither 'ddev drush' nor 'drush' command found"
+# Use vendor/bin/drush universally (works in all environments)
+DRUSH="vendor/bin/drush"
+if [ ! -f "$DRUSH" ]; then
+    echo "❌ Error: Drush not found at vendor/bin/drush"
+    echo "Run 'composer install' first"
     exit 1
 fi
 
@@ -147,7 +143,6 @@ mkdir -p "$BACKUP_DIR"
 log "========================================="
 log "Place Image Border Removal Script"
 log "========================================="
-log "Environment: $ENVIRONMENT"
 log "Dry Run: $DRY_RUN"
 log "Fuzz Tolerance: $FUZZ_TOLERANCE%"
 log "Backup Directory: $BACKUP_DIR"


### PR DESCRIPTION
Updates both trim_place_images.sh and fix_remaining_borders.sh to use vendor/bin/drush instead of environment detection (ddev drush vs drush).

Changes:
- Replace environment detection logic with simple vendor/bin/drush check
- Remove ENVIRONMENT variable and logging (no longer needed)
- Update fix_remaining_borders.sh instructions to use vendor/bin/drush
- Simplify error messaging

Benefits:
- Works universally across all environments (DDEV, production, CI/CD)
- No need for ddev to be installed in production
- Consistent behavior everywhere
- Simpler code with less branching logic