### PR TITLE
Fix product images causing 500 errors

### DIFF
--- a/webroot/themes/custom/saho_shop/templates/commerce/commerce-product--full.html.twig
+++ b/webroot/themes/custom/saho_shop/templates/commerce/commerce-product--full.html.twig
@@ -19,13 +19,13 @@
   <div class="product-main">
     {# Product Gallery #}
     <div class="commerce-product__gallery">
-      {% if product.field_images|render %}
+      {% if content.field_images|render %}
         <div class="main-image">
-          {{ product.field_images.0 }}
+          {{ content.field_images.0 }}
         </div>
-        {% if product.field_images|length > 1 %}
+        {% if content.field_images|length > 1 %}
           <div class="thumbnails">
-            {% for image in product.field_images %}
+            {% for image in content.field_images %}
               {{ image }}
             {% endfor %}
           </div>
@@ -42,9 +42,9 @@
       {# Title and Subtitle #}
       <h1 class="product-title">{{ product.title.value }}</h1>
 
-      {% if product.field_subtitle|render %}
+      {% if content.field_subtitle|render %}
         <div class="product-subtitle">
-          {{ product.field_subtitle }}
+          {{ content.field_subtitle }}
         </div>
       {% endif %}
 


### PR DESCRIPTION
CRITICAL: Products with images were failing with 500 errors

## Problem
- Template still using product.field_images (entity access)
- Should use content.field_images (pre-rendered)
- Only affected products with images (20 of 33 products)
- Products without images worked fine

## Solution
Changed image field access from product.* to content.*:
- product.field_images → content.field_images
- product.field_subtitle → content.field_subtitle (also fixed)

## Why This Fixes It
- content.field_images is already rendered by Drupal
- Safe to iterate and display
- Handles media entities correctly
- No entity object printing errors

## Impact
- Products with images now load correctly
- All 33 products should work
- No more 'cannot be printed' errors for images

Fixes: Products 2,5,6,7,8,9,10,11,12,13,18,19,20,21,22,26,27,28,30,31,32