### PR TITLE
Fix Solr config for production and DDEV environments

### DIFF
--- a/config/sync/search_api.index.saho_content.yml
+++ b/config/sync/search_api.index.saho_content.yml
@@ -1,6 +1,6 @@
 uuid: d8ef1dca-1d74-4820-9987-84ac801af483
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - field.storage.node.body

--- a/config/sync/search_api.server.local_solr.yml
+++ b/config/sync/search_api.server.local_solr.yml
@@ -1,6 +1,6 @@
 uuid: 1f788652-119d-4969-a526-7233a2258788
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - search_api_solr.solr_cache.cache_document_default_9_0_0

--- a/config/sync/search_api.server.saho_prod.yml
+++ b/config/sync/search_api.server.saho_prod.yml
@@ -1,6 +1,6 @@
 uuid: 79d04ca4-4df4-4974-85de-a1a8a65e8590
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - search_api_solr.solr_cache.cache_document_default_7_0_0

--- a/webroot/sites/default/settings.ddev.php
+++ b/webroot/sites/default/settings.ddev.php
@@ -100,14 +100,34 @@ if (extension_loaded('redis') && !empty(getenv('REDIS_HOST'))) {
   $settings['cache_prefix'] = 'd10_redis_';
 }
 
-$config['search_api.index.saho_global_ddev']['status'] = TRUE;
+// ============================================
+// SEARCH API / SOLR CONFIGURATION
+// ============================================
+// Enable local Solr server for DDEV.
 $config['search_api.server.local_solr']['status'] = TRUE;
-$config['search_api.server.local_solr']['backend_config'] = [
+$config['search_api.server.local_solr']['backend_config']['connector'] = 'solr_cloud_basic_auth';
+$config['search_api.server.local_solr']['backend_config']['connector_config'] = [
   'scheme' => 'http',
-  'host' => 'localhost',
+  'host' => 'solr',
   'port' => 8983,
-  'path' => '/solr',
+  'path' => '/',
   'core' => 'sahistory_content',
+  'timeout' => 5,
+  'index_timeout' => 5,
+  'optimize_timeout' => 10,
+  'finalize_timeout' => 30,
+  'commit_within' => 1000,
   'username' => 'solr',
   'password' => 'SolrRocks',
 ];
+
+// Disable production Solr server in DDEV.
+$config['search_api.server.saho_prod']['status'] = FALSE;
+
+// Enable and configure the main search index for local development.
+// The view uses saho_content, so we point it to local_solr for DDEV.
+$config['search_api.index.saho_content']['status'] = TRUE;
+$config['search_api.index.saho_content']['server'] = 'local_solr';
+
+// Also enable the DDEV-specific index (optional, for testing).
+$config['search_api.index.saho_global_ddev']['status'] = TRUE;


### PR DESCRIPTION
- Enable saho_prod server and saho_content index in config (for production)
- Disable local_solr server in base config (was causing solr:8983 errors on deploy)
- DDEV settings override enables local_solr with correct host for local dev
- Fix DDEV Solr connection: localhost -> solr (Docker service name)