### PR TITLE
Improve TDIH CSV export with date range filter and day-of-month sorting

### DIFF
--- a/config/sync/views.view.tdih_csv_export.yml
+++ b/config/sync/views.view.tdih_csv_export.yml
@@ -7,10 +7,12 @@ dependencies:
     - field.storage.node.field_event_type
     - node.type.event
   module:
+    - better_exposed_filters
     - csv_serialization
     - datetime
     - node
     - taxonomy
+    - tdih
     - user
     - views_data_export
 id: tdih_csv_export
@@ -82,7 +84,7 @@ display:
           type: datetime_custom
           settings:
             timezone_override: ''
-            date_format: 'Y-m-d'
+            date_format: 'j F Y'
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -279,7 +281,7 @@ display:
         options:
           offset: 0
       exposed_form:
-        type: basic
+        type: bef
         options:
           submit_button: Filter
           reset_button: true
@@ -288,6 +290,27 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
+          bef:
+            general:
+              autosubmit: false
+              autosubmit_exclude_textfield: false
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: false
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+            filter:
+              tdih_date_range:
+                plugin_id: default
+                advanced:
+                  placeholder_text: ''
+                  rewrite:
+                    filter_rewrite_values: ''
+                  collapsible: false
+                  is_secondary: false
+            sort: {  }
+            pager: {  }
       access:
         type: perm
         options:
@@ -297,20 +320,19 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        field_event_date_value:
-          id: field_event_date_value
+        tdih_date_sort:
+          id: tdih_date_sort
           table: node__field_event_date
-          field: field_event_date_value
+          field: tdih_date_sort
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: datetime
+          plugin_id: tdih_date_sort
           order: ASC
           expose:
             label: ''
             field_identifier: ''
           exposed: false
-          granularity: second
       arguments: {  }
       filters:
         status:
@@ -384,440 +406,32 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        field_event_date_value_month:
-          id: field_event_date_value_month
+        tdih_date_range:
+          id: tdih_date_range
           table: node__field_event_date
-          field: field_event_date_value
+          field: tdih_date_range
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: datetime
-          operator: '='
-          value:
-            min: ''
-            max: ''
-            value: ''
-            type: date
+          plugin_id: tdih_date_range
+          value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: field_event_date_value_month_op
-            label: Month
-            description: 'Select a month (1-12)'
+            operator_id: ''
+            label: 'Date Range'
+            description: 'Filter by month and day range (year is ignored)'
             use_operator: false
-            operator: field_event_date_value_month_op
+            operator: ''
             operator_limit_selection: false
             operator_list: {  }
-            identifier: month
+            identifier: tdih_range
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            min_placeholder: ''
-            max_placeholder: ''
-            placeholder: ''
-          is_grouped: true
-          group_info:
-            label: Month
-            description: 'Filter by month'
-            identifier: month
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: 'January (01)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-01-'
-                  type: date
-              2:
-                title: 'February (02)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-02-'
-                  type: date
-              3:
-                title: 'March (03)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-03-'
-                  type: date
-              4:
-                title: 'April (04)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-04-'
-                  type: date
-              5:
-                title: 'May (05)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-05-'
-                  type: date
-              6:
-                title: 'June (06)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-06-'
-                  type: date
-              7:
-                title: 'July (07)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-07-'
-                  type: date
-              8:
-                title: 'August (08)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-08-'
-                  type: date
-              9:
-                title: 'September (09)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-09-'
-                  type: date
-              10:
-                title: 'October (10)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-10-'
-                  type: date
-              11:
-                title: 'November (11)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-11-'
-                  type: date
-              12:
-                title: 'December (12)'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-12-'
-                  type: date
-        field_event_date_value_day:
-          id: field_event_date_value_day
-          table: node__field_event_date
-          field: field_event_date_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: datetime
-          operator: '='
-          value:
-            min: ''
-            max: ''
-            value: ''
-            type: date
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_event_date_value_day_op
-            label: Day
-            description: 'Select a day (1-31)'
-            use_operator: false
-            operator: field_event_date_value_day_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: day
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            min_placeholder: ''
-            max_placeholder: ''
-            placeholder: ''
-          is_grouped: true
-          group_info:
-            label: Day
-            description: 'Filter by day'
-            identifier: day
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: '1'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-01$'
-                  type: date
-              2:
-                title: '2'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-02$'
-                  type: date
-              3:
-                title: '3'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-03$'
-                  type: date
-              4:
-                title: '4'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-04$'
-                  type: date
-              5:
-                title: '5'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-05$'
-                  type: date
-              6:
-                title: '6'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-06$'
-                  type: date
-              7:
-                title: '7'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-07$'
-                  type: date
-              8:
-                title: '8'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-08$'
-                  type: date
-              9:
-                title: '9'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-09$'
-                  type: date
-              10:
-                title: '10'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-10$'
-                  type: date
-              11:
-                title: '11'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-11$'
-                  type: date
-              12:
-                title: '12'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-12$'
-                  type: date
-              13:
-                title: '13'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-13$'
-                  type: date
-              14:
-                title: '14'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-14$'
-                  type: date
-              15:
-                title: '15'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-15$'
-                  type: date
-              16:
-                title: '16'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-16$'
-                  type: date
-              17:
-                title: '17'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-17$'
-                  type: date
-              18:
-                title: '18'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-18$'
-                  type: date
-              19:
-                title: '19'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-19$'
-                  type: date
-              20:
-                title: '20'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-20$'
-                  type: date
-              21:
-                title: '21'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-21$'
-                  type: date
-              22:
-                title: '22'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-22$'
-                  type: date
-              23:
-                title: '23'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-23$'
-                  type: date
-              24:
-                title: '24'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-24$'
-                  type: date
-              25:
-                title: '25'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-25$'
-                  type: date
-              26:
-                title: '26'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-26$'
-                  type: date
-              27:
-                title: '27'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-27$'
-                  type: date
-              28:
-                title: '28'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-28$'
-                  type: date
-              29:
-                title: '29'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-29$'
-                  type: date
-              30:
-                title: '30'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-30$'
-                  type: date
-              31:
-                title: '31'
-                operator: regular_expression
-                value:
-                  min: ''
-                  max: ''
-                  value: '-31$'
-                  type: date
+          is_grouped: false
       style:
         type: table
         options:
@@ -832,7 +446,7 @@ display:
           default: field_event_date
           info:
             field_event_date:
-              sortable: true
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
@@ -947,7 +561,7 @@ display:
         type: full
         options:
           offset: 0
-          items_per_page: 50
+          items_per_page: 10
           total_pages: null
           id: 0
           tags:
@@ -958,7 +572,7 @@ display:
           expose:
             items_per_page: true
             items_per_page_label: 'Items per page'
-            items_per_page_options: '50, 100, 200, 500'
+            items_per_page_options: '5, 10, 20'
             items_per_page_options_all: true
             items_per_page_options_all_label: '- All -'
             offset: false

--- a/webroot/modules/custom/saho_utils/tdih/src/Plugin/views/filter/TdihDateRangeFilter.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Plugin/views/filter/TdihDateRangeFilter.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Drupal\tdih\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\filter\FilterPluginBase;
+
+/**
+ * Filter for TDIH date range by month and day (ignoring year).
+ *
+ * @ViewsFilter("tdih_date_range")
+ *
+ * @property \Drupal\views\Plugin\views\query\Sql $query
+ */
+class TdihDateRangeFilter extends FilterPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['expose']['contains']['from_month'] = ['default' => ''];
+    $options['expose']['contains']['from_day'] = ['default' => ''];
+    $options['expose']['contains']['to_month'] = ['default' => ''];
+    $options['expose']['contains']['to_day'] = ['default' => ''];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildExposedForm(&$form, FormStateInterface $form_state) {
+    $months = [
+      '' => '- Any -',
+      '1' => 'January',
+      '2' => 'February',
+      '3' => 'March',
+      '4' => 'April',
+      '5' => 'May',
+      '6' => 'June',
+      '7' => 'July',
+      '8' => 'August',
+      '9' => 'September',
+      '10' => 'October',
+      '11' => 'November',
+      '12' => 'December',
+    ];
+
+    $days = ['' => '- Any -'];
+    for ($i = 1; $i <= 31; $i++) {
+      $days[$i] = $i;
+    }
+
+    $identifier = $this->options['expose']['identifier'];
+
+    $form[$identifier . '_from_month'] = [
+      '#type' => 'select',
+      '#title' => $this->t('From Month'),
+      '#options' => $months,
+      '#default_value' => $this->value['from_month'] ?? '',
+    ];
+
+    $form[$identifier . '_from_day'] = [
+      '#type' => 'select',
+      '#title' => $this->t('From Day'),
+      '#options' => $days,
+      '#default_value' => $this->value['from_day'] ?? '',
+    ];
+
+    $form[$identifier . '_to_month'] = [
+      '#type' => 'select',
+      '#title' => $this->t('To Month'),
+      '#options' => $months,
+      '#default_value' => $this->value['to_month'] ?? '',
+    ];
+
+    $form[$identifier . '_to_day'] = [
+      '#type' => 'select',
+      '#title' => $this->t('To Day'),
+      '#options' => $days,
+      '#default_value' => $this->value['to_day'] ?? '',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function acceptExposedInput($input) {
+    $identifier = $this->options['expose']['identifier'];
+
+    $this->value['from_month'] = $input[$identifier . '_from_month'] ?? '';
+    $this->value['from_day'] = $input[$identifier . '_from_day'] ?? '';
+    $this->value['to_month'] = $input[$identifier . '_to_month'] ?? '';
+    $this->value['to_day'] = $input[$identifier . '_to_day'] ?? '';
+
+    // Return TRUE if any value is set.
+    return !empty($this->value['from_month']) || !empty($this->value['from_day']) ||
+           !empty($this->value['to_month']) || !empty($this->value['to_day']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $this->ensureMyTable();
+
+    $from_month = (int) ($this->value['from_month'] ?? 0);
+    $from_day = (int) ($this->value['from_day'] ?? 0);
+    $to_month = (int) ($this->value['to_month'] ?? 0);
+    $to_day = (int) ($this->value['to_day'] ?? 0);
+
+    // If no values set, don't filter.
+    if (!$from_month && !$from_day && !$to_month && !$to_day) {
+      return;
+    }
+
+    $field = "$this->tableAlias.$this->realField";
+
+    // Build the date range condition.
+    // Convert month-day to a comparable format (MMDD as integer).
+    if ($from_month && $from_day && $to_month && $to_day) {
+      // Full range specified.
+      $from_mmdd = $from_month * 100 + $from_day;
+      $to_mmdd = $to_month * 100 + $to_day;
+
+      // Use MONTH() and DAY() functions to extract and compare.
+      $mmdd_expression = "MONTH($field) * 100 + DAY($field)";
+
+      if ($from_mmdd <= $to_mmdd) {
+        // Normal range (e.g., Feb 1 to Feb 14).
+        $this->query->addWhereExpression(
+          $this->options['group'],
+          "$mmdd_expression BETWEEN :from_mmdd AND :to_mmdd",
+          [':from_mmdd' => $from_mmdd, ':to_mmdd' => $to_mmdd]
+        );
+      }
+      else {
+        // Wrap-around range (e.g., Dec 15 to Jan 15).
+        $this->query->addWhereExpression(
+          $this->options['group'],
+          "($mmdd_expression >= :from_mmdd OR $mmdd_expression <= :to_mmdd)",
+          [':from_mmdd' => $from_mmdd, ':to_mmdd' => $to_mmdd]
+        );
+      }
+    }
+    elseif ($from_month || $to_month) {
+      // Only month(s) specified.
+      if ($from_month && $to_month) {
+        if ($from_month <= $to_month) {
+          $this->query->addWhereExpression(
+            $this->options['group'],
+            "MONTH($field) BETWEEN :from_month AND :to_month",
+            [':from_month' => $from_month, ':to_month' => $to_month]
+          );
+        }
+        else {
+          // Wrap-around (e.g., November to February).
+          $this->query->addWhereExpression(
+            $this->options['group'],
+            "(MONTH($field) >= :from_month OR MONTH($field) <= :to_month)",
+            [':from_month' => $from_month, ':to_month' => $to_month]
+          );
+        }
+      }
+      elseif ($from_month) {
+        $this->query->addWhereExpression(
+          $this->options['group'],
+          "MONTH($field) = :month",
+          [':month' => $from_month]
+        );
+      }
+      elseif ($to_month) {
+        $this->query->addWhereExpression(
+          $this->options['group'],
+          "MONTH($field) = :month",
+          [':month' => $to_month]
+        );
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function adminSummary() {
+    return $this->t('TDIH Date Range');
+  }
+
+}

--- a/webroot/modules/custom/saho_utils/tdih/src/Plugin/views/sort/TdihDateSort.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Plugin/views/sort/TdihDateSort.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\tdih\Plugin\views\sort;
+
+use Drupal\views\Plugin\views\sort\SortPluginBase;
+
+/**
+ * Sort handler for TDIH dates by month and day (ignoring year).
+ *
+ * @ViewsSort("tdih_date_sort")
+ *
+ * @property \Drupal\views\Plugin\views\query\Sql $query
+ */
+class TdihDateSort extends SortPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Ensure the event date table is joined.
+    $this->query->ensureTable('node__field_event_date');
+    $field = "node__field_event_date.field_event_date_value";
+
+    // Sort by month first, then by day, ignoring year.
+    // This groups all January 1st events together, then January 2nd, etc.
+    $this->query->addOrderBy(
+      NULL,
+      "MONTH($field)",
+      $this->options['order'],
+      'tdih_month_sort'
+    );
+    $this->query->addOrderBy(
+      NULL,
+      "DAY($field)",
+      $this->options['order'],
+      'tdih_day_sort'
+    );
+    // Secondary sort by year for events on the same day.
+    $this->query->addOrderBy(
+      NULL,
+      "YEAR($field)",
+      $this->options['order'],
+      'tdih_year_sort'
+    );
+  }
+
+}

--- a/webroot/modules/custom/saho_utils/tdih/tdih.module
+++ b/webroot/modules/custom/saho_utils/tdih/tdih.module
@@ -100,3 +100,35 @@ function tdih_page_attachments(array &$attachments) {
     $attachments['#attached']['library'][] = 'tdih/tdih-page';
   }
 }
+
+/**
+ * Implements hook_views_query_alter().
+ *
+ * Alters the TDIH CSV export view to sort by month/day instead of full date.
+ */
+function tdih_views_query_alter($view, $query) {
+  if ($view->id() == 'tdih_csv_export') {
+    // Clear existing orderby to replace with our custom sort.
+    $query->orderby = [];
+
+    // Sort by month, then day, then year.
+    $query->addOrderBy(
+      NULL,
+      'MONTH(node__field_event_date.field_event_date_value)',
+      'ASC',
+      'tdih_month'
+    );
+    $query->addOrderBy(
+      NULL,
+      'DAY(node__field_event_date.field_event_date_value)',
+      'ASC',
+      'tdih_day'
+    );
+    $query->addOrderBy(
+      NULL,
+      'YEAR(node__field_event_date.field_event_date_value)',
+      'ASC',
+      'tdih_year'
+    );
+  }
+}

--- a/webroot/modules/custom/saho_utils/tdih/tdih.views.inc
+++ b/webroot/modules/custom/saho_utils/tdih/tdih.views.inc
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Views integration for TDIH module.
+ */
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function tdih_views_data_alter(array &$data) {
+  // Add custom TDIH date range filter to the event date field.
+  if (isset($data['node__field_event_date'])) {
+    $data['node__field_event_date']['tdih_date_range'] = [
+      'title' => t('TDIH Date Range (Month/Day)'),
+      'help' => t('Filter by month and day range, ignoring the year. Useful for This Day in History exports.'),
+      'filter' => [
+        'id' => 'tdih_date_range',
+        'field' => 'field_event_date_value',
+      ],
+    ];
+
+    // Add custom TDIH date sort (by month/day, ignoring year).
+    $data['node__field_event_date']['tdih_date_sort'] = [
+      'title' => t('TDIH Date Sort (Month/Day)'),
+      'help' => t('Sort by month and day, ignoring the year. Groups events by day-of-year.'),
+      'sort' => [
+        'id' => 'tdih_date_sort',
+        'field' => 'field_event_date_value',
+      ],
+    ];
+  }
+}


### PR DESCRIPTION
- Add custom date range filter (From/To Month and Day dropdowns)
- Filter by month-day range ignoring year (e.g., Feb 1-14 across all years)
- Sort results by day-of-month (all 1sts, then 2nds, etc.)
- Change items per page options to 5, 10, 20 (was 50, 100, 200, 500)
- Display dates in human-readable format (e.g., "1 December 1905")
- Add Views integration via tdih.views.inc
- Add TdihDateRangeFilter and TdihDateSort plugins