### PR TITLE
Fix: Update TDIH button to link to event node

### DIFF
--- a/.ddev/docker-compose.nodejs.yaml
+++ b/.ddev/docker-compose.nodejs.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       - "5173:5173"  # Vite dev server
       - "4173:4173"  # Vite preview server
-      - "3000:3000"  # Production Node.js server
+      - "3002:3000"  # Production Node.js server
     volumes:
       - type: bind
         source: ../saho-timeline-svelte

--- a/webroot/modules/custom/saho_utils/tdih/css/tdih-interactive.css
+++ b/webroot/modules/custom/saho_utils/tdih/css/tdih-interactive.css
@@ -403,7 +403,7 @@
   text-decoration: none;
 }
 
-/* "View more historical events" button - Ghost/Outline style to differentiate from solid buttons */
+/* "Read more" button - Ghost/Outline style to differentiate from solid buttons */
 .tdih-view-more-button.saho-button,
 .tdih-view-more-button.saho-button--primary {
   background: transparent !important;

--- a/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
@@ -171,8 +171,8 @@ class TdihInteractiveBlock extends BlockBase implements ContainerFactoryPluginIn
 
     $form['show_explore_button'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Show "Explore more historical events" button'),
-      '#description' => $this->t('Enable to show the button that links to the full This Day in History page.'),
+      '#title' => $this->t('Show "Read more" button'),
+      '#description' => $this->t('Enable to show the "Read more" button that links to the displayed event.'),
       '#default_value' => $this->configuration['show_explore_button'],
     ];
 

--- a/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
+++ b/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
@@ -110,16 +110,18 @@
     {% endif %}
   </div>
 
-  {% if show_explore_button %}
+  {% if show_explore_button and all_events|length > 0 %}
     <div class="tdih-footer text-center mt-4">
-      {% include 'saho:saho-button' with {
-        text: 'View more historical events'|t,
-        url: '/this-day-in-history',
-        size: 'medium',
-        attributes: {
-          class: ['tdih-view-more-button']
-        }
-      } %}
+      {% for item in all_events|slice(0, 1) %}
+        {% include 'saho:saho-button' with {
+          text: 'Read more'|t,
+          url: item.url,
+          size: 'medium',
+          attributes: {
+            class: ['tdih-view-more-button']
+          }
+        } %}
+      {% endfor %}
     </div>
   {% endif %}
 </div>

--- a/webroot/themes/custom/saho/templates/block/block--inline-block--tdih.html.twig
+++ b/webroot/themes/custom/saho/templates/block/block--inline-block--tdih.html.twig
@@ -42,11 +42,15 @@
     </div>
   {% endif %}
   
-  <div class="block-buttons">
-    {% include 'saho:saho-button' with {
-      text: 'More history'|t,
-      url: '/this-day-in-history',
-      size: 'medium'
-    } %}
-  </div>
+  {% if tdih_nodes %}
+    <div class="block-buttons">
+      {% for item in tdih_nodes %}
+        {% include 'saho:saho-button' with {
+          text: 'Read more'|t,
+          url: item.url,
+          size: 'medium'
+        } %}
+      {% endfor %}
+    </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
Changes:
- Update TDIH block button to link directly to displayed event node
- Change button text to "Read more" for clarity and brevity
- Fix nodejs container port conflict (3000 -> 3002)
- Update block configuration description to reflect new button behavior

Technical details:
- webroot/modules/custom/saho_utils/tdih/: Updated interactive block PHP and templates
- webroot/themes/custom/saho/templates/block/: Updated TDIH inline block template
- .ddev/docker-compose.nodejs.yaml: Changed port mapping to avoid conflict with other projects