### PR TITLE
fix: Show TDIH button even when no events are displayed

### DIFF
--- a/webroot/modules/custom/saho_utils/tdih/css/tdih-interactive.css
+++ b/webroot/modules/custom/saho_utils/tdih/css/tdih-interactive.css
@@ -428,6 +428,32 @@
   box-shadow: 0 2px 6px rgba(153, 0, 0, 0.15) !important;
 }
 
+/* Fallback "View more events" button - Solid style for no-events state */
+.tdih-fallback-button.saho-button,
+.tdih-fallback-button.saho-button--secondary {
+  background: var(--tdih-color-primary) !important;
+  color: var(--tdih-color-white) !important;
+  border: 2px solid var(--tdih-color-primary) !important;
+  box-shadow: 0 2px 8px rgba(153, 0, 0, 0.15) !important;
+}
+
+.tdih-fallback-button.saho-button:hover,
+.tdih-fallback-button.saho-button--secondary:hover,
+.tdih-fallback-button.saho-button:focus,
+.tdih-fallback-button.saho-button--secondary:focus {
+  background: var(--tdih-color-primary-dark) !important;
+  color: var(--tdih-color-white) !important;
+  border-color: var(--tdih-color-primary-dark) !important;
+  box-shadow: 0 4px 12px rgba(153, 0, 0, 0.25) !important;
+}
+
+.tdih-fallback-button.saho-button:active,
+.tdih-fallback-button.saho-button--secondary:active {
+  transform: translateY(1px) !important;
+  box-shadow: 0 2px 6px rgba(153, 0, 0, 0.2) !important;
+  color: var(--tdih-color-white) !important;
+}
+
 /* African Drum Loading Indicator */
 .tdih-interactive-block .ajax-progress {
   position: relative;

--- a/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
+++ b/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
@@ -110,18 +110,30 @@
     {% endif %}
   </div>
 
-  {% if show_explore_button and all_events|length > 0 %}
+  {% if show_explore_button %}
     <div class="tdih-footer text-center mt-4">
-      {% for item in all_events|slice(0, 1) %}
+      {% if all_events|length > 0 %}
+        {% for item in all_events|slice(0, 1) %}
+          {% include 'saho:saho-button' with {
+            text: 'Read more'|t,
+            url: item.url,
+            size: 'medium',
+            attributes: {
+              class: ['tdih-view-more-button']
+            }
+          } %}
+        {% endfor %}
+      {% else %}
         {% include 'saho:saho-button' with {
-          text: 'Read more'|t,
-          url: item.url,
+          text: 'View more events from this day'|t,
+          url: '/this-day-in-history',
           size: 'medium',
+          variant: 'secondary',
           attributes: {
-            class: ['tdih-view-more-button']
+            class: ['tdih-view-more-button', 'tdih-fallback-button']
           }
         } %}
-      {% endfor %}
+      {% endif %}
     </div>
   {% endif %}
 </div>


### PR DESCRIPTION
The button now always appears when show_explore_button is enabled:
- If events exist: 'Read more' with outline style linking to event
- If no events: 'View more events from this day' with solid style linking to TDIH page

This ensures the button is always accessible and visually distinct based on context.