### PR TITLE
feat: Switch to git tags for version tracking

### DIFF
--- a/scripts/deploy-default.sh
+++ b/scripts/deploy-default.sh
@@ -41,16 +41,16 @@ error_exit() {
 
 log "Starting deployment for default site"
 
-# Increment deploy version
-if [ -f "${PROJECT_ROOT}/DEPLOY_VERSION" ]; then
-    CURRENT_VERSION=$(cat "${PROJECT_ROOT}/DEPLOY_VERSION")
-    NEW_VERSION=$((CURRENT_VERSION + 1))
+# Get current version from git tag
+CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "no-tag")
+CURRENT_COMMIT_SHORT=$(git rev-parse --short HEAD)
+if [ "$CURRENT_TAG" = "no-tag" ]; then
+    VERSION="commit-${CURRENT_COMMIT_SHORT}"
 else
-    NEW_VERSION=1
+    VERSION="${CURRENT_TAG}"
 fi
-echo "$NEW_VERSION" > "${PROJECT_ROOT}/DEPLOY_VERSION"
-log "Deploy version: ${NEW_VERSION}"
-echo -e "${GREEN}Deploy #${NEW_VERSION}${NC}"
+log "Current version: ${VERSION}"
+echo -e "${GREEN}Deploying version: ${VERSION}${NC}"
 
 # Git pull
 echo -e "${YELLOW}[1/4] Pulling code...${NC}"
@@ -95,6 +95,8 @@ vendor/bin/drush cr -l "${SITE_URI}" >> "${LOG_FILE}" 2>&1
 
 echo ""
 echo -e "${GREEN}✓ DEPLOYMENT SUCCESSFUL${NC}"
-echo -e "Deploy version: #${NEW_VERSION}"
+echo -e "Version: ${VERSION}"
 echo -e "Log: ${LOG_FILE}"
+echo ""
+echo -e "${YELLOW}To tag a new version:${NC} git tag v1.2.3 && git push origin v1.2.3"
 echo ""

--- a/version.php
+++ b/version.php
@@ -1,23 +1,37 @@
 <?php
 /**
- * Display current deploy version
+ * Display current deployment version
  *
  * Access at: https://yourdomain.com/version.php
  */
 
-$version_file = __DIR__ . '/DEPLOY_VERSION';
+// Get git tag (version)
+$version = 'unknown';
+$git_dir = __DIR__ . '/.git';
 
-if (file_exists($version_file)) {
-    $version = trim(file_get_contents($version_file));
-    $timestamp = filemtime($version_file);
+if (is_dir($git_dir)) {
+    // Try to get the latest git tag
+    exec('git describe --tags --abbrev=0 2>/dev/null', $output, $return_code);
+    if ($return_code === 0 && !empty($output[0])) {
+        $version = trim($output[0]);
+    } else {
+        // Fallback to commit hash if no tags exist
+        exec('git rev-parse --short HEAD 2>/dev/null', $commit_output, $commit_return);
+        if ($commit_return === 0 && !empty($commit_output[0])) {
+            $version = 'commit-' . trim($commit_output[0]);
+        }
+    }
+
+    // Get commit date as deployment timestamp
+    exec('git log -1 --format=%ct 2>/dev/null', $timestamp_output);
+    $timestamp = !empty($timestamp_output[0]) ? (int)$timestamp_output[0] : time();
     $deployed_at = date('Y-m-d H:i:s T', $timestamp);
 } else {
-    $version = 'unknown';
     $deployed_at = 'never';
 }
 
 header('Content-Type: text/plain');
-echo "Deploy Version: #{$version}\n";
+echo "Version: {$version}\n";
 echo "Deployed At: {$deployed_at}\n";
 echo "Server: " . gethostname() . "\n";
 echo "PHP Version: " . PHP_VERSION . "\n";


### PR DESCRIPTION
Replace DEPLOY_VERSION counter with semantic versioning using git tags:

Changes:
- version.php now reads git tags (v1.2.3) instead of DEPLOY_VERSION
- Falls back to commit hash if no tags exist
- Updated deploy-default.sh to show git tag version
- Removed DEPLOY_VERSION increment logic
- Added helpful message about creating tags

Benefits:
- Proper semantic versioning (v1.2.3, v1.2.4)
- Version visible in GitHub releases
- Track WHAT changed, not just deployment count
- Industry standard approach

Usage:
git tag v1.0.0 && git push origin v1.0.0