### PR TITLE
Feat: Deploy to production only on version tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy to Production
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'  # Trigger on version tags (v1.0.0, v1.0.1, etc.)
   workflow_dispatch:
     inputs:
       environment:
@@ -40,9 +40,10 @@ jobs:
             cd ${{ secrets.DEPLOY_PATH_PROD }}
             echo "========================================="
             echo "Deploying to PRODUCTION"
+            echo "Tag: ${{ github.ref_name }}"
             echo "========================================="
-            git fetch origin
-            git reset --hard origin/main
+            git fetch origin --tags
+            git checkout ${{ github.ref_name }}
             scripts/deploy-all.sh production
             echo ""
             echo "✓ Production deployment complete"


### PR DESCRIPTION
Changes deployment pipeline to trigger automatically only when version tags are pushed, aligning with the new semantic versioning workflow.

Changes:
- Trigger: Changed from 'push to main' to 'push tags v*'
- Production: Deploys from git tags (v1.0.0, v1.1.0, etc.)
- Staging: Manual deployment only, uses main branch
- Manual deployment still available via workflow_dispatch

Deployment workflow:
1. Create and push tag: git tag v1.0.1 && git push origin v1.0.1
2. GitHub Actions automatically deploys tagged version to production
3. version.php displays the deployed tag

This prevents accidental deployments from every main branch push and ensures only versioned, intentional releases reach production.