### PR TITLE
SAHO-253: Fix Most Read Content title colors in dark mode

### DIFF
--- a/webroot/modules/custom/saho_statistics/css/top-read-content.css
+++ b/webroot/modules/custom/saho_statistics/css/top-read-content.css
@@ -468,11 +468,7 @@
     border-color: #374151;
   }
 
-  .top-read-title,
-  .top-read-item__title,
-  .top-read-card__title {
-    color: #f9fafb;
-  }
+  /* Title colors removed - inherit from theme for consistency */
 
   .top-read-item__views,
   .top-read-card__views {


### PR DESCRIPTION
Fixes title color inconsistency in the Most Read Content block by removing forced light color overrides in dark mode.

## Problem

Titles in the Most Read Content block were too light and not following the theme's standard typography due to a  media query forcing  on:
- 
- 
- 

## Solution

Removed the color override in dark mode, allowing titles to inherit proper colors from the theme's design system for consistency with other blocks.

## Testing

- ✅ Titles now match theme typography
- ✅ Dark mode still works correctly
- ✅ No visual regression on other block elements

## Files Changed

- 