### PR TITLE
SAHO-254: Simplify History Through Pictures button text

### DIFF
--- a/webroot/modules/custom/saho_statistics/templates/saho-history-through-pictures.html.twig
+++ b/webroot/modules/custom/saho_statistics/templates/saho-history-through-pictures.html.twig
@@ -113,11 +113,7 @@
   <div class="history-pictures-view-all">
     <a href="/history-through-pictures" class="saho-button saho-button--primary saho-button--medium saho-button--with-icon">
       <span class="saho-button__text">
-        {% if total_count > 0 %}
-          View All {{ total_count }} Images
-        {% else %}
-          View All Images
-        {% endif %}
+        View more
       </span>
       <svg class="saho-button__icon saho-button__icon--arrow-right" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z"/>


### PR DESCRIPTION
Simplifies the History Through Pictures block button text for better UX.

## Changes

- Changed button text from "View All X Images" to "View more"
- Removes dynamic count from button text
- Button still links correctly to /history-through-pictures

## Testing

✅ Button displays "View more"
✅ Link to /history-through-pictures works
✅ Consistent with other block "View more" buttons

## Files Changed

- webroot/modules/custom/saho_statistics/templates/saho-history-through-pictures.html.twig