### PR TITLE
SAHO-261: Standardize hero banner dimensions to 1640 x 720px

### DIFF
--- a/webroot/modules/custom/saho_utils/hero_banner/src/Plugin/Block/HeroBannerBlock.php
+++ b/webroot/modules/custom/saho_utils/hero_banner/src/Plugin/Block/HeroBannerBlock.php
@@ -184,7 +184,7 @@ class HeroBannerBlock extends BlockBase implements ContainerFactoryPluginInterfa
       ],
       '#title' => $this->t('Hero Banner Image'),
       '#default_value' => $default_media_entity,
-      '#description' => $this->t('Start typing to search for an image, or upload a new one through the media library.'),
+      '#description' => $this->t('<strong>Graphic Mode:</strong> Use images at <strong>1640 x 720px</strong> for optimal display. <br><strong>Standard Mode:</strong> Recommended minimum 1920 x 800px.'),
       '#maxlength' => 1024,
     ];
 

--- a/webroot/themes/custom/saho/components/layout/saho-hero-banner/saho-hero-banner.css
+++ b/webroot/themes/custom/saho/components/layout/saho-hero-banner/saho-hero-banner.css
@@ -161,12 +161,15 @@
 
 /**
  * Graphic Mode: Full image in natural proportions without cropping
+ * Standard size: 1640 x 720px (aspect ratio 2.278:1)
  */
 .saho-hero-banner--graphic {
   min-height: 0;
   height: auto;
   padding: 0 !important;
   cursor: pointer;
+  aspect-ratio: 1640 / 720;
+  width: 100%;
 }
 
 /* Remove ALL content constraints in graphic mode */
@@ -184,22 +187,23 @@
   max-width: none !important;
 }
 
-/* Picture container: relative positioning for natural image flow */
+/* Picture container: maintains 1640:720 aspect ratio */
 .saho-hero-banner--graphic .saho-hero-banner__picture {
   position: relative !important;
-  height: auto !important;
-  min-height: 0 !important;
+  height: 100% !important;
+  width: 100%;
+  aspect-ratio: 1640 / 720;
 }
 
-/* Image: full proportions, no cropping - shows entire graphic */
+/* Image: fills container at 1640:720 proportions */
 .saho-hero-banner--graphic .saho-hero-banner__image {
-  object-fit: contain !important;
+  object-fit: cover !important;
   object-position: center !important;
   width: 100% !important;
-  height: auto !important;
-  min-height: 0 !important;
-  max-height: none !important;
-  position: relative !important;
+  height: 100% !important;
+  position: absolute !important;
+  top: 0;
+  left: 0;
 }
 
 /* Make the ENTIRE banner clickable - simple and direct */


### PR DESCRIPTION
## Summary
Standardizes hero banner graphic mode to use fixed dimensions of 1640 x 720px across all banners.

## Changes

### Block Configuration
Added help text to image upload field:
- **Graphic Mode**: Use images at **1640 x 720px** for optimal display
- **Standard Mode**: Recommended minimum 1920 x 800px

### CSS Aspect Ratio
Enforced 1640:720 aspect ratio (2.278:1) on banner containers:
```css
.saho-hero-banner--graphic {
  aspect-ratio: 1640 / 720;
  width: 100%;
}

.saho-hero-banner--graphic .saho-hero-banner__picture {
  aspect-ratio: 1640 / 720;
  height: 100%;
}
```

### Image Display
- Changed to `object-fit: cover` to fill the 1640:720 container
- Image positioned absolutely to fill container completely
- Maintains consistent proportions regardless of uploaded image size

## Benefits
✅ Clear standard for design team (1640 x 720px)  
✅ Consistent display across all graphic mode banners  
✅ Proper aspect ratio enforcement via CSS  
✅ Works on all screen sizes (responsive)  
✅ Help text guides content editors  

## Testing
- [x] Banner displays at 1640:720 aspect ratio on desktop
- [x] Responsive on tablet and mobile
- [x] Help text visible in block configuration
- [x] Image fills container without distortion
- [x] Link still fully clickable

## Files Changed
- `webroot/modules/custom/saho_utils/hero_banner/src/Plugin/Block/HeroBannerBlock.php`
- `webroot/themes/custom/saho/components/layout/saho-hero-banner/saho-hero-banner.css`