### PR TITLE
SAHO-263: Fix hero banner graphic mode display on mobile

### DIFF
--- a/webroot/themes/custom/saho/components/layout/saho-hero-banner/saho-hero-banner.css
+++ b/webroot/themes/custom/saho/components/layout/saho-hero-banner/saho-hero-banner.css
@@ -356,11 +356,27 @@
     min-height: 0;
     height: auto;
     padding: 0 !important;
+    width: 100% !important;
+    display: block;
+  }
+
+  .saho-hero-banner--graphic .saho-hero-banner__picture {
+    display: block;
+    width: 100% !important;
+    height: auto !important;
+  }
+
+  .saho-hero-banner--graphic .saho-hero-banner__image {
+    display: block;
+    width: 100% !important;
+    height: auto !important;
+    position: static !important;
   }
 
   .saho-hero-banner--graphic .saho-hero-banner__content {
     padding: 0 !important;
     height: auto;
+    width: 100%;
   }
 
   .saho-hero-banner--graphic .saho-hero-banner__inner {
@@ -373,21 +389,32 @@
     min-height: 0;
     height: auto;
     padding: 0 !important;
+    width: 100% !important;
+  }
+
+  .saho-hero-banner--graphic .saho-hero-banner__picture {
+    display: block;
+    width: 100% !important;
+    height: auto !important;
+  }
+
+  .saho-hero-banner--graphic .saho-hero-banner__image {
+    display: block;
+    width: 100% !important;
+    height: auto !important;
+    position: static !important;
   }
 
   .saho-hero-banner--graphic .saho-hero-banner__content {
     padding: 0 !important;
     max-width: none !important;
     height: auto;
+    width: 100%;
   }
 
   .saho-hero-banner--graphic .saho-hero-banner__inner {
     padding: 0 !important;
     gap: 0 !important;
-  }
-
-  .saho-hero-banner--graphic .saho-hero-banner__picture {
-    height: auto !important;
   }
 }
 
@@ -396,11 +423,26 @@
     min-height: 0;
     height: auto;
     padding: 0 !important;
+    width: 100% !important;
+  }
+
+  .saho-hero-banner--graphic .saho-hero-banner__picture {
+    display: block;
+    width: 100% !important;
+    height: auto !important;
+  }
+
+  .saho-hero-banner--graphic .saho-hero-banner__image {
+    display: block;
+    width: 100% !important;
+    height: auto !important;
+    position: static !important;
   }
 
   .saho-hero-banner--graphic .saho-hero-banner__content {
     padding: 0 !important;
     height: auto;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes hero banner graphic mode appearing as a tiny image in the corner on mobile devices instead of displaying at full width.

## Issue
On mobile, the hero banner in graphic mode was displaying at a very small size in the upper left corner rather than filling the full width of the screen.

## Changes
- Added `display: block` to banner, picture, and image elements to prevent inline element spacing issues
- Set explicit `width: 100% !important` on all graphic mode container elements for mobile breakpoints
- Changed image positioning from `absolute` to `static` on mobile for natural flow
- Set `height: auto` on picture and image elements for proper proportional scaling

## Test plan
- [x] Verify hero banner graphic mode displays full width on mobile (< 768px)
- [x] Verify banner maintains proper aspect ratio on mobile
- [x] Verify banner is clickable on mobile
- [x] Verify desktop display remains unchanged
- [x] Test on various mobile screen sizes (360px, 576px, 768px)