### PR TITLE
Bugfix: Disable sticky header for authenticated users

### DIFF
--- a/webroot/themes/custom/saho/js/sticky-header.js
+++ b/webroot/themes/custom/saho/js/sticky-header.js
@@ -11,6 +11,20 @@
     attach: function (context) {
       once('saho-sticky-header', '.saho-header', context).forEach(function (header) {
 
+        // Disable sticky header for authenticated users (they need admin toolbar access)
+        // Check for admin toolbar or toolbar-administration elements
+        const hasToolbar = document.getElementById('toolbar-administration') ||
+                          document.querySelector('.toolbar') ||
+                          document.querySelector('#toolbar-bar') ||
+                          document.body.classList.contains('toolbar-fixed') ||
+                          document.body.classList.contains('toolbar-horizontal') ||
+                          document.body.classList.contains('toolbar-vertical') ||
+                          document.body.classList.contains('user-logged-in');
+
+        if (hasToolbar) {
+          return;
+        }
+
         let lastScrollY = window.scrollY;
         let ticking = false;
         const scrollThreshold = 5; // Minimum scroll distance to trigger


### PR DESCRIPTION
## Summary
- ✅ Disable sticky header for authenticated users
- ✅ Prevents interference with Drupal admin toolbar
- ✅ Checks multiple toolbar indicators for reliability

## Changes
The sticky header hide/show behavior now only activates for anonymous visitors. Authenticated users (admins, editors) will have a normal fixed header that doesn't hide on scroll.

## Detection Methods
Checks for:
- Admin toolbar elements: `#toolbar-administration`, `.toolbar`, `#toolbar-bar`
- Body classes: `toolbar-fixed`, `toolbar-horizontal`, `toolbar-vertical`, `user-logged-in`

## Test Plan
- [x] Tested as anonymous user - sticky header works (hides on scroll down, shows on scroll up)
- [x] Tested as authenticated user - sticky header disabled (normal fixed position)
- [x] Verified no interference with admin toolbar

## Impact
- Patch release (v1.6.1)
- No breaking changes
- Improves admin/editor UX