### PR TITLE
chore(config): uninstall contrib statistics module via config sync

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -132,7 +132,6 @@ module:
   sophron: 0
   spammaster: 0
   state_machine: 0
-  statistics: 0
   system: 0
   tamper: 0
   taxonomy: 0

--- a/config/sync/search_api.index.saho_content.yml
+++ b/config/sync/search_api.index.saho_content.yml
@@ -176,13 +176,6 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_tags
-  statistics_weight:
-    label: 'Sort Priority by Statistics'
-    property_path: statistics_weight
-    type: integer
-    indexed_locked: true
-    type_locked: true
-    hidden: true
   title:
     label: Title
     datasource_id: 'entity:node'
@@ -264,13 +257,6 @@ processor_settings:
   solr_date_range:
     weights:
       preprocess_index: 0
-  statistics:
-    weight: 0
-    totalcount: 0
-    daycount: 0
-    timestamp: 0
-    allowed_entity_types:
-      - node
   type_boost:
     weights:
       preprocess_index: 0


### PR DESCRIPTION
## Summary

- Drops `statistics: 0` from `config/sync/core.extension.yml` so the next `drush cim` uninstalls the contrib statistics module (PR #332 stopped using it but didn't take it out of `core.extension`).
- Removes the `search_api_sort_priority` Statistics processor (and its derived `statistics_weight` field) from `search_api.index.saho_content` — that processor calls `\Drupal\statistics\StatisticsViewsResult` + `statistics.storage.node`, so leaving it enabled would throw `ServiceNotFoundException` on reindex once the module is gone.

## Why

PR #332 stripped `drupal/statistics` from `composer.json` and deleted `statistics.settings.yml` / `ultimate_cron.job.statistics_cron.yml`, but the module was still listed in `core.extension.yml`. On the next deploy `drush cim` would have left it installed — meaning `node_counter` would still be written to alongside `saho_node_counter`, defeating the whole point of #328 (cut origin load).

`saho_statistics_update_9002()` already migrated `node_counter` → `saho_node_counter`, so `statistics`'s `hook_uninstall` dropping `node_counter` is non-destructive once the update hook has run.

## Local verification (DDEV, full prod data set)

- `drush cim -y` → `statistics` module uninstalled, `node_counter` dropped, `saho_node_counter` (81,539 rows) preserved.
- `TermTracker::getTotalPageViews` → 5,301,473 (unchanged).
- `saho_featured_articles` `isStatisticsAvailable` / `getNodeViewCount` / `getMostReadFeatured` all return the same data as before.
- `TopReadContentBlock` renders 6,641 bytes of valid HTML.
- `search_api` `saho_content` index still enabled, all other processors intact.
- Live page load on `/article/poqo`: beacon → controller → counter incremented 1466 → 1467. End-to-end pipeline works with `statistics` fully gone.

## Deploy notes

On the next deploy the standard order applies:
1. `composer install`
2. `drush updb -y` (runs `saho_statistics_update_9002` if not already applied)
3. `drush cim -y` (this PR's effect — uninstalls statistics, drops `node_counter`)
4. `drush cr`

`drush pm:uninstall statistics -y` is **no longer needed** as a manual step — the config import does it.

## Test plan

- [ ] Run `drush cim -y` on staging
- [ ] Confirm `drush pml --status=enabled | grep statistics` returns nothing
- [ ] Confirm Most-Read featured / TopReadContentBlock still render
- [ ] Confirm Solr reindex doesn't throw `ServiceNotFoundException`
- [ ] Confirm `/article/<any>` page-view beacon still records into `saho_node_counter`

Closes #328
Part of #327 (Cut origin load).