### PR TITLE
perf(mobile-lcp): cut render-blocking + WebP heroes + un-lazy LCP image

### DIFF
--- a/config/sync/image.style.saho_hero.yml
+++ b/config/sync/image.style.saho_hero.yml
@@ -13,3 +13,9 @@ effects:
       width: 1920
       height: null
       upscale: false
+  convert_webp:
+    uuid: a8b9c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
+    id: image_convert
+    weight: 1
+    data:
+      extension: webp

--- a/config/sync/image.style.saho_hero_mobile.yml
+++ b/config/sync/image.style.saho_hero_mobile.yml
@@ -13,3 +13,9 @@ effects:
       width: 768
       height: null
       upscale: false
+  convert_webp:
+    uuid: f3a4d1b2-7c5e-4b8a-9d2f-1c3e5a7b9d0e
+    id: image_convert
+    weight: 1
+    data:
+      extension: webp

--- a/perf/.gitignore
+++ b/perf/.gitignore
@@ -1,0 +1,4 @@
+# Lighthouse + Playwright artifacts are large and per-run.
+# Regenerate with: perf/scripts/* (see ../BASELINE-2026-05-12.md)
+baselines/
+node_modules/

--- a/perf/BASELINE-2026-05-12.md
+++ b/perf/BASELINE-2026-05-12.md
@@ -1,0 +1,103 @@
+# SAHO Performance Baseline — 2026-05-12 (mobile, prod)
+
+Target: **mobile LCP**. Per GSC Core Web Vitals, **28,187 mobile URLs are failing LCP** (>2.5s) and **49 are POOR** (>4s). CLS is fine (0 URLs failing). INP affects ~2,500 URLs — second priority. Desktop CWV is essentially solved (48 URLs needing improvement, 0 poor).
+
+## Mobile Lighthouse, against prod
+
+| Page | LCP | TBT | FCP | SI | Total weight |
+|---|---|---|---|---|---|
+| `/` (home) | **17.1 s** POOR | 250 ms NEEDS | 2.8 s NEEDS | 4.5 s NEEDS | 2,924 KiB |
+| `/featured` | **11.3 s** POOR | 290 ms NEEDS | 3.6 s POOR | 6.5 s POOR | 1,823 KiB |
+| `/article/poqo` | **5.3 s** POOR | 780 ms POOR | 2.2 s NEEDS | 3.6 s NEEDS | 1,410 KiB |
+| `/people/dorothy-adams` | **4.5 s** POOR | 180 ms GOOD | 2.0 s NEEDS | 2.4 s GOOD | 1,030 KiB |
+
+Every page is in POOR LCP territory. Home is the catastrophe.
+
+## Three biggest sinners (helicopter view)
+
+### 1. LCP image is `loading="lazy"` on the home page
+The LCP element on `/` is:
+
+```html
+<img class="block-image"
+     src="…/event_pics/Mathews-zk.jpg"
+     loading="lazy"
+     decoding="async">
+```
+
+Browsers don't prioritise lazy-loaded images. The browser doesn't even *discover* this image until layout pass, then waits in the queue behind everything else. This is the single most likely reason home LCP is 17 s instead of 5 s.
+
+**Fix:** find the Twig that renders the first above-the-fold hero/featured image. For that *first* image only, drop `loading="lazy"` and add `fetchpriority="high"`. Optionally add `<link rel="preload" as="image" fetchpriority="high">` in `<head>` from a preprocess hook so discovery happens during HTML parse.
+
+Files to check (grep):
+- `webroot/themes/custom/saho/templates/block/**.html.twig`
+- `webroot/modules/custom/**` blocks that render `block-image`
+- whichever preprocess builds the home page block list
+
+Expected LCP cut: **3–6 s on home** (high confidence).
+
+### 2. Render-blocking CSS chain — affects every page
+Per page, 5–8 separate stylesheets block first paint. Worst offenders:
+
+| Resource | Render-block delay | Note |
+|---|---|---|
+| `cdn.jsdelivr.net/.../glightbox.min.css` | ~900 ms (home) | Third-party CDN — adds DNS+TLS handshake on top of download |
+| `saho_tools/css/citation.css` | 620–780 ms every page | Citation modal — never visible until user clicks |
+| `saho_tools/css/citation-modern.css` | 470–630 ms every page | Same |
+| `saho_tools/css/sharing-modern.css` | 470–630 ms every page | Share modal — never visible until user clicks |
+| `libraries/aos/dist/aos.js` | 470–640 ms every page | Animate-on-scroll JS, render-blocking position |
+
+Lighthouse total est. savings: **860–2,200 ms per page**. On home: **1,750 ms.**
+
+**Fixes (low effort, low risk):**
+- Self-host glightbox.min.css (Composer asset or just commit the file). Removes the third-party DNS round-trip.
+- `defer` on `aos.js`. AOS animations are decorative; it can run after first paint.
+- Mark saho_tools sharing/citation CSS as `media="print" onload="this.media='all'"` — they load asynchronously this way without blocking paint. Or attach the libraries only when the citation/share button is interacted with (better long term).
+
+Expected LCP cut: **0.8–2.0 s every page** (high confidence).
+
+### 3. Hero image weight (home only)
+Home downloads ~1.75 MB of "saho_hero_mobile" image-style images (Drupal's named image derivative for mobile heroes), 4–5 images at 430–530 KB each. The first one is the LCP element; the rest are below the fold but eagerly fetched.
+
+| Image style variant | Wasted bytes |
+|---|---|
+| `saho_hero_mobile/.../2026...jpg` × 4 | 1,402 KiB combined |
+| `Demonstrators hold up images*` | 128 KiB |
+| `image-placeholder-title*` | 109 KiB |
+
+**Fixes:**
+- WebP/AVIF on the `saho_hero_mobile` image style (Drupal 11 supports this natively — config-only change). Typical saving: 30–50%.
+- Only the first hero needs eager load — lazy-load the rest. Combined with fix #1, this becomes mostly orthogonal once the first hero has `fetchpriority="high"`.
+- Confirm `saho_hero_mobile` style dimensions are actually mobile-sized — at 94 vw on a 375 px viewport, the rendered width is ~351 px (×2 DPR = 702 px). If the image style is generating 1200 px+ variants, that's pure waste.
+
+Expected LCP cut: **0.5–1.5 s on home** (medium confidence — overlaps with fixes 1 & 2).
+
+## Other notable findings
+
+- **`unused-javascript`: 2,040 ms / 694 KB** across the four pages. This is mostly likely the Bootstrap/Radix theme JS plus contrib modules' libraries that load on every page. Long-tail work, lower priority than the three above.
+- **`unused-css-rules`: 1,070 ms / 234 KB.** Same shape — long-tail.
+- **`unsized-images`** flags: theme footer icons + `marion-institute.png` lack explicit `width`/`height`. Tiny CLS contributor, not in the critical path right now (CLS is fine per GSC).
+- **TTFB is good** on all pages (20–520 ms server response). Drupal is responding fast; the LCP problem is entirely front-end.
+
+## Cumulative expected LCP improvement (rough)
+
+If all three fixes ship:
+- Home: 17.1 s → ~5–7 s (still NEEDS but possibly GOOD after CDN/cache)
+- Featured: 11.3 s → ~6 s
+- Article: 5.3 s → ~3 s (NEEDS or GOOD)
+- Biography: 4.5 s → ~2.5 s (GOOD)
+
+Combined with Cloudflare proxy (issue #327, not yet done) — edge caching would cut TTFB further on cache hits, and getting cached HTML to the user in <100 ms makes mobile LCP achievable globally.
+
+## How to re-measure
+
+```bash
+CHROME_PATH=/usr/bin/google-chrome npx --yes lighthouse <url> \
+  --quiet --chrome-flags="--headless=new --no-sandbox --disable-dev-shm-usage" \
+  --form-factor=mobile --only-categories=performance \
+  --output=html --output=json --output-path=<out>
+```
+
+Helper script: `perf/scripts/summarize.py perf/baselines/<date>/prod-mobile/*.report.json`
+
+Raw HTML reports: `perf/baselines/2026-05-12/prod-mobile/*.report.html` (open in browser).

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,50 @@
+# SAHO performance measurement
+
+Small harness for measuring mobile CWV (LCP focus) and producing the
+"is the fix working?" reports.
+
+## Tools
+
+- **Lighthouse CLI** — fired via `npx --yes lighthouse`. Mobile form factor + simulated 3G is the default for CWV-targeted runs.
+- **Playwright** — visual-regression screenshots at mobile (375×812 @2x) and desktop (1280×800).
+- **`scripts/summarize.py`** — parses Lighthouse JSON, prints a per-page metric table + ranks the biggest opportunities + lists LCP/CLS element details.
+- **`scripts/screenshots.mjs`** — captures full-page screenshots for both viewports across 4 SAHO page types.
+
+## Run a baseline against prod
+
+```bash
+DAY=$(date +%Y-%m-%d)
+mkdir -p perf/baselines/$DAY/prod-mobile
+for slug:url in home:https://sahistory.org.za/ \
+                article-poqo:https://sahistory.org.za/article/poqo \
+                bio-dorothy-adams:https://sahistory.org.za/people/dorothy-adams \
+                featured:https://sahistory.org.za/featured; do
+  CHROME_PATH=/usr/bin/google-chrome npx --yes lighthouse "${slug:url#*:}" \
+    --quiet \
+    --chrome-flags="--headless=new --no-sandbox --disable-dev-shm-usage" \
+    --form-factor=mobile --only-categories=performance \
+    --output=html --output=json \
+    --output-path="perf/baselines/$DAY/prod-mobile/${slug:url%:*}" \
+    --max-wait-for-load=60000
+done
+
+python3 perf/scripts/summarize.py perf/baselines/$DAY/prod-mobile/*.report.json
+```
+
+(In bash use the explicit form — the inline shell example above is just illustrative.)
+
+## Run a baseline against local DDEV
+
+Same commands but swap the URLs to `https://sahistory-web.ddev.site/...` and add `--ignore-certificate-errors` to `--chrome-flags`. Note: local DDEV variance is high — a single run swings TTFB ±700ms. Run 3 trials and take the median, or rely on the diagnostic insights (render-blocking-insight, image-delivery-insight) rather than raw LCP numbers when iterating on a fix.
+
+## Visual baselines
+
+```bash
+# perf/node_modules is a symlink to a working playwright install
+ln -sfn /tmp/saho-pw/node_modules perf/node_modules
+node perf/scripts/screenshots.mjs perf/baselines/$(date +%Y-%m-%d)/screenshots
+```
+
+## Why prod-only and mobile-only
+
+Per GSC Core Web Vitals (May 2026): 28,187 mobile URLs are failing LCP, 49 are poor. Desktop is essentially solved (0 poor). All CWV optimisation work for SAHO should target **mobile LCP**.

--- a/perf/scripts/screenshots.mjs
+++ b/perf/scripts/screenshots.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Capture full-page Playwright screenshots for the SAHO performance baseline.
+ *
+ * Run after a Lighthouse pass; produces the "before" visual reference
+ * we'll diff against once we ship the perf fixes.
+ *
+ * Usage: node perf/scripts/screenshots.mjs <out-dir>
+ */
+import { chromium } from 'playwright';
+import { mkdirSync } from 'fs';
+
+const outDir = process.argv[2] || `perf/baselines/${new Date().toISOString().slice(0, 10)}/screenshots`;
+mkdirSync(outDir, { recursive: true });
+
+const VIEWPORTS = {
+  mobile: { width: 375, height: 812, dpr: 2 },
+  desktop: { width: 1280, height: 800, dpr: 1 },
+};
+
+const PAGES = {
+  home: 'https://sahistory.org.za/',
+  'article-poqo': 'https://sahistory.org.za/article/poqo',
+  'bio-dorothy-adams': 'https://sahistory.org.za/people/dorothy-adams',
+  featured: 'https://sahistory.org.za/featured',
+};
+
+const browser = await chromium.launch({
+  executablePath:
+    process.env.CHROMIUM_PATH ||
+    '/home/mno/.cache/ms-playwright/chromium-1217/chrome-linux64/chrome',
+});
+try {
+  for (const [vname, v] of Object.entries(VIEWPORTS)) {
+    for (const [slug, url] of Object.entries(PAGES)) {
+      const ctx = await browser.newContext({
+        viewport: { width: v.width, height: v.height },
+        deviceScaleFactor: v.dpr,
+        userAgent:
+          vname === 'mobile'
+            ? 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+            : undefined,
+      });
+      const page = await ctx.newPage();
+      try {
+        await page.goto(url, { waitUntil: 'networkidle', timeout: 45000 });
+      } catch (e) {
+        // fall back to domcontentloaded if networkidle never settles (long polling, etc.)
+        await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+      }
+      const file = `${outDir}/${vname}-${slug}.png`;
+      try {
+        await page.screenshot({ path: file, fullPage: true });
+        console.log(`  ✓ ${file}`);
+      } catch (err) {
+        // Some pages are so tall the protocol bails. Fall back to viewport-only.
+        try {
+          await page.screenshot({ path: file, fullPage: false });
+          console.log(`  ✓ ${file} (viewport-only fallback)`);
+        } catch (err2) {
+          console.log(`  ✗ ${file} — ${err2.message}`);
+        }
+      }
+      await ctx.close();
+    }
+  }
+} finally {
+  await browser.close();
+}

--- a/perf/scripts/summarize.py
+++ b/perf/scripts/summarize.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Parse Lighthouse JSON reports and emit a helicopter-view summary.
+
+Usage: perf/scripts/summarize.py perf/baselines/<date>/prod-mobile/*.report.json
+"""
+from __future__ import annotations
+import json, sys, os, glob, statistics
+from collections import defaultdict
+
+# Metrics worth showing. Lighthouse units are ms unless noted.
+CORE_METRICS = [
+    ("first-contentful-paint", "FCP", "ms"),
+    ("largest-contentful-paint", "LCP", "ms"),
+    ("cumulative-layout-shift", "CLS", "score"),
+    ("total-blocking-time", "TBT", "ms"),
+    ("speed-index", "SI", "ms"),
+    ("interactive", "TTI", "ms"),
+    ("server-response-time", "TTFB", "ms"),
+]
+
+# Audits that report estimated savings ("opportunities" + a few diagnostics)
+OPP_AUDITS = [
+    "render-blocking-resources",
+    "uses-rel-preconnect",
+    "uses-rel-preload",
+    "unminified-css",
+    "unminified-javascript",
+    "unused-css-rules",
+    "unused-javascript",
+    "modern-image-formats",
+    "uses-optimized-images",
+    "uses-text-compression",
+    "uses-responsive-images",
+    "efficient-animated-content",
+    "duplicated-javascript",
+    "legacy-javascript",
+    "uses-webp-images",
+    "offscreen-images",
+    "total-byte-weight",
+    "dom-size",
+    "mainthread-work-breakdown",
+    "bootup-time",
+    "uses-long-cache-ttl",
+    "third-party-summary",
+    "third-party-facades",
+    "network-server-latency",
+    "non-composited-animations",
+    "layout-shift-elements",
+    "largest-contentful-paint-element",
+    "lcp-lazy-loaded",
+    "preload-lcp-image",
+    "prioritize-lcp-image",
+]
+
+
+def fmt(metric_id: str, audit: dict) -> str:
+    """Return a short human string for an audit numeric value."""
+    nv = audit.get("numericValue")
+    if nv is None:
+        return audit.get("displayValue") or "-"
+    unit = audit.get("numericUnit") or ""
+    if unit == "millisecond":
+        return f"{nv:,.0f} ms"
+    if unit == "byte":
+        return f"{nv/1024:,.0f} KB"
+    if unit == "element":
+        return f"{int(nv)} elements"
+    if unit == "unitless":
+        return f"{nv:.3f}"
+    return f"{nv} ({unit})"
+
+
+def grade(metric_id: str, value: float | None) -> str:
+    """CWV-style colour code."""
+    if value is None:
+        return "?"
+    thresholds = {
+        "largest-contentful-paint": (2500, 4000),
+        "cumulative-layout-shift": (0.1, 0.25),
+        "total-blocking-time": (200, 600),
+        "first-contentful-paint": (1800, 3000),
+        "speed-index": (3400, 5800),
+        "server-response-time": (800, 1800),
+        "interactive": (3800, 7300),
+    }
+    if metric_id not in thresholds:
+        return "-"
+    good, fail = thresholds[metric_id]
+    if value <= good:
+        return "GOOD"
+    if value <= fail:
+        return "NEEDS"
+    return "POOR"
+
+
+def per_page(report: dict) -> dict:
+    audits = report["audits"]
+    perf = report.get("categories", {}).get("performance", {})
+    return {
+        "url": report.get("finalUrl") or report.get("requestedUrl"),
+        "score": int((perf.get("score") or 0) * 100),
+        "metrics": {
+            mid: {
+                "label": label,
+                "value": audits.get(mid, {}).get("numericValue"),
+                "display": audits.get(mid, {}).get("displayValue"),
+                "grade": grade(mid, audits.get(mid, {}).get("numericValue")),
+            }
+            for mid, label, _unit in CORE_METRICS
+        },
+        "opps": [
+            {
+                "id": aid,
+                "title": audits[aid].get("title"),
+                "score": audits[aid].get("score"),
+                "numeric_value": audits[aid].get("numericValue"),
+                "numeric_unit": audits[aid].get("numericUnit"),
+                "display_value": audits[aid].get("displayValue"),
+                "savings_ms": (audits[aid].get("details") or {}).get("overallSavingsMs"),
+                "savings_bytes": (audits[aid].get("details") or {}).get("overallSavingsBytes"),
+            }
+            for aid in OPP_AUDITS
+            if aid in audits
+        ],
+    }
+
+
+def main(paths: list[str]) -> int:
+    pages = {}
+    for p in paths:
+        slug = os.path.basename(p).replace(".report.json", "")
+        with open(p) as f:
+            pages[slug] = per_page(json.load(f))
+
+    # 1) Per-page metric table
+    print("\n=== Per-page metrics (mobile, prod) ===")
+    header = f"{'page':<22} {'score':<6} " + " ".join(f"{m[1]:<8}" for m in CORE_METRICS)
+    print(header)
+    for slug, data in pages.items():
+        row = f"{slug:<22} {data['score']:<6} "
+        for mid, label, _u in CORE_METRICS:
+            m = data["metrics"][mid]
+            disp = m["display"] or (fmt(mid, {"numericValue": m["value"], "numericUnit": "millisecond" if mid != "cumulative-layout-shift" else "unitless"}))
+            disp = (disp or "-").replace(" ms", "ms").replace(" ", " ")
+            row += f"{disp:<8} "
+        print(row)
+
+    # 2) Grades table (CWV colour codes)
+    print("\n=== CWV grades ===")
+    print(f"{'page':<22} " + " ".join(f"{m[1]:<8}" for m in CORE_METRICS))
+    for slug, data in pages.items():
+        row = f"{slug:<22} "
+        for mid, label, _u in CORE_METRICS:
+            row += f"{data['metrics'][mid]['grade']:<8} "
+        print(row)
+
+    # 3) Cross-page opportunity ranking
+    print("\n=== Top opportunities by estimated wall-clock savings (sum across pages) ===")
+    agg_ms = defaultdict(float)
+    agg_bytes = defaultdict(float)
+    titles = {}
+    for slug, data in pages.items():
+        for o in data["opps"]:
+            if o["score"] is not None and o["score"] >= 0.9:
+                continue  # already passing
+            if o["savings_ms"]:
+                agg_ms[o["id"]] += o["savings_ms"]
+            if o["savings_bytes"]:
+                agg_bytes[o["id"]] += o["savings_bytes"]
+            titles[o["id"]] = o["title"]
+
+    print(f"{'audit':<35} {'~ms saved':<12} {'~KB saved':<12} title")
+    seen = set()
+    for aid, ms in sorted(agg_ms.items(), key=lambda x: -x[1]):
+        seen.add(aid)
+        kb = agg_bytes.get(aid, 0) / 1024
+        print(f"{aid:<35} {ms:<12,.0f} {kb:<12,.0f} {titles[aid]}")
+    for aid, b in sorted(agg_bytes.items(), key=lambda x: -x[1]):
+        if aid in seen:
+            continue
+        print(f"{aid:<35} {'-':<12} {b/1024:<12,.0f} {titles[aid]}")
+
+    # 4) Per-page LCP element + layout-shift elements
+    print("\n=== LCP element / layout-shift offenders ===")
+    for slug, data in pages.items():
+        report_path = paths_by_slug[slug]
+        with open(report_path) as f:
+            r = json.load(f)
+        lcp_el = r["audits"].get("largest-contentful-paint-element", {})
+        ls_el = r["audits"].get("layout-shift-elements", {})
+        print(f"\n  -- {slug} --")
+        items = (lcp_el.get("details") or {}).get("items") or []
+        if items:
+            inner = (items[0].get("items") or [{}])[0]
+            node = inner.get("node") or {}
+            print(f"    LCP element: {(node.get('snippet') or '-')[:140]}")
+            print(f"    LCP selector: {node.get('selector') or '-'}")
+        ls_items = (ls_el.get("details") or {}).get("items") or []
+        if ls_items:
+            print(f"    Layout-shift contributors ({len(ls_items)} elements):")
+            for li in ls_items[:5]:
+                node = li.get("node") or {}
+                print(f"      - shift={li.get('score', 0):.4f} {((node.get('snippet') or '')[:120])}")
+    return 0
+
+
+if __name__ == "__main__":
+    paths = sys.argv[1:] or sorted(glob.glob("perf/baselines/*/prod-mobile/*.report.json"))
+    paths_by_slug = {os.path.basename(p).replace(".report.json", ""): p for p in paths}
+    sys.exit(main(paths))

--- a/webroot/modules/custom/saho_statistics/saho_statistics.libraries.yml
+++ b/webroot/modules/custom/saho_statistics/saho_statistics.libraries.yml
@@ -20,9 +20,13 @@ history-through-pictures:
   css:
     theme:
       css/history-through-pictures.css: {}
-      https://cdn.jsdelivr.net/npm/glightbox@3.2.0/dist/css/glightbox.min.css: { type: external, minified: true }
+      # Self-hosted glightbox CSS (was loaded from jsdelivr CDN — added a
+      # render-blocking DNS+TLS handshake to every page that attached this
+      # library). Vendor copy is in module's vendor/glightbox/.
+      vendor/glightbox/css/glightbox.min.css: { minified: true }
   js:
-    https://cdn.jsdelivr.net/npm/glightbox@3.2.0/dist/js/glightbox.min.js: { type: external, minified: true, attributes: { defer: true } }
+    # Self-hosted glightbox JS (vendor/glightbox/js/glightbox.min.js).
+    vendor/glightbox/js/glightbox.min.js: { minified: true, attributes: { defer: true } }
     js/history-through-pictures-carousel.js: {}
     js/history-through-pictures-lightbox.js: {}
   dependencies:

--- a/webroot/themes/custom/saho/saho.theme
+++ b/webroot/themes/custom/saho/saho.theme
@@ -21,18 +21,12 @@ function saho_page_attachments_alter(array &$page) {
   // See: /admin/config/development/performance/critical-css
   // Critical CSS files are located in: themes/custom/saho/critical-css/
 
-  // Manually load AOS library to fix dependency issues
-  $page['#attached']['html_head'][] = [
-    [
-      '#type' => 'html_tag',
-      '#tag' => 'script',
-      '#attributes' => [
-        'src' => '/libraries/aos/dist/aos.js',
-        'defer' => FALSE,
-      ],
-    ],
-    'aos_library_manual',
-  ];
+  // AOS (animate-on-scroll) was previously force-loaded here with
+  // defer=FALSE, costing ~470-640ms of render-block per page. A
+  // codebase-wide grep for `data-aos` / `AOS.init` returned zero hits,
+  // so the library was downloading + parsing on every page for nothing.
+  // Removed. If a future template needs AOS, attach it via a proper
+  // Drupal library on the specific render path.
 
   // Add Organization Schema.org JSON-LD for site-wide recognition.
   // Only for anonymous users (not admin/editors).

--- a/webroot/themes/custom/saho/templates/block/block--inline-block--tdih.html.twig
+++ b/webroot/themes/custom/saho/templates/block/block--inline-block--tdih.html.twig
@@ -24,7 +24,12 @@
       {% for item in tdih_nodes %}
         {% if item.image %}
           <div class="block-image-wrapper">
-            <img src="{{ item.image }}" alt="{{ item.title|striptags }}" class="block-image" loading="lazy" decoding="async" />
+            {# First TDIH item is the home-page LCP element — load eagerly + high priority. #}
+            {% if loop.first %}
+              <img src="{{ item.image }}" alt="{{ item.title|striptags }}" class="block-image" fetchpriority="high" decoding="async" />
+            {% else %}
+              <img src="{{ item.image }}" alt="{{ item.title|striptags }}" class="block-image" loading="lazy" decoding="async" />
+            {% endif %}
             <div class="block-label">{{ item.event_date|date('Y') }}</div>
           </div>
         {% endif %}

--- a/webroot/themes/custom/saho/templates/block/featured-article-block.html.twig
+++ b/webroot/themes/custom/saho/templates/block/featured-article-block.html.twig
@@ -11,7 +11,8 @@
     <div class="block-content">
       {% if article_item.image %}
         <div class="block-image-wrapper">
-          <img src="{{ article_item.image }}" alt="{{ article_item.title|striptags }}" class="block-image" loading="lazy" decoding="async" />
+          {# Featured topics block sits in the home page LCP region — eager load. #}
+          <img src="{{ article_item.image }}" alt="{{ article_item.title|striptags }}" class="block-image" fetchpriority="high" decoding="async" />
           <div class="block-label">Article</div>
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary

Three coordinated fixes targeting **mobile LCP**, which Google Search Console says is failing on **28,187 URLs** (>2.5s) with **49 in POOR** territory (>4s). Desktop is essentially solved per GSC (0 poor URLs).

Lighthouse mobile run against prod corroborates: every page type is POOR LCP — home is catastrophic at **17.1s**. Full helicopter analysis in `perf/BASELINE-2026-05-12.md`.

## The three fixes

### 1. LCP image is no longer `loading=\"lazy\"`
On `/` the LCP element is the TDIH \"Today in history\" `block-image`. It rendered with `loading=\"lazy\"`, which actively defers browser discovery and download of the most important image on the page — the single most likely reason home LCP is 17s instead of ~5s. Lifted lazy from the **first** item in:
- `block--inline-block--tdih.html.twig`
- `featured-article-block.html.twig`

Both now use `fetchpriority=\"high\"`.

### 2. Removed dead AOS render-block
`saho.theme` was injecting `/libraries/aos/dist/aos.js` into `html_head` with `defer=FALSE` — render-blocking on every page, **~470-640ms** of wasted critical-path time. A codebase-wide grep for `data-aos` / `AOS.init` returned **zero hits**, so the library was downloading + executing on every page for nothing.

### 3. Self-hosted glightbox + WebP heroes
- `saho_statistics.libraries.yml` — glightbox CSS+JS now serve from the module's `vendor/` copy instead of `cdn.jsdelivr.net`. Removes a render-blocking third-party DNS + TLS handshake (**~900ms on home**).
- `config/sync/image.style.saho_hero{,_mobile}.yml` — added `image_convert: extension: webp` effect. Article feature banners now ship as WebP (typically **30-50% smaller** than JPEG at equivalent quality). The `<picture>` srcset attached by `saho.theme` already references both styles, so browsers automatically pick the WebP variant.

## Diagnostic impact (Lighthouse insights)

Comparing prod-baseline to local-with-fixes:

| Insight | Prod (before) | Local (after) | Δ |
|---|---|---|---|
| render-blocking-insight, home | 1,750ms | 870ms | -880ms |
| render-blocking-insight, featured | 2,200ms | 1,320ms | -880ms |
| image-delivery, hero banners | JPEG | WebP | ~30-50% smaller |

Raw LCP numbers locally are dominated by DDEV variance (TTFB swings ±700ms between runs). Real CWV impact will surface on prod in CrUX over the ~28-day rolling window after deploy.

## What's NOT in this PR (next-stage work)

- `saho_tools/css/citation*.css` + `sharing-modern.css` are still render-blocking. Lazy-attaching them on button interaction is a bigger refactor.
- The TDIH block emits raw image URLs (no Drupal image style applied). Even after fix #1, the image is downloaded at its source size. Switching the block to use an image style would unlock another big saving on home.
- General JS/CSS bundle weight (`unused-javascript` flagged 694 KB across the four pages) — long-tail work.

## Visual safety

Captured Playwright mobile + desktop screenshots in `perf/baselines/2026-05-12/screenshots/` (pre-fix) and verified rendering after each fix is intact. The `fetchpriority` / `loading` / `decoding` changes are metadata-only and don't alter rendered pixels. WebP conversion is visually indistinguishable at default quality.

## How to re-measure

```bash
CHROME_PATH=/usr/bin/google-chrome npx --yes lighthouse <url> \\
  --quiet --chrome-flags=\"--headless=new --no-sandbox --ignore-certificate-errors\" \\
  --form-factor=mobile --only-categories=performance \\
  --output=html --output=json --output-path=<out>
python3 perf/scripts/summarize.py perf/baselines/<date>/*/*.report.json
```

See `perf/README.md` for full instructions.

## Test plan

- [ ] `drush cim -y` on staging — verify `saho_hero{,_mobile}` styles get the convert_webp effect, no errors importing
- [ ] Load `/article/history-apartheid-south-africa` on staging — confirm `<picture>` srcset includes `.jpg.webp` URLs for both hero variants and they return 200
- [ ] Load `/` on staging — confirm no `aos.js` in `<head>`, TDIH `<img>` has `fetchpriority=\"high\"` and no `loading=\"lazy\"`
- [ ] Visit `/history-through-pictures` — confirm glightbox modal still opens (now serving from `/modules/custom/saho_statistics/vendor/glightbox/...`)
- [ ] No console errors related to missing AOS / data-aos
- [ ] After deploy + tag, re-run Lighthouse against prod and save to `perf/baselines/<post-deploy-date>/prod-mobile/` for the real-world delta

Refs #327 (Cut origin load).