### PR TITLE
perf(mobile-lcp r2): thumbnail image styles + scoped citation CSS + smaller hero + GTM defer + font preload

### DIFF
--- a/config/sync/google_analytics.settings.yml
+++ b/config/sync/google_analytics.settings.yml
@@ -32,5 +32,5 @@ codesnippet:
   before: ''
   after: ''
 translation_set: false
-cache: false
+cache: true
 debug: false

--- a/config/sync/image.style.saho_hero_mobile.yml
+++ b/config/sync/image.style.saho_hero_mobile.yml
@@ -10,7 +10,9 @@ effects:
     id: image_scale
     weight: 0
     data:
-      width: 768
+      # Mobile viewports paint these heroes at ~412 CSS px (94vw on 375px).
+      # 480 covers a typical 2x DPR without bloating to 2x the displayed size.
+      width: 480
       height: null
       upscale: false
   convert_webp:

--- a/config/sync/image.style.saho_thumbnail.yml
+++ b/config/sync/image.style.saho_thumbnail.yml
@@ -13,3 +13,9 @@ effects:
       width: 400
       height: 225
       upscale: false
+  convert_webp:
+    uuid: c2b3e4d5-6f7a-4b8c-9d0e-1f2a3b4c5d6e
+    id: image_convert
+    weight: 1
+    data:
+      extension: webp

--- a/webroot/modules/custom/saho_statistics/src/Plugin/Block/TopReadContentBlock.php
+++ b/webroot/modules/custom/saho_statistics/src/Plugin/Block/TopReadContentBlock.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
+use Drupal\image\Entity\ImageStyle;
 use Drupal\saho_statistics\TermTracker;
 use Drupal\saho_utils\Service\ImageExtractorService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -319,12 +320,16 @@ class TopReadContentBlock extends BlockBase implements ContainerFactoryPluginInt
       return NULL;
     }
 
-    // Get the file URI and convert to relative URL.
+    // Route through the saho_thumbnail image style (400x225 WebP) so the
+    // browser fetches a ~30 KB derivative instead of the raw source file —
+    // a typical Top Read row only displays the thumbnail at 80x58.
     $uri = $file->getFileUri();
-    // Remove 'public://' and prepend '/sites/default/files/'.
-    $path = str_replace('public://', '/sites/default/files/', $uri);
-
-    return $path;
+    $style = ImageStyle::load('saho_thumbnail');
+    if ($style) {
+      return $style->buildUrl($uri);
+    }
+    // Fallback if the image style isn't configured: relative public URL.
+    return str_replace('public://', '/sites/default/files/', $uri);
   }
 
 }

--- a/webroot/modules/custom/saho_tools/saho_tools.module
+++ b/webroot/modules/custom/saho_tools/saho_tools.module
@@ -68,14 +68,25 @@ function saho_tools_page_attachments_alter(array &$attachments) {
   // Check if we're on an admin route.
   $is_admin = \Drupal::service('router.admin_context')->isAdminRoute();
 
-  // Only attach the citation and sharing libraries on non-admin routes.
   if (!$is_admin) {
-    // Attach modal libraries - these depend on Bootstrap which loads via saho/style.
-    $attachments['#attached']['library'][] = 'saho_tools/citation';
-    $attachments['#attached']['library'][] = 'saho_tools/sharing';
-
-    // Attach mobile enhancements for dropdown/offcanvas support.
+    // Mobile enhancements are theme-wide; always attach on the front end.
     $attachments['#attached']['library'][] = 'saho/mobile.enhancements';
+
+    // Citation + sharing buttons only render on a handful of content types
+    // (per saho.theme citation/sharing button visibility). Attaching their
+    // CSS on every page added ~500 ms of render-block to listings, taxonomy
+    // pages, the homepage, etc. Scope the libraries to the bundles that
+    // actually surface the buttons.
+    $node = \Drupal::routeMatch()->getParameter('node');
+    $bundles_with_tools = ['article', 'biography', 'archive', 'place', 'event'];
+    $on_tools_page = $node instanceof NodeInterface
+      && in_array($node->bundle(), $bundles_with_tools, TRUE);
+
+    if ($on_tools_page) {
+      // Modal libraries — depend on Bootstrap which loads via saho/style.
+      $attachments['#attached']['library'][] = 'saho_tools/citation';
+      $attachments['#attached']['library'][] = 'saho_tools/sharing';
+    }
 
     // Add debugging information to check if the library is loaded.
     $attachments['#attached']['drupalSettings']['sahoTools']['debug'] = [
@@ -85,7 +96,6 @@ function saho_tools_page_attachments_alter(array &$attachments) {
     ];
 
     // If we're on a node page, add node data.
-    $node = \Drupal::routeMatch()->getParameter('node');
     if ($node instanceof NodeInterface) {
       // Add node data as drupalSettings for JavaScript.
       $node_data = [
@@ -134,7 +144,15 @@ function saho_tools_preprocess_html(&$variables) {
   // Check if we're on an admin route.
   $is_admin = \Drupal::service('router.admin_context')->isAdminRoute();
 
-  // Only add the citation modal container on non-admin routes.
+  // Citation + sharing modals only render on the handful of content
+  // types that surface the buttons; scope here mirrors the
+  // page_attachments_alter scope so /featured, listings, taxonomy etc.
+  // don't drag in the saho_tools CSS via the modal's #attached library.
+  $node_for_tools = \Drupal::routeMatch()->getParameter('node');
+  $tools_bundles = ['article', 'biography', 'archive', 'place', 'event'];
+  $emit_tools_modals = $node_for_tools instanceof NodeInterface
+    && in_array($node_for_tools->bundle(), $tools_bundles, TRUE);
+
   if (!$is_admin) {
 
     // Schema.org JSON-LD injection.
@@ -224,6 +242,12 @@ function saho_tools_preprocess_html(&$variables) {
         ],
         'schema_org_breadcrumb',
       ];
+    }
+
+    if (!$emit_tools_modals) {
+      // Done — skip citation + sharing modal injection on pages that
+      // never surface the buttons. Saves ~500 ms of render-block CSS.
+      return;
     }
 
     // Add streamlined citation modal - minimal structure, content loaded via template/JS.

--- a/webroot/modules/custom/saho_utils/featured_articles/src/Plugin/Block/FeaturedArticleBlock.php
+++ b/webroot/modules/custom/saho_utils/featured_articles/src/Plugin/Block/FeaturedArticleBlock.php
@@ -254,8 +254,10 @@ class FeaturedArticleBlock extends BlockBase implements ContainerFactoryPluginIn
    *   - image: The image URL if available
    */
   protected function buildArticleItem(NodeInterface $node) {
-    // Use EntityItemBuilderService for consistent item building.
-    $item = $this->entityItemBuilder->buildItemWithImage($node, 'field_article_image');
+    // saho_hero_mobile is the home-page LCP-region style (480w WebP).
+    // Passing it routes the image through the image-style pipeline so the
+    // browser gets ~50 KB WebP instead of the raw 800+ KB source.
+    $item = $this->entityItemBuilder->buildItemWithImage($node, 'field_article_image', 'saho_hero_mobile');
 
     // Ensure backward compatibility with 'image' key.
     if (isset($item['image_url'])) {

--- a/webroot/modules/custom/saho_utils/featured_biography/src/Plugin/Block/FeaturedBiographyBlock.php
+++ b/webroot/modules/custom/saho_utils/featured_biography/src/Plugin/Block/FeaturedBiographyBlock.php
@@ -656,8 +656,9 @@ class FeaturedBiographyBlock extends BlockBase implements ContainerFactoryPlugin
    *   The biography item data.
    */
   protected function buildBiographyItem($node) {
-    // Use EntityItemBuilderService for basic item building.
-    $item = $this->entityItemBuilder->buildItemWithImage($node, 'field_bio_pic');
+    // saho_thumbnail (400x225, WebP) is right-sized for the 80x81 bio
+    // thumbnails the home-page block emits — saves ~75 KB per portrait.
+    $item = $this->entityItemBuilder->buildItemWithImage($node, 'field_bio_pic', 'saho_thumbnail');
 
     // Ensure backward compatibility with 'nid' and 'image' keys.
     $item['nid'] = $item['id'];

--- a/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihBlock.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihBlock.php
@@ -474,8 +474,10 @@ class TdihBlock extends BlockBase implements ContainerFactoryPluginInterface {
    *   image, and rendered node.
    */
   protected function buildNodeItem($node) {
-    // Use EntityItemBuilderService for basic item building.
-    $item = $this->entityItemBuilder->buildItemWithImage($node, 'field_event_image');
+    // TDIH first item is the home-page LCP image (see PR #337 — block-image
+    // got fetchpriority=high). Route it through saho_hero_mobile so the
+    // browser fetches the 480w WebP variant instead of the raw 600+ KB jpg.
+    $item = $this->entityItemBuilder->buildItemWithImage($node, 'field_event_image', 'saho_hero_mobile');
 
     // Ensure backward compatibility with 'image' key.
     if (isset($item['image_url'])) {

--- a/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\image\Entity\ImageStyle;
 use Drupal\tdih\Service\NodeFetcher;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Ajax\AjaxResponse;
@@ -335,14 +336,16 @@ class TdihInteractiveBlock extends BlockBase implements ContainerFactoryPluginIn
         $event_timestamp = $dt->getTimestamp();
       }
 
-      // Get the image URL if available.
+      // Route through saho_hero_mobile (480w WebP) so the LCP-region TDIH
+      // image is ~50 KB instead of the raw 600+ KB jpg.
       $image_url = '';
       if ($node->hasField('field_event_image') && !$node->get('field_event_image')->isEmpty()) {
         /** @var \Drupal\file\FileInterface $file */
         $file = $node->get('field_event_image')->entity;
         if ($file) {
-          $file_url_generator = \Drupal::service('file_url_generator');
-          $image_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
+          $uri = $file->getFileUri();
+          $style = ImageStyle::load('saho_hero_mobile');
+          $image_url = $style ? $style->buildUrl($uri) : \Drupal::service('file_url_generator')->generateAbsoluteString($uri);
         }
       }
 
@@ -480,13 +483,16 @@ class TdihInteractiveBlock extends BlockBase implements ContainerFactoryPluginIn
       $event_timestamp = $dt->getTimestamp();
     }
 
-    // If there's an image field named "field_event_image," generate a URL.
+    // Route through saho_hero_mobile (480w WebP) so the LCP-region TDIH
+    // image is ~50 KB instead of the raw 600+ KB jpg.
     $image_url = '';
     if ($node->hasField('field_event_image') && !$node->get('field_event_image')->isEmpty()) {
       /** @var \Drupal\file\FileInterface $file */
       $file = $node->get('field_event_image')->entity;
       if ($file) {
-        $image_url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
+        $uri = $file->getFileUri();
+        $style = ImageStyle::load('saho_hero_mobile');
+        $image_url = $style ? $style->buildUrl($uri) : $this->fileUrlGenerator->generateAbsoluteString($uri);
       }
     }
 

--- a/webroot/themes/custom/saho/saho.theme
+++ b/webroot/themes/custom/saho/saho.theme
@@ -28,6 +28,28 @@ function saho_page_attachments_alter(array &$page) {
   // Removed. If a future template needs AOS, attach it via a proper
   // Drupal library on the specific render path.
 
+  // Preload the two Inter weights that body copy + hero captions use.
+  // PSI flagged Inter-SemiBold as the longest critical-chain item
+  // (1,424 ms). A preload hint lets the browser pull both weights
+  // during HTML parse instead of after the CSSOM resolves their
+  // @font-face declarations.
+  foreach (['Inter-SemiBold.woff2', 'Inter-Regular.woff2'] as $woff2) {
+    $page['#attached']['html_head'][] = [
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'link',
+        '#attributes' => [
+          'rel' => 'preload',
+          'as' => 'font',
+          'type' => 'font/woff2',
+          'href' => '/themes/custom/saho/fonts/inter/' . $woff2,
+          'crossorigin' => 'anonymous',
+        ],
+      ],
+      'saho_font_preload_' . strtolower(str_replace('.', '_', $woff2)),
+    ];
+  }
+
   // Add Organization Schema.org JSON-LD for site-wide recognition.
   // Only for anonymous users (not admin/editors).
   if (!\Drupal::currentUser()->isAuthenticated()) {


### PR DESCRIPTION
## Summary

Round 2 building on `v1.11.1` (PR #337). PageSpeed Insights against prod home page after R1 exposed the next layer of sinners. This PR addresses them.

| # | Sinner (per PSI) | Fix |
|---|---|---|
| A | ~1.7 MB of un-styled raw thumbnails on `/` (5 blocks emitting `/sites/default/files/<file>.jpg` URLs at full source resolution) | Pass image_style to `EntityItemBuilderService::buildItemWithImage` on 5 thumbnail blocks; refactor `TopReadContentBlock::getNodeImageUrl()` to use `ImageStyle::load()->buildUrl()` |
| B | `saho_thumbnail` style was JPEG-only | Add `image_convert: extension: webp` effect (same pattern as PR #337's `saho_hero{,_mobile}`) |
| C | saho_tools citation/sharing CSS render-blocking ~500 ms on every non-admin page — even pages without the buttons (`/`, `/featured`, listings, taxonomy, search) | Scope `saho_tools_page_attachments_alter()` AND `saho_tools_preprocess_html()` to the bundles that actually surface the buttons (article / biography / archive / place / event). Modals + libraries no longer inject on pages that can't open them. |
| D | `saho_hero_mobile` 768 w but displayed at ~412 w on mobile + GTM render-blocking and served from third-party CDN | Width 768 -> 480 (mobile 2x DPR target) + `google_analytics.cache` `false` -> `true` (gtag.js now served from local copy, no third-party handshake) |
| E | Inter-SemiBold sits at the end of the longest critical chain (1,424 ms) with no preload | Add `<link rel=preload as=font>` for SemiBold + Regular in `saho_page_attachments_alter()` |

## Lighthouse diagnostic impact (local DDEV)

`render-blocking-insight` estimated savings ratchet — these are the cleanest signal locally (raw LCP numbers are dominated by ±700 ms TTFB variance on dev):

| Page | Pre-R2 | After R2 | Δ |
|---|---|---|---|
| home | 870 ms | 240 ms | **−630 ms** |
| article-poqo | 1,640 ms | 350 ms | **−1,290 ms** |
| bio-dorothy-adams | 670 ms | 340 ms | **−330 ms** |
| featured | 1,320 ms | 820 ms | **−500 ms** |

`image-delivery-insight` on `/` no longer flags anything — the 1,752 KiB of un-styled thumbnails that PSI showed is fully resolved.

## What was verified end-to-end on local

- ✅ TDIH `block-image` URL now ends in `/styles/saho_hero_mobile/.../jpg.webp` (was raw `/sites/default/files/event_pics/...`)
- ✅ Most-Read + Featured Biographies thumbnails now go through `/styles/saho_thumbnail/.../jpg.webp`
- ✅ `/` no longer loads `saho_tools/css/citation.css` or `sharing-modern.css` (~500 ms render-block saved)
- ✅ `/featured` same — no saho_tools CSS
- ✅ `/article/poqo` + `/people/dorothy-adams` still load saho_tools CSS (buttons present)
- ✅ Inter-SemiBold + Inter-Regular preload tags in `<head>`
- ✅ GTM/gtag now served from `/sites/default/files/google_analytics/gtag.js` (local copy)
- ✅ Citation modal opens on click, content loads, dismiss works
- ✅ Sharing modal opens, populates URL/share buttons, dismiss works

## Visual safety

Captured Playwright mobile + desktop screenshots in `perf/baselines/2026-05-13/screenshots-r2-local/`. Changes are URL/attribute only, no rendering math touched — layouts intact.

## Deploy notes

Standard sequence:
1. `composer install`
2. `drush updb -y` (no new schema in this PR)
3. `drush cim -y` (applies the 3 config changes)
4. `drush image:flush saho_hero_mobile` + `drush image:flush saho_thumbnail` (clear stale derivatives)
5. `drush cr`

On the first hit to each affected URL, Drupal generates the new derivatives (480w `saho_hero_mobile`, 400x225 `saho_thumbnail` + WebP) on demand. First hit slightly slower; subsequent hits cached.

## Skipped in this PR (next-stage)

- **764 ms forced reflow** at `citation.js:604` / `sharing.js:266`. The fix (replacing `$backdrop[0].offsetHeight` after class toggle with CSS-animation-driven fade) risks breaking the modal-open transition. Tracked as a follow-up; doesn't directly affect LCP.

Refs PSI report 2026-05-13. Continues #327 "Cut origin load".

## Test plan

- [ ] `drush cim -y` on staging
- [ ] `drush image:flush saho_hero_mobile saho_thumbnail` (one at a time)
- [ ] Load `/` → confirm no saho_tools CSS in network panel; confirm TDIH block image URL contains `/styles/saho_hero_mobile/...jpg.webp`
- [ ] Load `/article/poqo` → confirm citation + share buttons render; click each → modal opens with content
- [ ] Load `/featured` → confirm no saho_tools CSS
- [ ] Verify `<link rel=preload>` for Inter fonts in `<head>` source
- [ ] Confirm `/sites/default/files/google_analytics/gtag.js` returns 200 (not 404)
- [ ] After deploy + tag, re-run PSI against prod and save report into `perf/baselines/<date>/`