### PR TITLE
security: pin Composer to 2.9.8 (GHSA-f9f8-rm49-7jv2 - GitHub Actions token disclosure)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -11,7 +11,10 @@ database:
     type: mysql
     version: "8.0"
 use_dns_when_possible: true
-composer_version: "2"
+# Pin Composer to the patched version that addresses GHSA-f9f8-rm49-7jv2
+# (token disclosure in error messages). See:
+# https://blog.packagist.com/composer-2-9-8-and-2-2-28-fix-github-actions-token-disclosure-in-error-messages/
+composer_version: "2.9.8"
 disable_settings_management: true
 web_environment: []
 nodejs_version: "16"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: composer:v2
+          # Pin to the patched Composer release that addresses
+          # GHSA-f9f8-rm49-7jv2 (token disclosure in error messages).
+          tools: composer:2.9.8
 
       - name: Get composer cache directory
         id: composer-cache
@@ -76,7 +78,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
-          tools: composer:v2
+          # Pin to the patched Composer release that addresses
+          # GHSA-f9f8-rm49-7jv2 (token disclosure in error messages).
+          tools: composer:2.9.8
 
       - name: Get composer cache directory
         id: composer-cache
@@ -116,7 +120,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.3
-          tools: composer:v2
+          # Pin to the patched Composer release that addresses
+          # GHSA-f9f8-rm49-7jv2 (token disclosure in error messages).
+          tools: composer:2.9.8
 
       - name: Install Drupal Check
         run: composer require mglaman/drupal-check --dev

--- a/.github/workflows/shop-ci.yml
+++ b/.github/workflows/shop-ci.yml
@@ -27,7 +27,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
-          tools: composer:v2
+          # Pin to the patched Composer release that addresses
+          # GHSA-f9f8-rm49-7jv2 (token disclosure in error messages).
+          tools: composer:2.9.8
           coverage: none
 
       - name: Get composer cache directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
-          tools: composer:v2
+          # Pin to the patched Composer release that addresses
+          # GHSA-f9f8-rm49-7jv2 (token disclosure in error messages).
+          tools: composer:2.9.8
           coverage: none
 
       - name: Install dependencies
@@ -74,6 +76,9 @@ jobs:
         with:
           php-version: '8.3'
           extensions: gd, pdo_mysql, opcache
+          # Pin to the patched Composer release that addresses
+          # GHSA-f9f8-rm49-7jv2 (token disclosure in error messages).
+          tools: composer:2.9.8
           coverage: xdebug
 
       - name: Get Composer cache directory


### PR DESCRIPTION
## Summary

Mitigates [GHSA-f9f8-rm49-7jv2](https://github.com/advisories/GHSA-f9f8-rm49-7jv2): Composer prior to 2.9.8 / 2.2.28 / 1.10.28 interpolates rejected GitHub tokens verbatim into stderr error messages. In CI logs the full token is exposed to anyone with job access. GitHub App installation tokens stay valid up to 1 hour; self-hosted-runner tokens up to 24 hours.

Source: https://blog.packagist.com/composer-2-9-8-and-2-2-28-fix-github-actions-token-disclosure-in-error-messages/

## Changes

- **`.ddev/config.yaml`**: `composer_version: "2"` -> `"2.9.8"` (was running 2.9.2 locally).
- **`.github/workflows/ci.yml`**: 3 setup-php blocks updated. `tools: composer:v2` -> `composer:2.9.8`.
- **`.github/workflows/shop-ci.yml`**: 1 setup-php block updated.
- **`.github/workflows/test.yml`**: 2 setup-php blocks updated. The PHPUnit job previously had no explicit `tools:` line and inherited setup-php's default, which would have remained vulnerable - now explicitly pinned.

## Verification

- DDEV restart picks up the new version - `ddev exec composer --version` reports `Composer version 2.9.8 2026-05-13 09:28:38`.
- YAML syntax validated on all 5 workflow files.
- Pinning to a specific patch release (rather than `composer:v2.9`) makes the security baseline explicit and reproducible.

## Operator follow-ups (not in repo)

- Run `composer self-update 2.9.8` on host machines / dev laptops / deploy targets that have a host-level Composer (host system here was on 2.2.6 - well below the 2.2.28 LTS fix).
- Audit recent CI run logs for any rejected-token error messages from this window; revoke any tokens found.

cc @madsnorgaard