### PR TITLE
fix(schema-org): align JSON-LD with Google rich-result types

### DIFF
--- a/webroot/modules/custom/saho_tools/SCHEMA_ORG.md
+++ b/webroot/modules/custom/saho_tools/SCHEMA_ORG.md
@@ -11,23 +11,29 @@ South African History Online (SAHO) now includes comprehensive Schema.org JSON-L
 
 ## Content Type Mapping
 
-### 1. Articles (2,809 nodes) → ScholarlyArticle
+### 1. Articles (2,809 nodes) → Article (+ additionalType ScholarlyArticle)
 
-**Schema.org Type**: `https://schema.org/ScholarlyArticle`
+**Schema.org Type**: `https://schema.org/Article` (with `additionalType: ScholarlyArticle`)
 
-**Fields Mapped (51 total)**:
+> **Why Article and not ScholarlyArticle as top-level?** Google Search Console's "Articles" enhancement report only counts `Article`, `NewsArticle`, and `BlogPosting`. ScholarlyArticle is kept as `additionalType` to preserve semantic precision.
+
+**Fields Mapped**:
 - `headline` ← title
+- `mainEntityOfPage` ← canonical WebPage URL
 - `abstract` ← field_synopsis
+- `description` ← field_synopsis OR first 500 chars of body
 - `articleBody` ← body (HTML stripped)
+- `wordCount` ← computed
+- `articleSection` ← first tag
 - `author` ← field_article_author (Person array)
 - `editor` ← field_article_editors (Person array)
-- `image` ← field_main_image, field_article_image, field_image (ImageObject)
+- `image` ← field_main_image, field_article_image, field_image (ImageObject with width/height)
 - `keywords` ← field_tags
 - `spatialCoverage` ← field_african_country (Place array)
 - `citation` ← field_ref_str (pipe-delimited array)
 - `datePublished` ← created date (ISO 8601)
 - `dateModified` ← changed date (ISO 8601)
-- `publisher` ← SAHO Organization
+- `publisher` ← SAHO Organization (logo 600×60)
 - `license` ← CC BY-NC-SA 4.0 URL
 - `isAccessibleForFree` ← true
 - `educationalUse` ← "research"
@@ -52,61 +58,101 @@ South African History Online (SAHO) now includes comprehensive Schema.org JSON-L
 }
 ```
 
-### 2. Biographies (10,772 nodes) → Person
+### 2. Biographies (10,772 nodes) → ProfilePage wrapping Person
 
-**Schema.org Type**: `https://schema.org/Person`
+**Schema.org Type**: `https://schema.org/ProfilePage` (with `mainEntity: Person`)
 
-**Fields Mapped (60 total)**:
+> **Why ProfilePage?** Google's 2024+ ProfilePage rich result is GSC-reportable; bare Person is not. Person is nested under `mainEntity` so all biographical data is preserved.
+
+**ProfilePage fields**:
+- `url`, `dateCreated`, `dateModified`
+- `mainEntity` ← Person (below)
+
+**Nested Person fields**:
 - `name` ← Composite (field_firstname + field_middlename + field_lastnamebio)
 - `givenName` ← field_firstname
 - `familyName` ← field_lastnamebio
 - `additionalName` ← field_middlename
+- `mainEntityOfPage` ← canonical WebPage URL
 - `birthDate` ← field_drupal_birth_date (ISO 8601)
 - `deathDate` ← field_drupal_death_date (ISO 8601)
 - `birthPlace` ← field_birth_location (Place)
 - `deathPlace` ← field_death_location (Place)
-- `image` ← field_bio_pic (ImageObject)
+- `image` ← field_bio_pic (ImageObject with width/height)
 - `jobTitle` ← field_position (array)
 - `affiliation` ← field_affiliation (Organization array)
 - `nationality` ← field_african_country (Country array)
-- `description` ← body (first 200 chars, HTML stripped)
+- `knowsAbout` ← field_tags (topics)
+- `description` ← body (first 300 chars, HTML stripped)
 - `sameAs` ← field_url (URL array)
 
-### 3. Events (17,656 nodes) → Event
+### 3. Historical Events (17,656 nodes) → Article + `about: Event`
 
-**Schema.org Type**: `https://schema.org/Event`
+**Schema.org Type**: `https://schema.org/Article` (with `additionalType: ScholarlyArticle`)
 
-**Fields Mapped (19 total)**:
-- `name` ← title
-- `startDate` ← field_event_date (ISO 8601)
+> **Why Article and not Event?** "This Day in History" entries describe historical events; they are not attendable. Schema.org Event is meant for concerts/lectures/festivals — Google's Event rich result rejects historical entries (missing performer/offers/Place) and rejected `VirtualLocation` outright (3,662 invalid items). The page is now an Article whose `about` property nests a Schema.org Event with `additionalType: HistoricalEvent` for AI/Knowledge Graph semantics.
+
+**Article fields**:
+- `headline` ← title
+- `mainEntityOfPage` ← canonical WebPage URL
+- `description` ← body (first 500 chars) OR generic fallback
+- `articleBody` + `wordCount` ← body
+- `image` ← field_tdih_image, field_event_image, field_image (ImageObject with dimensions)
+- `keywords` + `articleSection` ← field_event_type taxonomy
+- `spatialCoverage` ← field_african_country (Place array)
+- `citation` ← field_ref_str (pipe-delimited)
 - `temporalCoverage` ← field_event_date
-- `description` ← body (first 500 chars)
-- `image` ← field_tdih_image, field_event_image (ImageObject)
-- `additionalType` ← field_event_type (taxonomy terms)
-- `location` ← field_african_country (Place array)
-- `citation` ← field_ref_str (pipe-delimited array)
-- `organizer` ← SAHO Organization
-- `eventStatus` ← "EventScheduled"
-- `eventAttendanceMode` ← "OfflineEventAttendanceMode"
-- `isAccessibleForFree` ← true
+- `datePublished` / `dateModified` ← node timestamps
+- `publisher` ← SAHO Organization (logo 600×60)
+- `license` ← CC BY-NC-SA 4.0
 - `educationalUse` ← "research"
 - `inLanguage` ← "en-ZA"
 
-### 4. Archives (29,986 nodes) → ArchiveComponent
+**Nested `about: Event`**:
+- `name` ← title
+- `additionalType` ← `https://schema.org/HistoricalEvent`
+- `startDate` / `endDate` ← field_event_date
+- `location` ← field_african_country Place(s), or `{Place name: "South Africa", addressCountry: "ZA"}` fallback (never VirtualLocation)
 
-**Schema.org Type**: `https://schema.org/ArchiveComponent`
+### 3b. Upcoming Events → Event
 
-**Fields Mapped (44 total)**:
+**Schema.org Type**: `https://schema.org/Event`
+
+**Fields Mapped**:
+- `name`, `url`, `description`
+- `startDate`, `endDate` (defaults to startDate)
+- `location` ← Place from field_upcoming_venue, fallback to South Africa Place (never VirtualLocation)
+- `organizer` + `performer` ← SAHO Organization
+- `offers` ← free Offer
+- `eventStatus` ← `EventScheduled`
+- `eventAttendanceMode` ← `OfflineEventAttendanceMode`
+- `image` ← field_upcomingevent_image
+- `isAccessibleForFree` ← true
+- `inLanguage` ← "en-ZA"
+
+### 4. Archives (29,986 nodes) → Book or CreativeWork
+
+**Schema.org Type**: `https://schema.org/Book` when `field_isbn` is present, else `https://schema.org/CreativeWork` (with `additionalType: ArchiveComponent`).
+
+> **Why Book/CreativeWork and not ArchiveComponent?** ArchiveComponent has no Google rich-result template — ~30k archives have been invisible to GSC. Book is the matching GSC enhancement type for archived publications with ISBNs; CreativeWork covers everything else while staying recognized.
+
+**Fields Mapped**:
 - `name` ← field_publication_title or title
+- `mainEntityOfPage` ← canonical WebPage URL
 - `author` ← field_author (Person array)
+- `creator` ← author array OR SAHO Organization fallback
 - `datePublished` ← field_archive_publication_date, field_publication_date_archive
+- `dateModified` ← changed
 - `description` ← body (first 500 chars)
-- `image` ← field_archive_image (ImageObject)
-- `isbn` ← field_isbn
+- `image` ← field_archive_image (ImageObject with dimensions)
+- `isbn` ← field_isbn (when present)
+- `keywords` ← field_tags
 - `inLanguage` ← field_language or "en-ZA"
-- `provider` ← field_source (Organization array)
-- `associatedMedia` ← field_file_upload (MediaObject array with URLs)
+- `sourceOrganization` ← field_source (Organization array) — semantically corrected from `provider`
+- `associatedMedia` ← field_file_upload as **DataDownload** (was MediaObject)
 - `holdingArchive` ← SAHO ArchiveOrganization
+- `publisher` ← SAHO Organization (logo 600×60)
+- `copyrightHolder` ← SAHO Organization
 - `license` ← CC BY-NC-SA 4.0
 - `isAccessibleForFree` ← true
 

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/ArchiveSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/ArchiveSchemaBuilder.php
@@ -9,21 +9,16 @@ use Drupal\node\NodeInterface;
 use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
- * Builds Schema.org ArchiveComponent structured data for Archive nodes.
+ * Builds Schema.org structured data for Archive nodes.
  *
- * Maps SAHO archive materials (documents, publications, media) to
- * Schema.org ArchiveComponent vocabulary for archival discovery.
+ * Top-level @type is Book when an ISBN is present (matches GSC's Book
+ * enhancement report); otherwise CreativeWork. ArchiveComponent is kept
+ * as additionalType to preserve archival semantics. Bare ArchiveComponent
+ * has no Google rich-result template, which is why ~30k archive nodes
+ * have been invisible to GSC.
  */
 class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
 
-  /**
-   * Constructs an ArchiveSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
     protected FileUrlGeneratorInterface $fileUrlGenerator,
@@ -44,22 +39,30 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
+    $url = $node->toUrl()->setAbsolute()->toString();
+    $has_isbn = $node->hasField('field_isbn') && !$node->get('field_isbn')->isEmpty();
+
     $schema = [
       '@context' => 'https://schema.org',
-      '@type' => 'ArchiveComponent',
+      '@type' => $has_isbn ? 'Book' : 'CreativeWork',
+      'additionalType' => 'https://schema.org/ArchiveComponent',
       'name' => $node->getTitle(),
-      'url' => $node->toUrl()->setAbsolute()->toString(),
+      'url' => $url,
+      'mainEntityOfPage' => [
+        '@type' => 'WebPage',
+        '@id' => $url,
+      ],
       'dateModified' => date('c', $node->getChangedTime()),
     ];
 
-    // Add publication title (if different from node title).
+    // Prefer the publication title when set.
     if ($node->hasField('field_publication_title') && !$node->get('field_publication_title')->isEmpty()) {
       $schema['name'] = $node->get('field_publication_title')->value;
     }
 
-    // Add author.
+    // Authors (also surfaced as creator for GSC-friendly CreativeWork).
+    $authors = [];
     if ($node->hasField('field_author') && !$node->get('field_author')->isEmpty()) {
-      $authors = [];
       foreach ($node->get('field_author') as $author) {
         if (!empty($author->value)) {
           $authors[] = [
@@ -68,12 +71,22 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
           ];
         }
       }
-      if (!empty($authors)) {
-        $schema['author'] = count($authors) === 1 ? $authors[0] : $authors;
-      }
+    }
+    if (!empty($authors)) {
+      $schema['author'] = count($authors) === 1 ? $authors[0] : $authors;
+      $schema['creator'] = $schema['author'];
+    }
+    else {
+      // Fall back to SAHO as institutional creator so the field is never
+      // empty (Google flags missing creator on CreativeWork-like items).
+      $schema['creator'] = [
+        '@type' => 'Organization',
+        'name' => 'South African History Online',
+        'url' => \Drupal::request()->getSchemeAndHttpHost(),
+      ];
     }
 
-    // Add publication date.
+    // Publication date.
     if ($node->hasField('field_archive_publication_date') && !$node->get('field_archive_publication_date')->isEmpty()) {
       $pub_date = $node->get('field_archive_publication_date')->value;
       if (!empty($pub_date)) {
@@ -87,40 +100,61 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       }
     }
 
-    // Add description from body.
+    // Description from body.
     if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
       $body = $node->get('body')->value;
-      $description = strip_tags($body);
-      // Limit to 500 characters.
-      if (strlen($description) > 500) {
-        $description = substr($description, 0, 497) . '...';
-      }
+      $plain = strip_tags($body);
+      $description = strlen($plain) > 500 ? substr($plain, 0, 497) . '...' : $plain;
       $schema['description'] = $description;
     }
 
-    // Add archive image.
+    // Archive image.
     if ($node->hasField('field_archive_image') && !$node->get('field_archive_image')->isEmpty()) {
-      $field_value = $node->get('field_archive_image');
-      if ($field_value->entity instanceof File) {
-        $image_url = $this->fileUrlGenerator->generateAbsoluteString($field_value->entity->getFileUri());
-        $schema['image'] = [
+      $field_item = $node->get('field_archive_image')->first();
+      // @phpstan-ignore-next-line
+      $file = $field_item ? $field_item->entity : NULL;
+      if ($file instanceof File) {
+        $image_url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
+        $image = [
           '@type' => 'ImageObject',
           'url' => $image_url,
           'contentUrl' => $image_url,
         ];
+        $w = $field_item->get('width')->getValue();
+        $h = $field_item->get('height')->getValue();
+        if ($w) {
+          $image['width'] = (int) $w;
+        }
+        if ($h) {
+          $image['height'] = (int) $h;
+        }
+        $schema['image'] = $image;
       }
     }
 
-    // Add ISBN if available.
-    if ($node->hasField('field_isbn') && !$node->get('field_isbn')->isEmpty()) {
+    if ($has_isbn) {
       $schema['isbn'] = $node->get('field_isbn')->value;
     }
 
-    // Add language.
+    // Keywords from tags.
+    if ($node->hasField('field_tags') && !$node->get('field_tags')->isEmpty()) {
+      $keywords = [];
+      foreach ($node->get('field_tags') as $tag) {
+        // @phpstan-ignore-next-line
+        $term = $tag->entity;
+        if ($term) {
+          $keywords[] = $term->getName();
+        }
+      }
+      if (!empty($keywords)) {
+        $schema['keywords'] = implode(', ', $keywords);
+      }
+    }
+
+    // Language.
     if ($node->hasField('field_language') && !$node->get('field_language')->isEmpty()) {
       $languages = [];
       foreach ($node->get('field_language') as $language) {
-        /** @var \Drupal\taxonomy\Entity\Term|null $term */
         // @phpstan-ignore-next-line
         $term = $language->entity;
         if ($term) {
@@ -135,7 +169,7 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       $schema['inLanguage'] = 'en-ZA';
     }
 
-    // Add source/provider.
+    // Original source (semantically a sourceOrganization, not a provider).
     if ($node->hasField('field_source') && !$node->get('field_source')->isEmpty()) {
       $sources = [];
       foreach ($node->get('field_source') as $source) {
@@ -147,21 +181,20 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
         }
       }
       if (!empty($sources)) {
-        $schema['provider'] = count($sources) === 1 ? $sources[0] : $sources;
+        $schema['sourceOrganization'] = count($sources) === 1 ? $sources[0] : $sources;
       }
     }
 
-    // Add file upload as associatedMedia.
+    // File downloads as DataDownload (more specific than MediaObject).
     if ($node->hasField('field_file_upload') && !$node->get('field_file_upload')->isEmpty()) {
       $files = [];
       foreach ($node->get('field_file_upload') as $file_ref) {
-        /** @var \Drupal\file\Entity\File|null $file */
         // @phpstan-ignore-next-line
         $file = $file_ref->entity;
         if ($file instanceof File) {
           $file_url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
           $files[] = [
-            '@type' => 'MediaObject',
+            '@type' => 'DataDownload',
             'contentUrl' => $file_url,
             'encodingFormat' => $file->getMimeType(),
             'name' => $file->getFilename(),
@@ -173,14 +206,29 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       }
     }
 
-    // Add holdings as part of SAHO archive.
-    $schema['holdingArchive'] = [
+    // Holdings, publisher, license.
+    $base_url = \Drupal::request()->getSchemeAndHttpHost();
+    $org = [
       '@type' => 'ArchiveOrganization',
       'name' => 'South African History Online',
-      'url' => \Drupal::request()->getSchemeAndHttpHost(),
+      'url' => $base_url,
     ];
-
-    // Add license.
+    $schema['holdingArchive'] = $org;
+    $schema['publisher'] = [
+      '@type' => 'Organization',
+      'name' => 'South African History Online',
+      'url' => $base_url,
+      'logo' => [
+        '@type' => 'ImageObject',
+        'url' => $base_url . '/themes/custom/saho/logo.png',
+        'width' => 600,
+        'height' => 60,
+      ],
+    ];
+    $schema['copyrightHolder'] = [
+      '@type' => 'Organization',
+      'name' => 'South African History Online',
+    ];
     $schema['license'] = 'https://creativecommons.org/licenses/by-nc-sa/4.0/';
     $schema['isAccessibleForFree'] = TRUE;
 

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/ArticleSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/ArticleSchemaBuilder.php
@@ -10,21 +10,15 @@ use Drupal\node\NodeInterface;
 use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
- * Builds Schema.org ScholarlyArticle structured data for Article nodes.
+ * Builds Schema.org Article structured data for Article nodes.
  *
- * Maps SAHO article content to Schema.org ScholarlyArticle vocabulary
- * for optimal discovery by search engines and AI systems.
+ * Top-level @type is Article (Google Search Console's "Articles" report
+ * only counts Article/NewsArticle/BlogPosting; ScholarlyArticle is kept
+ * as additionalType to preserve semantics without sacrificing GSC
+ * visibility).
  */
 class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
 
-  /**
-   * Constructs an ArticleSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
     protected FileUrlGeneratorInterface $fileUrlGenerator,
@@ -45,28 +39,41 @@ class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
+    $url = $node->toUrl()->setAbsolute()->toString();
+
     $schema = [
       '@context' => 'https://schema.org',
-      '@type' => 'ScholarlyArticle',
+      '@type' => 'Article',
+      'additionalType' => 'https://schema.org/ScholarlyArticle',
       'headline' => $node->getTitle(),
-      'url' => $node->toUrl()->setAbsolute()->toString(),
+      'url' => $url,
+      'mainEntityOfPage' => [
+        '@type' => 'WebPage',
+        '@id' => $url,
+      ],
       'datePublished' => date('c', $node->getCreatedTime()),
       'dateModified' => date('c', $node->getChangedTime()),
     ];
 
-    // Add abstract/synopsis.
+    // Synopsis -> abstract; body -> articleBody + description + wordCount.
     if ($node->hasField('field_synopsis') && !$node->get('field_synopsis')->isEmpty()) {
       $schema['abstract'] = $node->get('field_synopsis')->value;
     }
-
-    // Add article body.
     if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
       $body = $node->get('body')->value;
-      // Strip HTML tags for articleBody.
-      $schema['articleBody'] = strip_tags($body);
+      $plain = strip_tags($body);
+      $schema['articleBody'] = $plain;
+      $schema['wordCount'] = str_word_count($plain);
+      // Description: prefer synopsis if present, else first 500 chars of body.
+      if (isset($schema['abstract'])) {
+        $schema['description'] = $schema['abstract'];
+      }
+      else {
+        $schema['description'] = strlen($plain) > 500 ? substr($plain, 0, 497) . '...' : $plain;
+      }
     }
 
-    // Add contributors (authors).
+    // Authors.
     if ($node->hasField('field_article_author') && !$node->get('field_article_author')->isEmpty()) {
       $authors = [];
       foreach ($node->get('field_article_author') as $author) {
@@ -82,7 +89,7 @@ class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
       }
     }
 
-    // Add editors.
+    // Editors.
     if ($node->hasField('field_article_editors') && !$node->get('field_article_editors')->isEmpty()) {
       $editors = [];
       foreach ($node->get('field_article_editors') as $editor) {
@@ -98,21 +105,16 @@ class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
       }
     }
 
-    // Add main image.
-    $image_url = $this->getImageUrl($node, ['field_main_image', 'field_article_image', 'field_image']);
-    if ($image_url) {
-      $schema['image'] = [
-        '@type' => 'ImageObject',
-        'url' => $image_url,
-        'contentUrl' => $image_url,
-      ];
+    // Main image with dimensions when available (Google: >=1200px for rich).
+    $image_data = $this->getImageData($node, ['field_main_image', 'field_article_image', 'field_image']);
+    if ($image_data) {
+      $schema['image'] = $image_data;
     }
 
-    // Add keywords/tags.
+    // Keywords + articleSection from tags.
     if ($node->hasField('field_tags') && !$node->get('field_tags')->isEmpty()) {
       $keywords = [];
       foreach ($node->get('field_tags') as $tag) {
-        /** @var \Drupal\taxonomy\Entity\Term|null $term */
         // @phpstan-ignore-next-line
         $term = $tag->entity;
         if ($term) {
@@ -121,14 +123,14 @@ class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
       }
       if (!empty($keywords)) {
         $schema['keywords'] = implode(', ', $keywords);
+        $schema['articleSection'] = $keywords[0];
       }
     }
 
-    // Add spatial coverage (African countries).
+    // Spatial coverage.
     if ($node->hasField('field_african_country') && !$node->get('field_african_country')->isEmpty()) {
       $places = [];
       foreach ($node->get('field_african_country') as $country) {
-        /** @var \Drupal\taxonomy\Entity\Term|null $term */
         // @phpstan-ignore-next-line
         $term = $country->entity;
         if ($term) {
@@ -143,78 +145,92 @@ class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
       }
     }
 
-    // Add citations from field_ref_str (pipe-delimited).
+    // Citations.
     if ($node->hasField('field_ref_str') && !$node->get('field_ref_str')->isEmpty()) {
       $ref_str = $node->get('field_ref_str')->value;
       if (!empty($ref_str)) {
-        $citations = array_filter(explode('|', $ref_str));
+        $citations = array_filter(array_map('trim', explode('|', $ref_str)));
         if (!empty($citations)) {
-          $schema['citation'] = array_map('trim', $citations);
+          $schema['citation'] = array_values($citations);
         }
       }
     }
 
-    // Add publisher (SAHO organization).
     $schema['publisher'] = $this->getPublisherSchema();
-
-    // Add license and educational properties.
     $schema['license'] = 'https://creativecommons.org/licenses/by-nc-sa/4.0/';
     $schema['isAccessibleForFree'] = TRUE;
     $schema['educationalUse'] = 'research';
-
-    // Add inLanguage.
     $schema['inLanguage'] = 'en-ZA';
 
     return $schema;
   }
 
   /**
-   * Get image URL from node image fields.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The node entity.
-   * @param array $field_names
-   *   Array of field names to check in priority order.
-   *
-   * @return string|null
-   *   The absolute image URL or NULL if not found.
+   * Build an ImageObject with width/height when available.
    */
-  protected function getImageUrl(NodeInterface $node, array $field_names): ?string {
+  protected function getImageData(NodeInterface $node, array $field_names): ?array {
     foreach ($field_names as $field_name) {
-      if ($node->hasField($field_name) && !$node->get($field_name)->isEmpty()) {
-        $field_value = $node->get($field_name);
+      if (!$node->hasField($field_name) || $node->get($field_name)->isEmpty()) {
+        continue;
+      }
+      $field_item = $node->get($field_name)->first();
+      if (!$field_item) {
+        continue;
+      }
+      // @phpstan-ignore-next-line
+      $entity = $field_item->entity;
 
-        // Handle file fields.
-        if ($field_value->entity instanceof File) {
-          return $this->fileUrlGenerator->generateAbsoluteString($field_value->entity->getFileUri());
+      if ($entity instanceof File) {
+        $url = $this->fileUrlGenerator->generateAbsoluteString($entity->getFileUri());
+        $image = [
+          '@type' => 'ImageObject',
+          'url' => $url,
+          'contentUrl' => $url,
+        ];
+        $w = $field_item->get('width')->getValue();
+        $h = $field_item->get('height')->getValue();
+        if ($w) {
+          $image['width'] = (int) $w;
         }
+        if ($h) {
+          $image['height'] = (int) $h;
+        }
+        return $image;
+      }
 
-        // Handle media entity reference fields.
-        if ($field_value->entity instanceof ContentEntityInterface && $field_value->entity->hasField('field_media_image')) {
-          $media_entity = $field_value->entity;
-          if (!$media_entity->get('field_media_image')->isEmpty()) {
-            $file_entity = $media_entity->get('field_media_image')->entity;
-            if ($file_entity instanceof File) {
-              return $this->fileUrlGenerator->generateAbsoluteString($file_entity->getFileUri());
+      if ($entity instanceof ContentEntityInterface && $entity->hasField('field_media_image')) {
+        if (!$entity->get('field_media_image')->isEmpty()) {
+          $media_item = $entity->get('field_media_image')->first();
+          // @phpstan-ignore-next-line
+          $file = $media_item ? $media_item->entity : NULL;
+          if ($file instanceof File) {
+            $url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
+            $image = [
+              '@type' => 'ImageObject',
+              'url' => $url,
+              'contentUrl' => $url,
+            ];
+            $w = $media_item->get('width')->getValue();
+            $h = $media_item->get('height')->getValue();
+            if ($w) {
+              $image['width'] = (int) $w;
             }
+            if ($h) {
+              $image['height'] = (int) $h;
+            }
+            return $image;
           }
         }
       }
     }
-
     return NULL;
   }
 
   /**
-   * Get SAHO publisher schema.
-   *
-   * @return array
-   *   Publisher organization schema.
+   * Publisher with logo dimensions (Google AMP/Article rich-result spec).
    */
   protected function getPublisherSchema(): array {
-    $request = \Drupal::request();
-    $base_url = $request->getSchemeAndHttpHost();
-
+    $base_url = \Drupal::request()->getSchemeAndHttpHost();
     return [
       '@type' => 'Organization',
       'name' => 'South African History Online',
@@ -222,6 +238,8 @@ class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
       'logo' => [
         '@type' => 'ImageObject',
         'url' => $base_url . '/themes/custom/saho/logo.png',
+        'width' => 600,
+        'height' => 60,
       ],
     ];
   }

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/BiographySchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/BiographySchemaBuilder.php
@@ -9,21 +9,14 @@ use Drupal\node\NodeInterface;
 use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
- * Builds Schema.org Person structured data for Biography nodes.
+ * Builds Schema.org ProfilePage structured data for Biography nodes.
  *
- * Maps SAHO biography content to Schema.org Person vocabulary
- * for optimal discovery by search engines and AI systems.
+ * Top-level @type is ProfilePage (Google's 2024+ rich-result type for
+ * person pages) with the Person nested under mainEntity. ProfilePage IS
+ * reported in GSC's enhancement reports; bare Person is not.
  */
 class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
 
-  /**
-   * Constructs a BiographySchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
     protected FileUrlGeneratorInterface $fileUrlGenerator,
@@ -44,83 +37,95 @@ class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
-    $schema = [
-      '@context' => 'https://schema.org',
+    $url = $node->toUrl()->setAbsolute()->toString();
+
+    $person = [
       '@type' => 'Person',
       'name' => $node->getTitle(),
-      'url' => $node->toUrl()->setAbsolute()->toString(),
+      'url' => $url,
+      'mainEntityOfPage' => [
+        '@type' => 'WebPage',
+        '@id' => $url,
+      ],
     ];
 
     // Build full name from components.
     $name_parts = [];
     if ($node->hasField('field_firstname') && !$node->get('field_firstname')->isEmpty()) {
       $name_parts[] = $node->get('field_firstname')->value;
-      $schema['givenName'] = $node->get('field_firstname')->value;
+      $person['givenName'] = $node->get('field_firstname')->value;
     }
     if ($node->hasField('field_middlename') && !$node->get('field_middlename')->isEmpty()) {
       $name_parts[] = $node->get('field_middlename')->value;
-      $schema['additionalName'] = $node->get('field_middlename')->value;
+      $person['additionalName'] = $node->get('field_middlename')->value;
     }
     if ($node->hasField('field_lastnamebio') && !$node->get('field_lastnamebio')->isEmpty()) {
       $name_parts[] = $node->get('field_lastnamebio')->value;
-      $schema['familyName'] = $node->get('field_lastnamebio')->value;
+      $person['familyName'] = $node->get('field_lastnamebio')->value;
     }
     if (!empty($name_parts)) {
-      $schema['name'] = implode(' ', $name_parts);
+      $person['name'] = implode(' ', $name_parts);
     }
 
-    // Add birth date.
+    // Dates.
     if ($node->hasField('field_drupal_birth_date') && !$node->get('field_drupal_birth_date')->isEmpty()) {
       $birth_date = $node->get('field_drupal_birth_date')->value;
       if (!empty($birth_date)) {
-        $schema['birthDate'] = $birth_date;
+        $person['birthDate'] = $birth_date;
       }
     }
-
-    // Add death date.
     if ($node->hasField('field_drupal_death_date') && !$node->get('field_drupal_death_date')->isEmpty()) {
       $death_date = $node->get('field_drupal_death_date')->value;
       if (!empty($death_date)) {
-        $schema['deathDate'] = $death_date;
+        $person['deathDate'] = $death_date;
       }
     }
 
-    // Add birth place.
+    // Birth/death places.
     if ($node->hasField('field_birth_location') && !$node->get('field_birth_location')->isEmpty()) {
       $birth_location = $node->get('field_birth_location')->value;
       if (!empty($birth_location)) {
-        $schema['birthPlace'] = [
+        $person['birthPlace'] = [
           '@type' => 'Place',
           'name' => $birth_location,
         ];
       }
     }
-
-    // Add death place.
     if ($node->hasField('field_death_location') && !$node->get('field_death_location')->isEmpty()) {
       $death_location = $node->get('field_death_location')->value;
       if (!empty($death_location)) {
-        $schema['deathPlace'] = [
+        $person['deathPlace'] = [
           '@type' => 'Place',
           'name' => $death_location,
         ];
       }
     }
 
-    // Add biography image.
+    // Image (with dimensions when available).
     if ($node->hasField('field_bio_pic') && !$node->get('field_bio_pic')->isEmpty()) {
-      $field_value = $node->get('field_bio_pic');
-      if ($field_value->entity instanceof File) {
-        $image_url = $this->fileUrlGenerator->generateAbsoluteString($field_value->entity->getFileUri());
-        $schema['image'] = [
+      $field_item = $node->get('field_bio_pic')->first();
+      // @phpstan-ignore-next-line
+      $file = $field_item ? $field_item->entity : NULL;
+      if ($file instanceof File) {
+        $image_url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
+        $image = [
           '@type' => 'ImageObject',
           'url' => $image_url,
           'contentUrl' => $image_url,
         ];
+        $w = $field_item->get('width')->getValue();
+        $h = $field_item->get('height')->getValue();
+        if ($w) {
+          $image['width'] = (int) $w;
+        }
+        if ($h) {
+          $image['height'] = (int) $h;
+        }
+        $person['image'] = $image;
       }
     }
 
-    // Add job title/position.
+    // Job title.
     if ($node->hasField('field_position') && !$node->get('field_position')->isEmpty()) {
       $positions = [];
       foreach ($node->get('field_position') as $position) {
@@ -129,11 +134,11 @@ class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
         }
       }
       if (!empty($positions)) {
-        $schema['jobTitle'] = count($positions) === 1 ? $positions[0] : $positions;
+        $person['jobTitle'] = count($positions) === 1 ? $positions[0] : $positions;
       }
     }
 
-    // Add affiliation.
+    // Affiliation.
     if ($node->hasField('field_affiliation') && !$node->get('field_affiliation')->isEmpty()) {
       $affiliations = [];
       foreach ($node->get('field_affiliation') as $affiliation) {
@@ -145,15 +150,14 @@ class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
         }
       }
       if (!empty($affiliations)) {
-        $schema['affiliation'] = count($affiliations) === 1 ? $affiliations[0] : $affiliations;
+        $person['affiliation'] = count($affiliations) === 1 ? $affiliations[0] : $affiliations;
       }
     }
 
-    // Add nationality (from African country field).
+    // Nationality.
     if ($node->hasField('field_african_country') && !$node->get('field_african_country')->isEmpty()) {
       $countries = [];
       foreach ($node->get('field_african_country') as $country) {
-        /** @var \Drupal\taxonomy\Entity\Term|null $term */
         // @phpstan-ignore-next-line
         $term = $country->entity;
         if ($term) {
@@ -164,35 +168,55 @@ class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
         }
       }
       if (!empty($countries)) {
-        $schema['nationality'] = count($countries) === 1 ? $countries[0] : $countries;
+        $person['nationality'] = count($countries) === 1 ? $countries[0] : $countries;
       }
     }
 
-    // Add description from body.
+    // knowsAbout from tags.
+    if ($node->hasField('field_tags') && !$node->get('field_tags')->isEmpty()) {
+      $topics = [];
+      foreach ($node->get('field_tags') as $tag) {
+        // @phpstan-ignore-next-line
+        $term = $tag->entity;
+        if ($term) {
+          $topics[] = $term->getName();
+        }
+      }
+      if (!empty($topics)) {
+        $person['knowsAbout'] = $topics;
+      }
+    }
+
+    // Description (up to 300 chars; Google accommodates the longer cap).
     if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
       $body = $node->get('body')->value;
-      // Get first 200 characters as description.
-      $description = strip_tags($body);
-      if (strlen($description) > 200) {
-        $description = substr($description, 0, 197) . '...';
-      }
-      $schema['description'] = $description;
+      $plain = strip_tags($body);
+      $description = strlen($plain) > 300 ? substr($plain, 0, 297) . '...' : $plain;
+      $person['description'] = $description;
     }
 
-    // Add sameAs for related URLs if available.
+    // External profile URLs.
     if ($node->hasField('field_url') && !$node->get('field_url')->isEmpty()) {
       $urls = [];
-      foreach ($node->get('field_url') as $url) {
-        if (!empty($url->uri)) {
-          $urls[] = $url->uri;
+      foreach ($node->get('field_url') as $url_item) {
+        if (!empty($url_item->uri)) {
+          $urls[] = $url_item->uri;
         }
       }
       if (!empty($urls)) {
-        $schema['sameAs'] = $urls;
+        $person['sameAs'] = $urls;
       }
     }
 
-    return $schema;
+    // Wrap Person in ProfilePage (Google rich-result type for profiles).
+    return [
+      '@context' => 'https://schema.org',
+      '@type' => 'ProfilePage',
+      'url' => $url,
+      'dateCreated' => date('c', $node->getCreatedTime()),
+      'dateModified' => date('c', $node->getChangedTime()),
+      'mainEntity' => $person,
+    ];
   }
 
 }

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/EventSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/EventSchemaBuilder.php
@@ -10,21 +10,15 @@ use Drupal\node\NodeInterface;
 use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
- * Builds Schema.org Event structured data for Event nodes.
+ * Builds Schema.org Article structured data for historical Event nodes.
  *
- * Maps SAHO "This Day in History" (TDIH) events to Schema.org Event
- * vocabulary for optimal discovery by search engines and AI systems.
+ * "This Day in History" entries describe historical events; they are not
+ * attendable events. The page is therefore modeled as a Schema.org Article
+ * (a GSC-eligible type) with the historical event nested under `about` as
+ * a Schema.org Event with additionalType=HistoricalEvent.
  */
 class EventSchemaBuilder implements SchemaOrgBuilderInterface {
 
-  /**
-   * Constructs an EventSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
     protected FileUrlGeneratorInterface $fileUrlGenerator,
@@ -45,59 +39,51 @@ class EventSchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
+    $url = $node->toUrl()->setAbsolute()->toString();
+
     $schema = [
       '@context' => 'https://schema.org',
-      '@type' => 'Event',
-      'additionalType' => 'https://schema.org/HistoricalEvent',
-      'name' => $node->getTitle(),
-      'url' => $node->toUrl()->setAbsolute()->toString(),
+      '@type' => 'Article',
+      'additionalType' => 'https://schema.org/ScholarlyArticle',
+      'headline' => $node->getTitle(),
+      'url' => $url,
+      'mainEntityOfPage' => [
+        '@type' => 'WebPage',
+        '@id' => $url,
+      ],
+      'datePublished' => date('c', $node->getCreatedTime()),
+      'dateModified' => date('c', $node->getChangedTime()),
     ];
 
-    // Add event date as startDate and temporalCoverage.
+    // Event date drives the historical event's startDate.
     $event_date = NULL;
     if ($node->hasField('field_event_date') && !$node->get('field_event_date')->isEmpty()) {
       $event_date = $node->get('field_event_date')->value;
     }
 
-    // Fallback: Use node created date if event date is missing.
-    if (empty($event_date)) {
-      $event_date = date('c', $node->getCreatedTime());
-    }
-
-    $schema['startDate'] = $event_date;
-    $schema['endDate'] = $event_date;
-    $schema['temporalCoverage'] = $event_date;
-
-    // Add event description from body.
+    // Body becomes description + articleBody.
     if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
       $body = $node->get('body')->value;
-      $description = strip_tags($body);
-      // Limit to 500 characters for description.
-      if (strlen($description) > 500) {
-        $description = substr($description, 0, 497) . '...';
-      }
+      $plain = strip_tags($body);
+      $description = strlen($plain) > 500 ? substr($plain, 0, 497) . '...' : $plain;
       $schema['description'] = $description;
+      $schema['articleBody'] = $plain;
+      $schema['wordCount'] = str_word_count($plain);
     }
     else {
-      // Fallback: Use generic description if body is missing.
       $schema['description'] = 'Historical event from South African History Online archives.';
     }
 
-    // Add event image (field_tdih_image or field_event_image).
-    $image_url = $this->getImageUrl($node, ['field_tdih_image', 'field_event_image', 'field_image']);
-    if ($image_url) {
-      $schema['image'] = [
-        '@type' => 'ImageObject',
-        'url' => $image_url,
-        'contentUrl' => $image_url,
-      ];
+    // Article image.
+    $image_data = $this->getImageData($node, ['field_tdih_image', 'field_event_image', 'field_image']);
+    if ($image_data) {
+      $schema['image'] = $image_data;
     }
 
-    // Add event type as additionalType.
+    // Keywords from event type taxonomy.
     if ($node->hasField('field_event_type') && !$node->get('field_event_type')->isEmpty()) {
       $event_types = [];
       foreach ($node->get('field_event_type') as $event_type) {
-        /** @var \Drupal\taxonomy\Entity\Term|null $term */
         // @phpstan-ignore-next-line
         $term = $event_type->entity;
         if ($term) {
@@ -105,114 +91,165 @@ class EventSchemaBuilder implements SchemaOrgBuilderInterface {
         }
       }
       if (!empty($event_types)) {
-        $schema['additionalType'] = count($event_types) === 1 ? $event_types[0] : $event_types;
+        $schema['keywords'] = implode(', ', $event_types);
+        $schema['articleSection'] = $event_types[0];
       }
     }
 
-    // Add location (African country).
+    // Spatial coverage from African country.
+    $places = $this->getPlaces($node);
+    if (!empty($places)) {
+      $schema['spatialCoverage'] = count($places) === 1 ? $places[0] : $places;
+    }
+
+    // Citations.
+    if ($node->hasField('field_ref_str') && !$node->get('field_ref_str')->isEmpty()) {
+      $ref_str = $node->get('field_ref_str')->value;
+      if (!empty($ref_str)) {
+        $citations = array_filter(array_map('trim', explode('|', $ref_str)));
+        if (!empty($citations)) {
+          $schema['citation'] = array_values($citations);
+        }
+      }
+    }
+
+    // Temporal coverage for the article itself (when did this describe).
+    if ($event_date) {
+      $schema['temporalCoverage'] = $event_date;
+    }
+
+    // Nested Event under `about` — the actual historical event the article
+    // describes. Uses Place (never VirtualLocation) so it validates cleanly.
+    $about_event = [
+      '@type' => 'Event',
+      'additionalType' => 'https://schema.org/HistoricalEvent',
+      'name' => $node->getTitle(),
+    ];
+    if ($event_date) {
+      $about_event['startDate'] = $event_date;
+      $about_event['endDate'] = $event_date;
+    }
+    if (!empty($places)) {
+      $about_event['location'] = count($places) === 1 ? $places[0] : $places;
+    }
+    else {
+      $about_event['location'] = [
+        '@type' => 'Place',
+        'name' => 'South Africa',
+        'address' => [
+          '@type' => 'PostalAddress',
+          'addressCountry' => 'ZA',
+        ],
+      ];
+    }
+    $schema['about'] = $about_event;
+
+    // Publisher, license, language.
+    $schema['publisher'] = $this->getPublisherSchema();
+    $schema['license'] = 'https://creativecommons.org/licenses/by-nc-sa/4.0/';
+    $schema['isAccessibleForFree'] = TRUE;
+    $schema['educationalUse'] = 'research';
+    $schema['inLanguage'] = 'en-ZA';
+
+    return $schema;
+  }
+
+  /**
+   * Build Place entities from field_african_country.
+   */
+  protected function getPlaces(NodeInterface $node): array {
+    $places = [];
     if ($node->hasField('field_african_country') && !$node->get('field_african_country')->isEmpty()) {
-      $countries = [];
       foreach ($node->get('field_african_country') as $country) {
-        /** @var \Drupal\taxonomy\Entity\Term|null $term */
         // @phpstan-ignore-next-line
         $term = $country->entity;
         if ($term) {
-          $countries[] = [
+          $places[] = [
             '@type' => 'Place',
             'name' => $term->getName(),
           ];
         }
       }
-      if (!empty($countries)) {
-        $schema['location'] = count($countries) === 1 ? $countries[0] : $countries;
-      }
     }
-
-    // Fallback: Use VirtualLocation if no physical location.
-    if (empty($schema['location'])) {
-      $schema['location'] = [
-        '@type' => 'VirtualLocation',
-        'url' => $node->toUrl()->setAbsolute()->toString(),
-      ];
-    }
-
-    // Add citations from field_ref_str (pipe-delimited).
-    if ($node->hasField('field_ref_str') && !$node->get('field_ref_str')->isEmpty()) {
-      $ref_str = $node->get('field_ref_str')->value;
-      if (!empty($ref_str)) {
-        $citations = array_filter(explode('|', $ref_str));
-        if (!empty($citations)) {
-          $schema['citation'] = array_map('trim', $citations);
-        }
-      }
-    }
-
-    // Add publisher (SAHO as curator/publisher of historical events).
-    $schema['publisher'] = $this->getOrganizationSchema();
-
-    // Add educational properties.
-    $schema['isAccessibleForFree'] = TRUE;
-    $schema['educationalUse'] = 'research';
-
-    // Add inLanguage.
-    $schema['inLanguage'] = 'en-ZA';
-
-    // Note: eventStatus and eventAttendanceMode removed.
-    // Not applicable to historical events.
-    return $schema;
+    return $places;
   }
 
   /**
-   * Get image URL from node image fields.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The node entity.
-   * @param array $field_names
-   *   Array of field names to check in priority order.
-   *
-   * @return string|null
-   *   The absolute image URL or NULL if not found.
+   * Build an ImageObject (with width/height when available).
    */
-  protected function getImageUrl(NodeInterface $node, array $field_names): ?string {
+  protected function getImageData(NodeInterface $node, array $field_names): ?array {
     foreach ($field_names as $field_name) {
-      if ($node->hasField($field_name) && !$node->get($field_name)->isEmpty()) {
-        $field_value = $node->get($field_name);
+      if (!$node->hasField($field_name) || $node->get($field_name)->isEmpty()) {
+        continue;
+      }
+      $field_item = $node->get($field_name)->first();
+      if (!$field_item) {
+        continue;
+      }
+      // @phpstan-ignore-next-line
+      $entity = $field_item->entity;
 
-        // Handle file fields.
-        if ($field_value->entity instanceof File) {
-          return $this->fileUrlGenerator->generateAbsoluteString($field_value->entity->getFileUri());
+      // Direct file field.
+      if ($entity instanceof File) {
+        $image = [
+          '@type' => 'ImageObject',
+          'url' => $this->fileUrlGenerator->generateAbsoluteString($entity->getFileUri()),
+        ];
+        $image['contentUrl'] = $image['url'];
+        $w = $field_item->get('width')->getValue();
+        $h = $field_item->get('height')->getValue();
+        if ($w) {
+          $image['width'] = (int) $w;
         }
+        if ($h) {
+          $image['height'] = (int) $h;
+        }
+        return $image;
+      }
 
-        // Handle media entity reference fields.
-        if ($field_value->entity instanceof ContentEntityInterface && $field_value->entity->hasField('field_media_image')) {
-          $media_entity = $field_value->entity;
-          if (!$media_entity->get('field_media_image')->isEmpty()) {
-            $file_entity = $media_entity->get('field_media_image')->entity;
-            if ($file_entity instanceof File) {
-              return $this->fileUrlGenerator->generateAbsoluteString($file_entity->getFileUri());
+      // Media reference.
+      if ($entity instanceof ContentEntityInterface && $entity->hasField('field_media_image')) {
+        if (!$entity->get('field_media_image')->isEmpty()) {
+          $media_item = $entity->get('field_media_image')->first();
+          // @phpstan-ignore-next-line
+          $file = $media_item ? $media_item->entity : NULL;
+          if ($file instanceof File) {
+            $image = [
+              '@type' => 'ImageObject',
+              'url' => $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri()),
+            ];
+            $image['contentUrl'] = $image['url'];
+            $w = $media_item->get('width')->getValue();
+            $h = $media_item->get('height')->getValue();
+            if ($w) {
+              $image['width'] = (int) $w;
             }
+            if ($h) {
+              $image['height'] = (int) $h;
+            }
+            return $image;
           }
         }
       }
     }
-
     return NULL;
   }
 
   /**
-   * Get SAHO organization schema.
-   *
-   * @return array
-   *   Organization schema for publisher/curator.
+   * Get SAHO publisher schema with logo dimensions (Google AMP spec).
    */
-  protected function getOrganizationSchema(): array {
-    $request = \Drupal::request();
-    $base_url = $request->getSchemeAndHttpHost();
-
+  protected function getPublisherSchema(): array {
+    $base_url = \Drupal::request()->getSchemeAndHttpHost();
     return [
       '@type' => 'Organization',
       'name' => 'South African History Online',
       'url' => $base_url,
+      'logo' => [
+        '@type' => 'ImageObject',
+        'url' => $base_url . '/themes/custom/saho/logo.png',
+        'width' => 600,
+        'height' => 60,
+      ],
     ];
   }
 

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/ImageSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/ImageSchemaBuilder.php
@@ -94,7 +94,9 @@ class ImageSchemaBuilder implements SchemaOrgBuilderInterface {
       $schema['description'] = $description;
     }
 
-    // Add creator/photographer if available.
+    // Add creator/photographer if available; fall back to SAHO as
+    // institutional creator so Google's Image Metadata report stops
+    // flagging missing-creator on ~2k images without an attributed person.
     if ($node->hasField('field_photographer') && !$node->get('field_photographer')->isEmpty()) {
       $schema['creator'] = [
         '@type' => 'Person',
@@ -105,6 +107,13 @@ class ImageSchemaBuilder implements SchemaOrgBuilderInterface {
       $schema['creator'] = [
         '@type' => 'Person',
         'name' => $node->get('field_author')->value,
+      ];
+    }
+    else {
+      $schema['creator'] = [
+        '@type' => 'Organization',
+        'name' => 'South African History Online',
+        'url' => \Drupal::request()->getSchemeAndHttpHost(),
       ];
     }
 
@@ -126,10 +135,10 @@ class ImageSchemaBuilder implements SchemaOrgBuilderInterface {
 
     $schema['copyrightNotice'] = '© ' . date('Y') . ' South African History Online. Licensed under CC BY-NC-SA 4.0.';
 
-    // Add creditText based on creator.
-    if (isset($schema['creator'])) {
-      $creator_name = $schema['creator']['name'];
-      $schema['creditText'] = 'Photo by ' . $creator_name . ' / SAHO';
+    // Credit text: only add the "Photo by" prefix when the creator is a
+    // named Person; if SAHO is the institutional creator, use the plain name.
+    if (($schema['creator']['@type'] ?? '') === 'Person') {
+      $schema['creditText'] = 'Photo by ' . $schema['creator']['name'] . ' / SAHO';
     }
     else {
       $schema['creditText'] = 'South African History Online (SAHO)';

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/UpcomingEventSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/UpcomingEventSchemaBuilder.php
@@ -107,27 +107,36 @@ class UpcomingEventSchemaBuilder implements SchemaOrgBuilderInterface {
       }
     }
 
-    // Add location (venue).
+    // Location (venue). Always emit a Place (Google rejects VirtualLocation
+    // for Event rich results). When no venue is set, fall back to a generic
+    // South Africa Place rather than a virtual URL placeholder.
     if ($node->hasField('field_upcoming_venue') && !$node->get('field_upcoming_venue')->isEmpty()) {
-      $venue = $node->get('field_upcoming_venue')->value;
+      $venue = trim(strip_tags($node->get('field_upcoming_venue')->value));
       if (!empty($venue)) {
         $schema['location'] = [
           '@type' => 'Place',
-          'name' => strip_tags($venue),
+          'name' => $venue,
+          'address' => [
+            '@type' => 'PostalAddress',
+            'addressCountry' => 'ZA',
+          ],
         ];
       }
     }
-
-    // Fallback: Use VirtualLocation if no physical location.
     if (empty($schema['location'])) {
       $schema['location'] = [
-        '@type' => 'VirtualLocation',
-        'url' => $node->toUrl()->setAbsolute()->toString(),
+        '@type' => 'Place',
+        'name' => 'South Africa',
+        'address' => [
+          '@type' => 'PostalAddress',
+          'addressCountry' => 'ZA',
+        ],
       ];
     }
 
-    // Add organizer (SAHO).
+    // Add organizer + performer (SAHO hosts these gatherings).
     $schema['organizer'] = $this->getOrganizationSchema();
+    $schema['performer'] = $this->getOrganizationSchema();
 
     // Add offers (free event).
     $schema['offers'] = [


### PR DESCRIPTION
## Summary

Google Search Console flagged structural issues across our JSON-LD output:

- **3,662 dated-event nodes invalid** ("Invalid object type for field location" — `VirtualLocation` rejected for `Event`)
- **2,084 image nodes missing `creator`**
- **2,809 articles, 10,772 biographies, 29,986 archives never appeared in GSC enhancement reports** because `ScholarlyArticle` / `Person` / `ArchiveComponent` are not Google rich-result-eligible top-level `@type` values.

This PR realigns each builder to a GSC-eligible top-level type while preserving the original Schema.org semantics via `additionalType` (or, for biographies, `mainEntity` nesting).

### Per-builder changes

| Builder | Before | After |
| --- | --- | --- |
| `EventSchemaBuilder` | `Event` with `VirtualLocation` fallback | `Article` + nested `about: Event(HistoricalEvent)` with a real `Place` (never virtual) |
| `UpcomingEventSchemaBuilder` | `Event` with `VirtualLocation` fallback | `Event` with `Place` fallback; adds `performer` |
| `ImageSchemaBuilder` | `creator` only when `field_photographer`/`field_author` set | Falls back to SAHO `Organization` so `creator` is always present; smarter `creditText` |
| `ArticleSchemaBuilder` | `ScholarlyArticle` | `Article` (with `additionalType: ScholarlyArticle`); adds `mainEntityOfPage`, `wordCount`, `description`, `articleSection`, image dimensions, publisher logo dimensions |
| `BiographySchemaBuilder` | bare `Person` | `ProfilePage` (2024+ Google rich result) wrapping `Person` under `mainEntity`; adds `knowsAbout`, 300-char description cap |
| `ArchiveSchemaBuilder` | `ArchiveComponent` | `Book` when ISBN present, else `CreativeWork` (with `additionalType: ArchiveComponent`); adds `creator` fallback, `keywords`, `copyrightHolder`; `provider` -> `sourceOrganization`; files use `DataDownload` |

### Expected GSC impact (2-8 weeks)

- 3,662 invalid Event errors -> resolved
- 2,084 missing-creator image warnings -> resolved
- 4 historical-event warning buckets (performer/offers/eventStatus/organizer, ~3,629 each) -> resolved (Article doesn't require those)
- 2,809 articles -> newly visible in GSC "Articles" report
- 10,772 biographies -> newly visible in GSC "ProfilePage" report
- 29,986 archives -> newly visible in GSC "Book"/"CreativeWork" reports

## Test plan

- [ ] phpcs `--standard=Drupal` on `webroot/modules/custom/saho_tools/src/Service/Builder/` (clean locally)
- [ ] drupal-check on `saho_tools/src/Service/Builder/` (clean locally)
- [ ] Spot-check 1 live URL per content type with [Google Rich Results Test](https://search.google.com/test/rich-results):
  - dated-event: `https://sahistory.org.za/dated-event/world-aids-day` (should now validate as Article)
  - upcoming-event: any current `/upcoming-event/*` (Event, Place location)
  - article: `https://sahistory.org.za/article/cradle-humankind`
  - biography: `https://sahistory.org.za/people/nelson-mandela` (should detect ProfilePage)
  - archive: any `/archive/*` (Book if ISBN, else CreativeWork)
- [ ] `ddev drush cr` after deploy so the new schemas are emitted
- [ ] Watch GSC over 2-8 weeks: error/warning buckets should decline, enhancement reports for Articles/ProfilePage/Book should populate