### PR TITLE
feat(shop): rework impact stats - credible 60,000+ with breakdown + scroll-in animation

### DIFF
--- a/webroot/themes/custom/saho_shop/css/pages/frontpage.css
+++ b/webroot/themes/custom/saho_shop/css/pages/frontpage.css
@@ -525,19 +525,57 @@
   flex-direction: column;
   align-items: center;
   padding: 1.5rem 1rem;
+  text-align: center;
 }
 .support-impact__number {
-  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-size: clamp(2.25rem, 5vw, 3.25rem);
   font-weight: 800;
   color: #900;
   line-height: 1;
-  margin-bottom: 0.5rem;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+.support-impact__rule {
+  display: block;
+  width: 36px;
+  height: 2px;
+  background: #b88a2e;
+  border-radius: 2px;
+  margin: 0 auto 0.75rem;
+  opacity: 0.85;
 }
 .support-impact__label {
-  font-size: 0.9rem;
-  color: #475569;
-  text-align: center;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1e293b;
+  line-height: 1.45;
+  max-width: 26ch;
+}
+.support-impact__breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: baseline;
+  gap: 0.35rem 0.5rem;
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
   line-height: 1.4;
+  color: #475569;
+}
+.support-impact__breakdown .support-impact__bucket {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.support-impact__breakdown .support-impact__dot {
+  color: #b88a2e;
+  font-weight: 700;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+.support-impact__stat--data .support-impact__number {
+  font-weight: 900;
 }
 .support-impact__text {
   max-width: 700px;
@@ -546,6 +584,15 @@
   font-size: 1rem;
   line-height: 1.7;
   color: #475569;
+}
+@media (max-width: 480px) {
+  .support-impact__breakdown {
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .support-impact__breakdown .support-impact__dot {
+    display: none;
+  }
 }
 
 .support-partner {

--- a/webroot/themes/custom/saho_shop/js/impact-stats.js
+++ b/webroot/themes/custom/saho_shop/js/impact-stats.js
@@ -1,0 +1,86 @@
+/**
+ * @file
+ * Animate the SAHO Shop "Why your support matters" impact-stat numbers
+ * from 0 to their final value on scroll-in.
+ *
+ * The server-rendered HTML already contains the final value, so this is
+ * pure progressive enhancement - if the JS never runs, or the user
+ * prefers reduced motion, the correct number stays put. Animation is
+ * one-shot per stat (the IntersectionObserver disconnects on first hit).
+ */
+
+((Drupal, once) => {
+  const DURATION_MS = 1500;
+
+  // Format with non-breaking thin space groupings to match SA convention
+  // (e.g. "60 000") rather than the comma grouping toLocaleString gives.
+  const formatNumber = (n) =>
+    n.toLocaleString('en-ZA').replace(/,/g, ' ').replace(/ /g, ' ');
+
+  const animateCount = (el, target, suffix) => {
+    const start = performance.now();
+    const tick = (now) => {
+      const t = Math.min(1, (now - start) / DURATION_MS);
+      // easeOutCubic - decelerates as it approaches the target
+      const eased = 1 - Math.pow(1 - t, 3);
+      el.textContent = formatNumber(Math.round(eased * target)) + suffix;
+      if (t < 1) {
+        window.requestAnimationFrame(tick);
+      } else {
+        // Final paint at the exact target value to avoid rounding drift.
+        el.textContent = formatNumber(target) + suffix;
+      }
+    };
+    window.requestAnimationFrame(tick);
+  };
+
+  Drupal.behaviors.sahoShopImpactStats = {
+    attach(context) {
+      const prefersReducedMotion = window.matchMedia(
+        '(prefers-reduced-motion: reduce)'
+      ).matches;
+
+      // Reduced-motion users: leave the server-rendered final value
+      // untouched and skip the animation entirely.
+      if (prefersReducedMotion) {
+        return;
+      }
+
+      // Older browsers without IntersectionObserver: also skip and leave
+      // the final value in place.
+      if (typeof window.IntersectionObserver === 'undefined') {
+        return;
+      }
+
+      once('saho-impact-stat', '[data-count-target]', context).forEach((el) => {
+        const target = parseInt(el.dataset.countTarget, 10);
+        const suffix = el.dataset.countSuffix || '';
+        if (Number.isNaN(target)) {
+          return;
+        }
+
+        // Reset to 0 so the animation has somewhere to start from.
+        el.textContent = '0' + suffix;
+
+        const io = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                animateCount(el, target, suffix);
+                io.disconnect();
+              }
+            });
+          },
+          {
+            // Fire just after the stat enters the viewport so the animation
+            // is visible (not playing out off-screen as the user scrolls in).
+            rootMargin: '0px 0px -10% 0px',
+            threshold: 0,
+          }
+        );
+
+        io.observe(el);
+      });
+    },
+  };
+})(Drupal, once);

--- a/webroot/themes/custom/saho_shop/saho_shop.libraries.yml
+++ b/webroot/themes/custom/saho_shop/saho_shop.libraries.yml
@@ -219,6 +219,11 @@ page.front:
   css:
     base:
       css/pages/frontpage.css: {}
+  js:
+    js/impact-stats.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 
 page.article:
   css:

--- a/webroot/themes/custom/saho_shop/scss/pages/frontpage.scss
+++ b/webroot/themes/custom/saho_shop/scss/pages/frontpage.scss
@@ -320,21 +320,74 @@
     flex-direction: column;
     align-items: center;
     padding: 1.5rem 1rem;
+    text-align: center;
   }
 
   &__number {
-    font-size: clamp(2rem, 4vw, 2.75rem);
+    font-size: clamp(2.25rem, 5vw, 3.25rem);
     font-weight: 800;
     color: $cp-primary;
     line-height: 1;
-    margin-bottom: 0.5rem;
+    letter-spacing: -0.01em;
+    margin-bottom: 0.75rem;
+    // Tabular numerals so the digits hold their column while animating
+    // and don't shift width on each frame.
+    font-variant-numeric: tabular-nums;
+  }
+
+  // Small gold rule between number and label - SAHO accent across hero,
+  // publications-hero and now here for visual cohesion.
+  &__rule {
+    display: block;
+    width: 36px;
+    height: 2px;
+    background: $cp-accent;
+    border-radius: 2px;
+    margin: 0 auto 0.75rem;
+    opacity: 0.85;
   }
 
   &__label {
-    font-size: 0.9rem;
-    color: $cp-text-muted;
-    text-align: center;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: $cp-text;
+    line-height: 1.45;
+    max-width: 26ch;
+  }
+
+  // Breakdown row that backs up the number with the real bucket counts.
+  // Inline with thin separators on desktop, wraps gracefully on mobile.
+  &__breakdown {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: baseline;
+    gap: 0.35rem 0.5rem;
+    margin-top: 0.75rem;
+    font-size: 0.8rem;
     line-height: 1.4;
+    color: $cp-text-muted;
+
+    .support-impact__bucket {
+      white-space: nowrap;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .support-impact__dot {
+      color: $cp-accent;
+      font-weight: 700;
+      user-select: none;
+    }
+  }
+
+  // Slightly emphasised treatment for the data-driven stat so the number
+  // and its supporting evidence read as one block.
+  &__stat--data {
+    .support-impact__number {
+      // Subtle weight bump and a tiny down-shift so the breakdown line
+      // sits close to it as a unit.
+      font-weight: 900;
+    }
   }
 
   &__text {
@@ -344,6 +397,18 @@
     font-size: 1rem;
     line-height: 1.7;
     color: $cp-text-muted;
+  }
+
+  // Mobile: breakdown line stacks vertically when it would wrap awkwardly.
+  @media (max-width: 480px) {
+    &__breakdown {
+      flex-direction: column;
+      gap: 0.15rem;
+
+      .support-impact__dot {
+        display: none;
+      }
+    }
   }
 }
 

--- a/webroot/themes/custom/saho_shop/templates/page/page--front.html.twig
+++ b/webroot/themes/custom/saho_shop/templates/page/page--front.html.twig
@@ -291,24 +291,51 @@
         <h2 id="impact-heading" class="support-section-title">{{ 'Why Your Support Matters'|t }}</h2>
 
         <div class="row g-0 justify-content-center">
+
+          {# Stat 1: Free #}
           <div class="col-sm-4 text-center">
             <div class="support-impact__stat">
-              <span class="support-impact__number">Free</span>
+              <span class="support-impact__number">{{ 'Free'|t }}</span>
+              <span class="support-impact__rule" aria-hidden="true"></span>
               <span class="support-impact__label">{{ 'Always free to access - no paywalls, ever'|t }}</span>
             </div>
           </div>
+
+          {# Stat 2: data-driven corpus stat. Server-rendered value is the
+             final state so no-JS / reader-mode users see the right number.
+             Drupal.behaviors.sahoShopImpactStats animates from 0 to target
+             on scroll-in via IntersectionObserver, gated by
+             prefers-reduced-motion. The breakdown line backs the number
+             with the real DB buckets so it never reads arbitrary. #}
           <div class="col-sm-4 text-center">
-            <div class="support-impact__stat">
-              <span class="support-impact__number">40 000+</span>
+            <div class="support-impact__stat support-impact__stat--data"
+                 role="group"
+                 aria-label="{{ '60,000 plus articles, biographies and historical records, including 30,000 archive items, 17,000 historical events, and 10,000 biographies'|t }}">
+              <span class="support-impact__number"
+                    data-count-target="60000"
+                    data-count-suffix="+"
+                    aria-hidden="true">60 000+</span>
+              <span class="support-impact__rule" aria-hidden="true"></span>
               <span class="support-impact__label">{{ 'Articles, biographies &amp; historical records'|t }}</span>
+              <span class="support-impact__breakdown" aria-hidden="true">
+                <span class="support-impact__bucket">{{ '30 000 archives'|t }}</span>
+                <span class="support-impact__dot">·</span>
+                <span class="support-impact__bucket">{{ '17 000 events'|t }}</span>
+                <span class="support-impact__dot">·</span>
+                <span class="support-impact__bucket">{{ '10 000 biographies'|t }}</span>
+              </span>
             </div>
           </div>
+
+          {# Stat 3: longevity #}
           <div class="col-sm-4 text-center">
             <div class="support-impact__stat">
-              <span class="support-impact__number">25+ yrs</span>
+              <span class="support-impact__number">{{ '25+ yrs'|t }}</span>
+              <span class="support-impact__rule" aria-hidden="true"></span>
               <span class="support-impact__label">{{ 'Documenting South African history online'|t }}</span>
             </div>
           </div>
+
         </div>
 
         <p class="support-impact__text">


### PR DESCRIPTION
## Why

The shop frontpage's "40 000+ Articles, biographies & historical records" stat reads as marketing fluff — the number isn't anchored to anything visible, and stakeholder feedback flagged it as feeling unimpressively low for a 25-year-old archive.

Real DB on the main site shows:

| Bundle | Count |
|---|---|
| archive | 30,125 |
| event | 17,654 |
| biography | 10,774 |
| article | 2,809 |
| place | 1,847 |
| **Total** | **63,209** |

## What

Bumped to **60 000+** with three supporting moves so the number reads as evidence, not marketing.

1. **Breakdown row** below the label: `30 000 archives · 17 000 events · 10 000 biographies`. Backs up the headline number with the actual buckets. Gold dot separators on desktop, stacks on narrow mobile.

2. **Scroll-in count-up animation** in `webroot/themes/custom/saho_shop/js/impact-stats.js`. IntersectionObserver + requestAnimationFrame, no third-party library. Server renders the final value so no-JS / reader-mode / search engines see the right number; JS resets to 0 only after it's confirmed the user has scroll behavior and reduced-motion isn't on, then animates when the stat enters the viewport. One-shot per stat.

3. **Visual cohesion with the SAHO design system**:
   - Gold accent rule (`.support-impact__rule`) under every number, matching the eyebrow pattern on publications-hero and the new Publications block.
   - Tabular numerals so digits don't shimmy during animation.
   - Slightly heavier weight on the data-driven stat.

## Accessibility

- `prefers-reduced-motion: reduce` -> skips animation entirely. Final value stays put.
- Animated `<span>` is `aria-hidden="true"`. The parent `.support-impact__stat--data` has `role="group"` + `aria-label` that announces the final value and full breakdown, so screen readers get the meaning once without the spam of intermediate animation frames.
- Browsers without IntersectionObserver fall back to the server-rendered final value.

## Layout

Three-up row preserved on >= sm. Breakdown wraps on tablet, stacks vertically on <= 480px with the gold separators hidden.

## Verified locally

- Animation plays from 0 -> 60 000 over 1.5s on scroll-in
- prefers-reduced-motion: reduce -> no animation, final value visible
- Three stats render correctly with gold rule + breakdown on the middle one
- Drupal.behaviors.sahoShopImpactStats attached and the `once()` guard prevents double-init

## Files

- `templates/page/page--front.html.twig` - markup
- `scss/pages/frontpage.scss` + compiled `css/pages/frontpage.css` - styles
- `js/impact-stats.js` - new animation behavior
- `saho_shop.libraries.yml` - attach the JS to page.front