### PR TITLE
fix(shop): restore /publications hero + cart + grid styles wiped by SCSS rebuild

### DIFF
--- a/webroot/themes/custom/saho_shop/css/pages/catalog.css
+++ b/webroot/themes/custom/saho_shop/css/pages/catalog.css
@@ -1,20 +1,156 @@
+:root {
+  --saho-color-primary: #900;
+  --saho-color-primary-dark: #8b0000;
+  --saho-color-secondary: #3a4a64;
+  --saho-color-accent: #b88a2e;
+  --saho-color-accent-dark: #8b6914;
+  --saho-radius-pill: 9999px;
+  --saho-motion-emphasis: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --saho-shadow-card-hover: 0 12px 28px rgba(0, 0, 0, 0.12);
+  --saho-ring-focus: 0 0 0 3px rgba(184, 138, 46, 0.45);
+}
+
+.publications-hero {
+  position: relative;
+  background: #1a1a2e;
+  background-image: linear-gradient(135deg, #1a1a2e 0%, #16213e 60%, #0f3460 100%);
+  overflow: hidden;
+  padding: 3.5rem 0 3rem;
+  color: #fff;
+}
+.publications-hero__backdrop {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.publications-hero__books {
+  width: 100%;
+  height: 100%;
+  -o-object-fit: cover;
+     object-fit: cover;
+}
+.publications-hero__inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+.publications-hero__text {
+  flex: 1 1 auto;
+}
+.publications-hero__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #b88a2e;
+  margin-bottom: 0.6rem;
+}
+.publications-hero__rule {
+  display: inline-block;
+  width: 2rem;
+  height: 1px;
+  background: #b88a2e;
+  opacity: 0.7;
+}
+.publications-hero__title {
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.5rem;
+  color: #fff;
+}
+.publications-hero__subtitle {
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin: 0;
+  max-width: 480px;
+}
+.publications-hero__badge {
+  flex: 0 0 auto;
+  background: rgba(184, 138, 46, 0.15);
+  border: 1px solid rgba(184, 138, 46, 0.5);
+  border-radius: 40px;
+  padding: 0.5rem 1.1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: #e8c86a;
+  white-space: nowrap;
+}
+.publications-hero__badge-star {
+  font-size: 1rem;
+  line-height: 1;
+}
+.publications-hero__badge-text {
+  font-weight: 600;
+}
+.publications-hero__badge-link {
+  color: #b88a2e;
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(184, 138, 46, 0.4);
+  transition: color 0.15s, border-color 0.15s;
+}
+.publications-hero__badge-link:hover {
+  color: #e8c86a;
+  border-color: #e8c86a;
+}
+@media (max-width: 575.98px) {
+  .publications-hero {
+    padding: 2rem 0 2rem;
+  }
+  .publications-hero__badge {
+    width: 100%;
+    justify-content: center;
+  }
+  .publications-hero__subtitle {
+    font-size: 0.9rem;
+  }
+}
+
+.publications-catalog {
+  padding: 2.5rem 0 4rem;
+  background: #f8f8f6;
+}
+
+.view-product-catalog .views-exposed-form {
+  background: #fff;
+  border: 1px solid #e0ddd6;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
 @media (min-width: 992px) {
   .view-product-catalog .views-exposed-form {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
   }
-  .view-product-catalog .views-exposed-form .form-label {
-    margin: 0 0.5rem 0 0;
-    white-space: nowrap;
-    font-weight: bold;
+  .view-product-catalog .views-exposed-form .form-item {
+    margin: 0 !important;
   }
   .view-product-catalog .views-exposed-form .form-item,
 .view-product-catalog .views-exposed-form .form-actions {
     display: flex;
     align-items: center;
   }
-  .view-product-catalog .views-exposed-form .form-item {
-    margin: 0.5rem 1.5rem 0.5rem 0 !important;
+  .view-product-catalog .views-exposed-form .form-label {
+    margin: 0 0.5rem 0 0;
+    white-space: nowrap;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #555;
   }
   .view-product-catalog .views-exposed-form.form-style-minimal {
     align-items: flex-end;
@@ -22,6 +158,134 @@
   .view-product-catalog .views-exposed-form.form-style-minimal .form-item {
     display: block;
   }
+}
+.view-product-catalog .views-exposed-form .form-text {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.9rem;
+  transition: border-color 0.15s;
+}
+.view-product-catalog .views-exposed-form .form-text:focus {
+  border-color: #900;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(153, 0, 0, 0.12);
+}
+.view-product-catalog .views-exposed-form .form-submit {
+  background: #900;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.35rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.view-product-catalog .views-exposed-form .form-submit:hover {
+  background: #8b0000;
+}
+.view-product-catalog .view-content {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+}
+@media (min-width: 576px) {
+  .view-product-catalog .view-content {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+  }
+}
+@media (min-width: 768px) {
+  .view-product-catalog .view-content {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+@media (min-width: 1200px) {
+  .view-product-catalog .view-content {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.75rem;
+  }
+}
+.view-product-catalog .view-content .views-row,
+.view-product-catalog .view-content .product-item {
+  display: contents;
+}
+.view-product-catalog .pager {
+  margin-top: 2.5rem;
+  display: flex;
+  justify-content: center;
+}
+.view-product-catalog .pager__items {
+  display: flex;
+  gap: 0.25rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  align-items: center;
+}
+.view-product-catalog .pager__item a,
+.view-product-catalog .pager__item--current .pager__link,
+.view-product-catalog .pager__item--current {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  height: 2.25rem;
+  padding: 0 0.5rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  text-decoration: none;
+  font-weight: 500;
+  transition: background 0.15s, color 0.15s;
+}
+.view-product-catalog .pager__item a {
+  color: #333;
+  background: #fff;
+  border: 1px solid #ddd;
+}
+.view-product-catalog .pager__item a:hover {
+  background: #900;
+  color: #fff;
+  border-color: #900;
+}
+.view-product-catalog .pager__item--current {
+  background: #900;
+  color: #fff;
+  border: 1px solid #900;
+  font-weight: 700;
+}
+.view-product-catalog .view-empty {
+  text-align: center;
+  padding: 4rem 1rem;
+  color: #666;
+}
+.view-product-catalog .view-empty p {
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+}
+
+.product-card-publication .product-price-cart .btn,
+.product-card-modern .product-price-cart .btn {
+  background-color: #900;
+  border-color: #900;
+  color: #fff;
+}
+.product-card-publication .product-price-cart .btn:hover, .product-card-publication .product-price-cart .btn:focus,
+.product-card-modern .product-price-cart .btn:hover,
+.product-card-modern .product-price-cart .btn:focus {
+  background-color: #8b0000;
+  border-color: #8b0000;
+  color: #fff;
+}
+.product-card-publication .product-price-cart .btn.bi-btn-basket,
+.product-card-modern .product-price-cart .btn.bi-btn-basket {
+  background-color: #900;
+  filter: none;
+}
+.product-card-publication .order-item-price,
+.product-card-modern .order-item-price {
+  color: #900;
 }
 
 /*# sourceMappingURL=catalog.css.map */

--- a/webroot/themes/custom/saho_shop/scss/pages/catalog.scss
+++ b/webroot/themes/custom/saho_shop/scss/pages/catalog.scss
@@ -1,20 +1,170 @@
 //
-// Catalog page
+// Publications / Catalog page - SAHO Shop
 // ----------------------------
 //
+// Restored from compiled-only CSS that lived in dist/catalog.css before the
+// PR #339 production rebuild. Now driven from SCSS so it survives rebuilds.
+//
 @import "../global";
+@import "../support-tokens";
 
-// Catalog view.
+
+// ----------------------------------------------------------
+// Hero
+// ----------------------------------------------------------
+.publications-hero {
+  position: relative;
+  background: #1a1a2e;
+  background-image: linear-gradient(135deg, #1a1a2e 0%, #16213e 60%, #0f3460 100%);
+  overflow: hidden;
+  padding: 3.5rem 0 3rem;
+  color: #fff;
+
+  &__backdrop {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  &__books {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &__inner {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  &__text {
+    flex: 1 1 auto;
+  }
+
+  &__eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: $cp-accent;
+    margin-bottom: 0.6rem;
+  }
+
+  &__rule {
+    display: inline-block;
+    width: 2rem;
+    height: 1px;
+    background: $cp-accent;
+    opacity: 0.7;
+  }
+
+  &__title {
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 800;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.5rem;
+    color: #fff;
+  }
+
+  &__subtitle {
+    font-size: 1rem;
+    color: rgba(255, 255, 255, 0.7);
+    margin: 0;
+    max-width: 480px;
+  }
+
+  // Champion discount badge
+  &__badge {
+    flex: 0 0 auto;
+    background: rgba(184, 138, 46, 0.15);
+    border: 1px solid rgba(184, 138, 46, 0.5);
+    border-radius: 40px;
+    padding: 0.5rem 1.1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    color: #e8c86a;
+    white-space: nowrap;
+  }
+
+  &__badge-star {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  &__badge-text {
+    font-weight: 600;
+  }
+
+  &__badge-link {
+    color: $cp-accent;
+    font-weight: 700;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(184, 138, 46, 0.4);
+    transition: color 0.15s, border-color 0.15s;
+
+    &:hover {
+      color: #e8c86a;
+      border-color: #e8c86a;
+    }
+  }
+
+  @include media-breakpoint-down(sm) {
+    padding: 2rem 0 2rem;
+
+    &__badge {
+      width: 100%;
+      justify-content: center;
+    }
+
+    &__subtitle {
+      font-size: 0.9rem;
+    }
+  }
+}
+
+
+// ----------------------------------------------------------
+// Catalog section wrapper
+// ----------------------------------------------------------
+.publications-catalog {
+  padding: 2.5rem 0 4rem;
+  background: #f8f8f6;
+}
+
+
+// ----------------------------------------------------------
+// Catalog view: filter bar, grid, pagination
+// ----------------------------------------------------------
 .view-product-catalog {
-  @include media-breakpoint-up("lg") {
-    .views-exposed-form {
+
+  // Exposed filter bar
+  .views-exposed-form {
+    background: #fff;
+    border: 1px solid #e0ddd6;
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+
+    @include media-breakpoint-up(lg) {
       display: flex;
       flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
 
-      .form-label {
-        margin: 0 0.5rem 0 0;
-        white-space: nowrap;
-        font-weight: bold;
+      .form-item {
+        margin: 0 !important;
       }
 
       .form-item,
@@ -23,11 +173,14 @@
         align-items: center;
       }
 
-      .form-item {
-        margin: 0.5rem 1.5rem 0.5rem 0 !important;
+      .form-label {
+        margin: 0 0.5rem 0 0;
+        white-space: nowrap;
+        font-weight: 600;
+        font-size: 0.85rem;
+        color: #555;
       }
 
-      // Minimal form styles.
       &.form-style-minimal {
         align-items: flex-end;
 
@@ -36,5 +189,158 @@
         }
       }
     }
+
+    // Search input
+    .form-text {
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      padding: 0.35rem 0.75rem;
+      font-size: 0.9rem;
+      transition: border-color 0.15s;
+
+      &:focus {
+        border-color: $cp-primary;
+        outline: none;
+        box-shadow: 0 0 0 3px rgba(153, 0, 0, 0.12);
+      }
+    }
+
+    // Submit button
+    .form-submit {
+      background: $cp-primary;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 0.35rem 1rem;
+      font-size: 0.875rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+
+      &:hover {
+        background: $cp-primary-dark;
+      }
+    }
+  }
+
+  // Publication grid - responsive columns
+  .view-content {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+
+    @include media-breakpoint-up(sm) {
+      grid-template-columns: repeat(2, 1fr);
+      gap: 1.5rem;
+    }
+
+    @include media-breakpoint-up(md) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    @include media-breakpoint-up(xl) {
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1.75rem;
+    }
+
+    // Views wraps each row in a div with col classes; flatten so the grid
+    // template above governs layout instead of Bootstrap columns.
+    .views-row,
+    .product-item {
+      display: contents;
+    }
+  }
+
+  // Pagination
+  .pager {
+    margin-top: 2.5rem;
+    display: flex;
+    justify-content: center;
+  }
+
+  .pager__items {
+    display: flex;
+    gap: 0.25rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    align-items: center;
+  }
+
+  .pager__item a,
+  .pager__item--current .pager__link,
+  .pager__item--current {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.25rem;
+    height: 2.25rem;
+    padding: 0 0.5rem;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    text-decoration: none;
+    font-weight: 500;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .pager__item a {
+    color: #333;
+    background: #fff;
+    border: 1px solid #ddd;
+
+    &:hover {
+      background: $cp-primary;
+      color: #fff;
+      border-color: $cp-primary;
+    }
+  }
+
+  .pager__item--current {
+    background: $cp-primary;
+    color: #fff;
+    border: 1px solid $cp-primary;
+    font-weight: 700;
+  }
+
+  // Empty state
+  .view-empty {
+    text-align: center;
+    padding: 4rem 1rem;
+    color: #666;
+
+    p {
+      font-size: 1.1rem;
+      margin-bottom: 1.5rem;
+    }
+  }
+}
+
+
+// ----------------------------------------------------------
+// Add-to-cart pill on publication / modern teaser cards
+// ----------------------------------------------------------
+.product-card-publication,
+.product-card-modern {
+  .product-price-cart .btn {
+    background-color: $cp-primary;
+    border-color: $cp-primary;
+    color: #fff;
+
+    &:hover,
+    &:focus {
+      background-color: $cp-primary-dark;
+      border-color: $cp-primary-dark;
+      color: #fff;
+    }
+
+    // Basket icon variant - keep red, do not invert
+    &.bi-btn-basket {
+      background-color: $cp-primary;
+      filter: none;
+    }
+  }
+
+  .order-item-price {
+    color: $cp-primary;
   }
 }


### PR DESCRIPTION
## Summary

- **Root cause:** PR #311 wrote ~340 lines of catalog styles directly to compiled `catalog.css` without ever adding them to `catalog.scss`. PR #339's `npm run production` rebuild regenerated `catalog.css` from the source SCSS and dropped everything not in the source. Five categories of styles vanished from `/publications`: the dark navy hero block, the responsive 2/3/4 column grid, the exposed filter bar (white card + focus state + red submit), the SAHO red Add-to-Cart pill, and the SAHO red pagination active state.
- **Fix:** Port the full pre-regression CSS into `scss/pages/catalog.scss` so future production rebuilds preserve it. Use `$cp-primary` / `$cp-primary-dark` / `$cp-accent` tokens from `_support-tokens.scss` instead of raw hex.
- **Scope:** `scss/pages/catalog.scss` + rebuilt `css/pages/catalog.css`. No template, library, or markup changes.

## Test plan

- [x] `npm run css-compile && npm run css-prefix` succeeds (worktree off main)
- [x] Visit https://shop.ddev.site/publications - hero gradient + SAHO SHOP eyebrow + champion discount pill render
- [x] Computed style on `.publications-hero` returns the navy gradient + 56px top padding + white text
- [x] Computed style on `.product-card-publication .product-price-cart .btn` returns `rgb(153, 0, 0)` (SAHO red) background + border
- [x] Three-column grid layout on desktop, two-column on tablet, decorative book backdrop visible
- [ ] CI build green
- [ ] Follow-up: audit other shop theme CSS files for the same compiled-only drift pattern (see internal task #3)

## Note on the drift trap

This is the second category of regression caused by PR #339's production rebuild (the first was the legacy commerce-paypal `[class*="paypal"]` selector). Worth confirming during review that no other `saho_shop/css/**/*.css` file has more declarations than its `.scss` twin.