### PR TITLE
fix(donate): /donate fall back to commerce_payfast admin config so cPanel admins don't need settings.php edits

### DIFF
--- a/webroot/modules/custom/saho_donate/src/Controller/DonateController.php
+++ b/webroot/modules/custom/saho_donate/src/Controller/DonateController.php
@@ -6,6 +6,7 @@ use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Site\Settings;
 use Drupal\saho_donate\Form\DonateForm;
+use Drupal\saho_donate\PayfastCredentials;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -141,10 +142,13 @@ class DonateController extends ControllerBase {
     $data = $request->request->all();
 
     // Require passphrase to be configured - reject all ITNs otherwise.
-    $passphrase = Settings::get('payfast_passphrase', '');
+    // PayfastCredentials::get() looks in $settings[] first, then falls
+    // back to the commerce_payment_gateway.payfast config entity so the
+    // admin UI can drive credentials without touching settings.php.
+    $passphrase = PayfastCredentials::get()['passphrase'];
     if ($passphrase === '') {
       $this->getLogger('saho_donate')->error(
-        'PayFast ITN: payfast_passphrase is not set in settings.php - all ITN notifications rejected.'
+        'PayFast ITN: passphrase not set in settings.php or in the commerce_payfast gateway admin form - all ITN notifications rejected.'
       );
       return new Response('Configuration error', 500);
     }

--- a/webroot/modules/custom/saho_donate/src/Form/DonateForm.php
+++ b/webroot/modules/custom/saho_donate/src/Form/DonateForm.php
@@ -4,7 +4,7 @@ namespace Drupal\saho_donate\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Site\Settings;
+use Drupal\saho_donate\PayfastCredentials;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -132,9 +132,24 @@ class DonateForm extends FormBase {
     $email  = $form_state->getValue('email');
     $name   = trim((string) ($form_state->getValue('name') ?? ''));
 
-    $merchant_id  = Settings::get('payfast_merchant_id', '');
-    $merchant_key = Settings::get('payfast_merchant_key', '');
-    $passphrase   = Settings::get('payfast_passphrase', '');
+    $creds        = PayfastCredentials::get();
+    $merchant_id  = $creds['merchant_id'];
+    $merchant_key = $creds['merchant_key'];
+    $passphrase   = $creds['passphrase'];
+
+    if ($merchant_id === '' || $merchant_key === '') {
+      // Fail fast with a friendly message rather than letting PayFast
+      // return a generic 400 about missing fields. Log to watchdog so
+      // operators see this in the admin error log.
+      \Drupal::logger('saho_donate')->error(
+        'PayFast credentials missing: set merchant_id / merchant_key via the commerce_payfast gateway admin form or via $settings[] in settings.php.'
+      );
+      $this->messenger()->addError(
+        $this->t('Donations are temporarily unavailable. The payment gateway is not configured. Please try again later or contact us at info@sahistory.org.za.')
+      );
+      $form_state->setRebuild(TRUE);
+      return;
+    }
 
     $request  = $this->requestStack->getCurrentRequest();
     $base_url = $request->getSchemeAndHttpHost();

--- a/webroot/modules/custom/saho_donate/src/PayfastCredentials.php
+++ b/webroot/modules/custom/saho_donate/src/PayfastCredentials.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\saho_donate;
+
+use Drupal\Core\Site\Settings;
+
+/**
+ * Resolves PayFast credentials for the saho_donate one-off donation flow.
+ *
+ * Two storage locations are checked, in order:
+ *
+ * 1. PHP $settings[] in settings.php / env vars (Settings::get()).
+ * 2. The Drupal config entity for Commerce's PayFast gateway
+ *    (commerce_payment.commerce_payment_gateway.payfast), which is what
+ *    the shop's admin UI writes to.
+ *
+ * Operators can drive credentials either way. On cPanel hosts where env
+ * vars are awkward, filling the Commerce gateway admin form is enough -
+ * the saho_donate /donate page will pick the same values up via this
+ * helper.
+ */
+final class PayfastCredentials {
+
+  /**
+   * Returns merchant_id / merchant_key / passphrase.
+   *
+   * @return array
+   *   Keys: merchant_id, merchant_key, passphrase. Empty strings when unset.
+   */
+  public static function get(): array {
+    $id = (string) Settings::get('payfast_merchant_id', '');
+    $key = (string) Settings::get('payfast_merchant_key', '');
+    $passphrase = (string) Settings::get('payfast_passphrase', '');
+
+    // If any of the three is missing, peek at the commerce_payment_gateway
+    // config entity so the admin UI on the shop becomes the single source
+    // of truth.
+    if ($id === '' || $key === '' || $passphrase === '') {
+      $gateway = \Drupal::config('commerce_payment.commerce_payment_gateway.payfast')
+        ->get('configuration') ?? [];
+      $id = $id !== '' ? $id : (string) ($gateway['merchant_id'] ?? '');
+      $key = $key !== '' ? $key : (string) ($gateway['merchant_key'] ?? '');
+      $passphrase = $passphrase !== '' ? $passphrase : (string) ($gateway['passphrase'] ?? '');
+    }
+
+    return [
+      'merchant_id' => $id,
+      'merchant_key' => $key,
+      'passphrase' => $passphrase,
+    ];
+  }
+
+  /**
+   * Quick boolean: are id + key both set?
+   *
+   * Passphrase is optional for the redirect flow (only required for ITN
+   * signature verification), so it's not part of the missing() check.
+   */
+  public static function missing(): bool {
+    $creds = self::get();
+    return $creds['merchant_id'] === '' || $creds['merchant_key'] === '';
+  }
+
+}


### PR DESCRIPTION
## What was happening

Operator filled the **commerce_payfast gateway** credentials via the shop admin UI. That's a Drupal config entity (\`commerce_payment.commerce_payment_gateway.payfast\` -> \`configuration.merchant_id\` etc).

The main site's \`/donate\` form (saho_donate \`DonateForm\`) reads from a different place: PHP \`$settings[]\` via \`Settings::get('payfast_merchant_id')\`. On cPanel hosts where env vars are awkward and \`settings.php\` hadn't been manually patched, those Settings stayed empty, the form POSTed empty fields to PayFast, and PayFast returned:

> 400 Bad Request
> The merchant id field is required.
> The merchant key field is required.

## What this PR does

New helper \`Drupal\\saho_donate\\PayfastCredentials::get()\`. Two-stage lookup:

1. PHP \`$settings[]\` via \`Settings::get()\` - existing path, still preferred for env-var / settings.php setups.
2. Drupal config entity \`commerce_payment.commerce_payment_gateway.payfast\` \`configuration\` sub-keys - the source of truth filled via the shop admin UI.

Each of merchant_id / merchant_key / passphrase falls back independently, so a mixed setup (e.g. passphrase in settings.php, id+key in admin UI) also works.

## Updates

- **\`DonateForm::submitForm()\`**: uses the helper. If id or key is still empty after both lookups, logs to watchdog (\`saho_donate\` channel), shows a friendly Messenger error ("Donations are temporarily unavailable…"), and rebuilds the form. Visitor never sees PayFast's raw 400.
- **\`DonateController::notify()\`**: uses the same helper for the ITN passphrase check, so the webhook signature flow benefits from the same fallback.

## What did NOT change

- The optional \`$settings['payfast_valid_ips']\` IP allowlist stays on \`Settings::get()\` - it's intentionally an operator-only gate, not part of the admin UI source.
- No new config schema. No DB changes.
- No template changes.

## How an operator now configures /donate

**Easiest (cPanel-friendly):** open \`/admin/commerce/config/payment-gateways\` -> PayFast -> fill merchant_id / merchant_key / passphrase via the admin form. Save. Both shop checkouts AND main-site \`/donate\` will work.

**Alternative (env-var or settings.php):** unchanged from before - set \`$settings['payfast_merchant_id']\` etc in \`webroot/sites/default/settings.php\` and those override the admin config (helper checks \$settings first).

## Tested locally

- \`PayfastCredentials::get()\` correctly returns the commerce gateway values when \$settings is empty.
- \`PayfastCredentials::missing()\` returns true only if id or key is empty across both sources.
- With both empty: form rebuilds with the friendly error, no PayFast round-trip, no fatal.
- phpcs --standard=Drupal clean.

## Related

- Address GHSA-f9f8-rm49-7jv2 (already shipped via #340)
- /donate full pathway redesign (#339, v1.12.0)