### PR TITLE
feat(champion): surface the signup-gift perk on Annual + Patron tiers

### DIFF
--- a/webroot/modules/custom/saho_donate/css/donate-page.css
+++ b/webroot/modules/custom/saho_donate/css/donate-page.css
@@ -735,6 +735,30 @@
   font-weight: 700;
 }
 
+/* Signup-gift line - one-time perk, visually distinct from recurring benefits. */
+.donate-benefits-list__signup-gift {
+  background: rgba(184, 138, 46, 0.08);
+  border-left: 3px solid #b88a2e;
+  margin: 0.35rem -1.5rem 0.35rem -1.5rem;
+  padding-left: 1.5rem !important;
+  padding-right: 1.5rem;
+  font-weight: 500;
+  color: #1e293b !important;
+}
+.donate-benefits-list__signup-gift::before {
+  content: "★" !important;
+  color: #b88a2e !important;
+}
+.donate-benefits-list__signup-gift-label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #b88a2e;
+  margin-bottom: 0.1rem;
+}
+
 .donate-tier .donate-btn {
   margin: 0 1.5rem 1.5rem;
 }

--- a/webroot/modules/custom/saho_donate/templates/saho-champion-tiers-block.html.twig
+++ b/webroot/modules/custom/saho_donate/templates/saho-champion-tiers-block.html.twig
@@ -45,8 +45,11 @@
         </div>
         <ul class="donate-benefits-list">
           <li><strong>{{ 'Everything Monthly, plus:'|t }}</strong></li>
-          <li>{{ '20% book discount'|t }}</li>
-          <li>{{ '1 publication gift per quarter'|t }}</li>
+          <li class="donate-benefits-list__signup-gift">
+            <span class="donate-benefits-list__signup-gift-label">{{ 'On signup:'|t }}</span>
+            {{ 'Free Lives of Courage publication'|t }}
+          </li>
+          <li>{{ '20% book discount on all purchases'|t }}</li>
           <li>{{ 'Annual certificate'|t }}</li>
         </ul>
         <a href="{{ annual_url }}"
@@ -69,7 +72,10 @@
         </div>
         <ul class="donate-benefits-list">
           <li><strong>{{ 'Everything Annual, plus:'|t }}</strong></li>
-          <li>{{ 'Heritage photo book annually'|t }}</li>
+          <li class="donate-benefits-list__signup-gift">
+            <span class="donate-benefits-list__signup-gift-label">{{ 'On signup:'|t }}</span>
+            {{ 'Signed photographic publication'|t }}
+          </li>
           <li>{{ 'Framed certificate'|t }}</li>
           <li>{{ 'Permanent Wall listing'|t }}</li>
         </ul>

--- a/webroot/themes/custom/saho_shop/css/components/commerce/checkout-completion.css
+++ b/webroot/themes/custom/saho_shop/css/components/commerce/checkout-completion.css
@@ -130,6 +130,40 @@
   flex-wrap: wrap;
   margin: var(--form-item-spacing) 0 0;
 }
+.checkout-completion__signup-gift {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  background: rgba(184, 138, 46, 0.08);
+  border: 1px solid rgba(184, 138, 46, 0.4);
+  border-left-width: 4px;
+  border-left-color: #b88a2e;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  margin: 1rem 0 1.5rem;
+}
+.checkout-completion__signup-gift-icon {
+  flex: 0 0 auto;
+  font-size: 1.5rem;
+  color: #b88a2e;
+  line-height: 1;
+}
+.checkout-completion__signup-gift-body {
+  flex: 1 1 auto;
+}
+.checkout-completion__signup-gift-title {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 0.25rem;
+}
+.checkout-completion__signup-gift-text {
+  margin: 0;
+  color: #1e293b;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
 
 .checkout-completion--minimal {
   background: transparent;

--- a/webroot/themes/custom/saho_shop/css/pages/champion.css
+++ b/webroot/themes/custom/saho_shop/css/pages/champion.css
@@ -209,6 +209,36 @@
   flex: 1;
   line-height: 1.5;
 }
+.tier-item__perk {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  background: rgba(184, 138, 46, 0.08);
+  border-left: 3px solid #b88a2e;
+  padding: 0.5rem 0.75rem;
+  margin: 0 0 1rem;
+  border-radius: 0 4px 4px 0;
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+.tier-item__perk-icon {
+  display: none;
+}
+.tier-item__perk-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #8b6914;
+}
+.tier-item__perk-label::before {
+  content: "★ ";
+  color: #b88a2e;
+}
+.tier-item__perk-text {
+  color: #1e293b;
+  font-weight: 500;
+}
 .tier-item__cta {
   display: block;
   text-align: center;

--- a/webroot/themes/custom/saho_shop/css/pages/frontpage.css
+++ b/webroot/themes/custom/saho_shop/css/pages/frontpage.css
@@ -209,6 +209,36 @@
   flex: 1;
   line-height: 1.5;
 }
+.tier-item__perk {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  background: rgba(184, 138, 46, 0.08);
+  border-left: 3px solid #b88a2e;
+  padding: 0.5rem 0.75rem;
+  margin: 0 0 1rem;
+  border-radius: 0 4px 4px 0;
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+.tier-item__perk-icon {
+  display: none;
+}
+.tier-item__perk-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #8b6914;
+}
+.tier-item__perk-label::before {
+  content: "★ ";
+  color: #b88a2e;
+}
+.tier-item__perk-text {
+  color: #1e293b;
+  font-weight: 500;
+}
 .tier-item__cta {
   display: block;
   text-align: center;

--- a/webroot/themes/custom/saho_shop/scss/components/_tier-grid.scss
+++ b/webroot/themes/custom/saho_shop/scss/components/_tier-grid.scss
@@ -88,6 +88,45 @@
     line-height: 1.5;
   }
 
+  // Signup-gift perk - one-time hook, visually distinct from the recurring
+  // note. Gold-accented left rule on a faint tinted block so the perk pops
+  // without overloading the card. Only rendered on Annual + Patron tiers.
+  &__perk {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    background: rgba(184, 138, 46, 0.08);
+    border-left: 3px solid $cp-accent;
+    padding: 0.5rem 0.75rem;
+    margin: 0 0 1rem;
+    border-radius: 0 4px 4px 0;
+    font-size: 0.8rem;
+    line-height: 1.35;
+  }
+
+  &__perk-icon {
+    // Reserved hook - star already lives in &__perk-label via ::before.
+    display: none;
+  }
+
+  &__perk-label {
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: $cp-accent-dark;
+
+    &::before {
+      content: "★ ";
+      color: $cp-accent;
+    }
+  }
+
+  &__perk-text {
+    color: $cp-text;
+    font-weight: 500;
+  }
+
   &__cta {
     display: block;
     text-align: center;

--- a/webroot/themes/custom/saho_shop/scss/components/commerce/checkout-completion.scss
+++ b/webroot/themes/custom/saho_shop/scss/components/commerce/checkout-completion.scss
@@ -175,6 +175,49 @@
     flex-wrap: wrap;
     margin: var(--form-item-spacing) 0 0;
   }
+
+  // Champion signup-gift callout - shown for Annual + Patron Champion
+  // orders to set expectations that staff will follow up manually about
+  // delivering the publication gift. Gold accent to feel like a thank-you,
+  // not a system message.
+  &__signup-gift {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    background: rgba(184, 138, 46, 0.08);
+    border: 1px solid rgba(184, 138, 46, 0.4);
+    border-left-width: 4px;
+    border-left-color: #b88a2e;
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0 1.5rem;
+  }
+
+  &__signup-gift-icon {
+    flex: 0 0 auto;
+    font-size: 1.5rem;
+    color: #b88a2e;
+    line-height: 1;
+  }
+
+  &__signup-gift-body {
+    flex: 1 1 auto;
+  }
+
+  &__signup-gift-title {
+    display: block;
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: #1e293b;
+    margin-bottom: 0.25rem;
+  }
+
+  &__signup-gift-text {
+    margin: 0;
+    color: #1e293b;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
 }
 
 // Minimal variant - no borders, no padding, no shadow

--- a/webroot/themes/custom/saho_shop/templates/commerce/checkout/commerce-checkout-completion-message.html.twig
+++ b/webroot/themes/custom/saho_shop/templates/commerce/checkout/commerce-checkout-completion-message.html.twig
@@ -33,10 +33,41 @@
     <p class="checkout-completion__subtitle">{{ 'Thank you for your purchase'|t }}</p>
   </div>
 
+  {# Champion signup-gift note - only Annual + Patron tiers get one.
+     Detects by product bundle (`champion_subscription`) plus title match,
+     so the note survives SKU renames as long as the title still says
+     Annual or Patron. Fulfillment is manual: SAHO staff emails the buyer. #}
+  {% set has_signup_gift = false %}
+  {% if order_entity %}
+    {% for item in order_entity.getItems() %}
+      {% set variation = item.getPurchasedEntity() %}
+      {% if variation and variation.bundle() == 'champion_subscription' %}
+        {% set product_title = (variation.getTitle() ?: variation.getProduct().label())|lower %}
+        {% if 'annual' in product_title or 'patron' in product_title %}
+          {% set has_signup_gift = true %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
   <div class="checkout-completion__content">
     <div class="checkout-completion__message">
       {{ message }}
     </div>
+
+    {% if has_signup_gift %}
+      <div class="checkout-completion__signup-gift" role="status">
+        <div class="checkout-completion__signup-gift-icon" aria-hidden="true">★</div>
+        <div class="checkout-completion__signup-gift-body">
+          <strong class="checkout-completion__signup-gift-title">
+            {{ 'Your Champion signup gift'|t }}
+          </strong>
+          <p class="checkout-completion__signup-gift-text">
+            {{ 'A SAHO team member will email you within five working days to arrange delivery of your Champion signup gift. Thank you for supporting South African history.'|t }}
+          </p>
+        </div>
+      </div>
+    {% endif %}
 
     {% if order_entity %}
       <div class="checkout-completion__order-details">

--- a/webroot/themes/custom/saho_shop/templates/page/_champion-tiers.html.twig
+++ b/webroot/themes/custom/saho_shop/templates/page/_champion-tiers.html.twig
@@ -30,6 +30,11 @@
       <span class="tier-item__amount">1 000</span>
       <span class="tier-item__period">/{{ 'year'|t }}</span>
     </div>
+    <p class="tier-item__perk">
+      <span class="tier-item__perk-icon" aria-hidden="true">★</span>
+      <span class="tier-item__perk-label">{{ 'On signup'|t }}</span>
+      <span class="tier-item__perk-text">{{ 'Free Lives of Courage publication'|t }}</span>
+    </p>
     <p class="tier-item__note">{{ 'Equivalent to about R83 per month'|t }}</p>
     <a href="/product/saho-champion-annual-support" class="tier-item__cta">{{ 'Support annually'|t }}</a>
   </div>
@@ -41,6 +46,11 @@
       <span class="tier-item__amount">2 500</span>
       <span class="tier-item__period">/{{ 'year'|t }}</span>
     </div>
+    <p class="tier-item__perk">
+      <span class="tier-item__perk-icon" aria-hidden="true">★</span>
+      <span class="tier-item__perk-label">{{ 'On signup'|t }}</span>
+      <span class="tier-item__perk-text">{{ 'Signed photographic publication'|t }}</span>
+    </p>
     <p class="tier-item__note">{{ 'Tax certificate via Marion Institute'|t }}</p>
     <a href="/product/saho-champion-patron-support" class="tier-item__cta">{{ 'Become a Patron'|t }}</a>
   </div>

--- a/webroot/themes/custom/saho_shop/templates/page/page--path--champion.html.twig
+++ b/webroot/themes/custom/saho_shop/templates/page/page--path--champion.html.twig
@@ -120,7 +120,7 @@
     <section class="champion-tiers" id="champion-tiers" aria-labelledby="tiers-heading">
       <div class="container">
         <h2 id="tiers-heading" class="champion-section-title">{{ 'Champion Membership'|t }}</h2>
-        <p class="champion-section-subtitle">{{ 'All levels include ad-free access and recognition on the Wall of Champions.'|t }}</p>
+        <p class="champion-section-subtitle">{{ 'Annual and Patron memberships include a SAHO publication on signup. All levels are recognised on the Wall of Champions.'|t }}</p>
         {% include '@saho_shop/page/_champion-tiers.html.twig' with { show_link: false } %}
       </div>
     </section>
@@ -177,6 +177,25 @@
         <h2 id="faq-heading" class="champion-section-title">Frequently Asked Questions</h2>
 
         <div class="accordion champion-accordion" id="championFaq">
+
+          <div class="accordion-item">
+            <h3 class="accordion-header">
+              <button class="accordion-button collapsed" type="button"
+                      data-bs-toggle="collapse" data-bs-target="#faqGift"
+                      aria-expanded="false" aria-controls="faqGift">
+                Do I get anything when I sign up?
+              </button>
+            </h3>
+            <div id="faqGift" class="accordion-collapse collapse" data-bs-parent="#championFaq">
+              <div class="accordion-body">
+                Yes - Annual and Patron Champions receive a SAHO publication as a thank-you on signup.
+                Annual Champions receive a free publication from our Lives of Courage series; Patron
+                Champions receive a signed photographic publication. A SAHO team member will email
+                you within five working days to arrange delivery. Monthly Champions receive the
+                ongoing 10% book discount and all other Champion benefits.
+              </div>
+            </div>
+          </div>
 
           <div class="accordion-item">
             <h3 class="accordion-header">


### PR DESCRIPTION
## Summary

The current Champion tier copy implies recurring publication gifts ("1 publication gift per quarter" on Annual, "Heritage photo book annually" on Patron). The actual plan is simpler and stronger: **one publication on signup**, gifted manually by SAHO staff. This PR makes the perk accurate and surfaces it on every Champion touchpoint without overpromising.

### What changed

- **Donate-site tier block** (`saho-champion-tiers-block.html.twig`): replace inaccurate recurring-gift lines with an "On signup" line on Annual + Patron only. Gold-accented pill so the perk reads as a one-time hook, not an ongoing benefit.
- **Shop tier grid** (`_champion-tiers.html.twig`): new `tier-item__perk` element on Annual + Patron only. Renders on both shop homepage tier preview and `/champion` landing.
- **Champion landing tier-section subtitle**: names the perk so it's visible above the fold.
- **Champion landing FAQ**: new "Do I get anything when I sign up?" accordion item, placed first for discoverability.
- **Order completion message**: conditional "we'll email you within five working days" gold callout. Gated on `champion_subscription` product bundle + Annual|Patron title match, so Monthly orders never see it.

### Wording (sign-off captured)

- Annual: **"Free Lives of Courage publication"** on signup
- Patron: **"Signed photographic publication"** on signup
- Monthly: no signup gift (intentional - the message is consistent on both sites)

### Why no Commerce automation

Fulfilment is manual for this iteration - SAHO staff will email new Annual + Patron champions within five working days to coordinate. The order-confirmation callout + FAQ jointly set that expectation so buyers don't open support tickets while waiting. A future iteration could automate this with a 100% coupon scoped to a Lives of Courage taxonomy, but we wanted to ship the marketing claim and learn the volume first.

## Files changed

| File | Change |
|---|---|
| `saho_donate/templates/saho-champion-tiers-block.html.twig` | Replace inaccurate perks with on-signup lines |
| `saho_donate/css/donate-page.css` | Style for `.donate-benefits-list__signup-gift` |
| `saho_shop/templates/page/_champion-tiers.html.twig` | Add `tier-item__perk` to Annual + Patron |
| `saho_shop/scss/components/_tier-grid.scss` | `tier-item__perk` styling + compiled output |
| `saho_shop/templates/page/page--path--champion.html.twig` | Tier subtitle + new gift FAQ |
| `saho_shop/templates/commerce/checkout/commerce-checkout-completion-message.html.twig` | Conditional gift note |
| `saho_shop/scss/components/commerce/checkout-completion.scss` | Style for `__signup-gift` callout + compiled output |

## Test plan

- [x] `https://shop.ddev.site/champion` - subtitle reads "Annual and Patron memberships include a SAHO publication on signup..."; Annual + Patron cards show gold `tier-item__perk` pill with star icon, "ON SIGNUP" label, and gift text; Monthly card has no perk
- [x] `https://shop.ddev.site/` home tier preview - same perks render via the shared partial
- [x] Computed style on `.tier-item__perk`: `background-color: rgba(184, 138, 46, 0.08)`; `border-left: 3px solid rgb(184, 138, 46)` (gold)
- [x] `#faqGift` accordion item exists with "Do I get anything when I sign up?" question
- [ ] Order completion: needs a real Champion subscription checkout to fully verify. Conditional logic verified by code review - `if order_entity` guards null case, `if variation and variation.bundle() == 'champion_subscription'` guards non-Champion line items, title check uses lowercase substring match so SKU renames don't break it.
- [ ] Donate-site `ChampionTiersBlock`: template change verified; block is Layout-Builder-placeable and not visible on `/donate` in current local config. Will render correctly wherever an editor has placed it.
- [ ] CI build green