### PR TITLE
fix(shop): config_ignore so admin-form PayFast credentials survive deploys

### DIFF
--- a/config/shop/commerce_payment.commerce_payment_gateway.payfast.yml
+++ b/config/shop/commerce_payment.commerce_payment_gateway.payfast.yml
@@ -14,8 +14,13 @@ configuration:
   payment_method_types:
     - credit_card
   collect_billing_information: false
-  merchant_id: abc123
-  merchant_key: abc123
+  # Credentials are managed via /admin/commerce/config/payment-gateways
+  # and protected from re-import by config_ignore.settings.yml.
+  # Leaving these empty in the exported YAML so even if config_ignore is
+  # disabled / mis-configured at deploy, a re-import cannot write false
+  # placeholder credentials (was "abc123" historically) into the DB.
+  merchant_id: ''
+  merchant_key: ''
   passphrase: ''
   redirect_method: post
   debug: 0

--- a/config/shop/config_ignore.settings.yml
+++ b/config/shop/config_ignore.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: IgOVnECx6lbVt6JVFnadoEEugneDf3UblPZnOzov43Q
+mode: simple
+ignored_config_entities:
+  - commerce_payment.commerce_payment_gateway.payfast

--- a/config/shop/core.extension.yml
+++ b/config/shop/core.extension.yml
@@ -35,6 +35,7 @@ module:
   commerce_variation_cart_form: 0
   commerce_wishlist: 0
   config: 0
+  config_ignore: 0
   contact: 0
   contextual: 0
   datetime: 0


### PR DESCRIPTION
## What was happening

Every deploy ran \`drush cim\` against \`config/shop\`, which contained \`commerce_payment.commerce_payment_gateway.payfast.yml\` with placeholder credentials:

\`\`\`yaml
merchant_id: abc123
merchant_key: abc123
\`\`\`

That import overwrote whatever the operator filled in via \`/admin/commerce/config/payment-gateways\` -> PayFast. PayFast then rejected requests because \`abc123\` isn't a valid merchant.

Visible failure on prod just now:
\`https://shop.sahistory.org.za/checkout/25/order_information\` -> "No payment gateway selected."

## Two-part fix

### 1. Enable \`drupal/config_ignore\` on the shop

The module was already in \`composer require\` but never installed on the shop site. Enabling it + adding the gateway entity to \`ignored_config_entities\` makes \`drush cim\` skip that one config on import, so admin-form values persist.

\`config/shop/config_ignore.settings.yml\`:
\`\`\`yaml
mode: simple
ignored_config_entities:
  - commerce_payment.commerce_payment_gateway.payfast
\`\`\`

### 2. Sanitise the exported YAML

Even with config_ignore enabled, the placeholder \`abc123\` shouldn't sit in the repo - if config_ignore is ever disabled or mis-configured during a deploy, a single import would write false credentials back. Changed to empty strings with a comment explaining the design:

\`\`\`yaml
configuration:
  # Credentials are managed via /admin/commerce/config/payment-gateways
  # and protected from re-import by config_ignore.settings.yml.
  # Leaving these empty in the exported YAML so even if config_ignore is
  # disabled / mis-configured at deploy, a re-import cannot write false
  # placeholder credentials (was "abc123" historically) into the DB.
  merchant_id: ''
  merchant_key: ''
  passphrase: ''
\`\`\`

## Post-merge operator steps

After this lands on prod:

1. Pull + \`drush --uri=https://shop.sahistory.org.za cim -y\` once - this enables config_ignore and registers the ignore list. Future runs will skip the gateway.
2. Refill credentials via \`/admin/commerce/config/payment-gateways\` -> PayFast (mode: live, merchant_id, merchant_key, passphrase).
3. Save. From now on, every deploy leaves those values alone.

## Related

- #347 (already merged in v1.12.4) added a \`PayfastCredentials\` helper so the main-site /donate form falls back to the same admin-form values. Combined with this PR: one place to enter PayFast credentials, both /donate and shop checkout work, no settings.php / env-var distribution needed.

## Audit checklist

- [ ] After deploy, \`drush --uri=https://shop.sahistory.org.za config-status\` should show 0 pending overrides for commerce_payment.commerce_payment_gateway.payfast
- [ ] Visit \`/admin/commerce/config/payment-gateways\` -> PayFast and confirm credentials are still set after a second deploy
- [ ] Test a checkout (small test product) to confirm "No payment gateway selected" is gone