### PR TITLE
fix(shop): champion_membership no longer routes through commerce_recurring (fixes 'No payment gateway selected')

### DIFF
--- a/config/shop/commerce_product.commerce_product_variation_type.champion_membership.yml
+++ b/config/shop/commerce_product.commerce_product_variation_type.champion_membership.yml
@@ -3,11 +3,20 @@ langcode: en
 status: true
 dependencies:
   module:
-    - commerce_recurring
+    - commerce_payment
 id: champion_membership
 label: 'SAHO Champion Membership'
-traits:
-  - purchasable_entity_subscription
+# Was: traits: [purchasable_entity_subscription] + orderItemType:
+# recurring_product_variation. That routed champion cart orders through
+# commerce_recurring, which filters out non-tokenizing payment gateways
+# at checkout - PayFast Offsite Redirect is a non-tokenizing gateway, so
+# Commerce showed "No payment gateway selected" and no checkout could
+# complete. PayFast Drupal contrib doesn't implement tokenization, so
+# the practical fix is to drop the recurring routing and treat champion
+# membership as a one-time payment that the supporter renews manually
+# (matching the existing UX on /donate and the champion landing page).
+# A future PR can re-introduce real recurring billing once the project
+# adopts a tokenizing gateway (Stripe or a tokenizing PayFast variant).
 locked: false
-orderItemType: recurring_product_variation
+orderItemType: default
 generateTitle: true


### PR DESCRIPTION
## Root cause of "No payment gateway selected" at shop checkout

The \`champion_membership\` variation type was configured to use the \`recurring_product_variation\` order item type. Adding a champion product to the cart created an order item that routes the order through commerce_recurring. commerce_recurring filters out payment gateways that don't implement stored-payment-method tokenization (it needs a token to charge future billing periods). PayFast Offsite Redirect is a non-tokenizing gateway. No gateways pass the filter -> Commerce shows "No payment gateway selected" -> checkout dead.

## Same root cause as the v1.12.0 fatal

The earlier "Error: Call to a member function toBillingPeriod() on null in Drupal\\commerce_recurring\\RecurringOrderManager->refreshOrder()" was the SAME problem from a different angle. v1.12.0 patched it defensively (\`saho_donate_commerce_order_presave\` seeds an empty billing_period to skip the fatal). After this PR lands the defensive guard becomes redundant, though it stays as belt-and-braces.

## What changed

\`config/shop/commerce_product.commerce_product_variation_type.champion_membership.yml\`:
- \`orderItemType\`: \`recurring_product_variation\` -> \`default\`
- dropped trait \`purchasable_entity_subscription\`
- dropped module dep \`commerce_recurring\`, added \`commerce_payment\`
- comment in the file records the why so a future PR adding a tokenizing gateway knows what to re-enable

## Operator steps after this lands

1. \`drush --uri=https://shop.sahistory.org.za cim -y\`
2. **Clear any cart orders that still hold \`recurring_product_variation\` order items** - they were created before the fix and still carry the old routing. Quick way:

   \`\`\`
   drush --uri=https://shop.sahistory.org.za eval '
   foreach (\Drupal\commerce_order\Entity\Order::loadMultiple() as $o) {
     if ($o->bundle() === "recurring" && $o->getState()->getId() === "draft") {
       echo "deleting draft recurring order ".$o->id().PHP_EOL;
       $o->delete();
     }
   }'
   \`\`\`

3. Test: add Champion Monthly to cart -> /cart -> Checkout -> proceed. PayFast should be selectable, redirect to PayFast, complete.

## What this does NOT do

- Doesn't implement real recurring billing. Champion membership becomes a one-time purchase that the supporter manually renews each period.
- If you want true auto-renewing subscription billing, that's a follow-up that needs either a tokenizing gateway (Stripe, or a patched commerce_payfast variant) or PayFast's own ad-hoc subscription API integrated as a separate plugin.