### PR TITLE
feat(donate): main /donate redirect + post-update to lower Champion prices on prod

### DIFF
--- a/webroot/modules/custom/saho_donate/saho_donate.post_update.php
+++ b/webroot/modules/custom/saho_donate/saho_donate.post_update.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @file
+ * Post-update hooks for the saho_donate module.
+ */
+
+use Drupal\commerce_price\Price;
+
+/**
+ * Lower Champion membership prices per the v1.12.0 plan.
+ *
+ * Prices were lowered locally via a one-off drush eval, but never made
+ * it to prod. This post-update bakes the price drop into a hook so a
+ * single `drush updb -y` on prod picks it up:
+ *
+ *   CHAMPION-MONTHLY: R200 -> R100
+ *   CHAMPION-ANNUAL:  R2,000 -> R1,000
+ *
+ * Idempotent: if a variation is already at the target price, it's
+ * skipped (avoids touching custom admin edits the operator may have
+ * made after the original drop).
+ *
+ * Only effective on the site where the champion product variations
+ * live (the shop). On any other site in the multisite, the loadBy
+ * call returns empty and the hook becomes a no-op.
+ */
+function saho_donate_post_update_lower_champion_prices(?array &$sandbox = NULL): string {
+  $targets = [
+    'CHAMPION-MONTHLY' => '100.00',
+    'CHAMPION-ANNUAL' => '1000.00',
+  ];
+
+  /** @var \Drupal\commerce_product\ProductVariationStorageInterface $storage */
+  $storage = \Drupal::entityTypeManager()->getStorage('commerce_product_variation');
+  $variations = $storage->loadByProperties(['sku' => array_keys($targets)]);
+
+  $updated = 0;
+  $skipped = 0;
+  foreach ($variations as $variation) {
+    $target_amount = $targets[$variation->getSku()] ?? NULL;
+    if ($target_amount === NULL) {
+      continue;
+    }
+    $current = $variation->getPrice();
+    $currency = $current ? $current->getCurrencyCode() : 'ZAR';
+
+    // Skip if already at target - keeps the hook safely re-runnable
+    // and respectful of any manual admin adjustments since first run.
+    if ($current && (string) $current->getNumber() === $target_amount) {
+      $skipped++;
+      continue;
+    }
+
+    $variation->setPrice(new Price($target_amount, $currency));
+    $variation->save();
+    $updated++;
+  }
+
+  return sprintf(
+    'Lowered Champion prices: %d variation(s) updated, %d already at target, %d not found.',
+    $updated,
+    $skipped,
+    count($targets) - count($variations)
+  );
+}

--- a/webroot/modules/custom/saho_donate/src/Controller/DonateController.php
+++ b/webroot/modules/custom/saho_donate/src/Controller/DonateController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Site\Settings;
 use Drupal\saho_donate\Form\DonateForm;
 use Drupal\saho_donate\PayfastCredentials;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -42,10 +43,27 @@ class DonateController extends ControllerBase {
   /**
    * Renders the /donate page: PayFast form + alternative pathways below.
    *
-   * @return array
-   *   A render array.
+   * Site-level override: if $settings['saho_donate_redirect_url'] is set
+   * (e.g. on the multisite main site where commerce_payfast credentials
+   * don't reach), the controller short-circuits with a 302 to that URL.
+   * Set in settings.php like:
+   *
+   *   $settings['saho_donate_redirect_url'] = 'https://shop.sahistory.org.za/donate';
+   *
+   * Leave unset to render the in-page PayFast form (existing behaviour).
+   *
+   * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+   *   Render array, or a 302 redirect to the configured external donate
+   *   page.
    */
-  public function page(): array {
+  public function page(): array|RedirectResponse {
+    $redirect_url = (string) Settings::get('saho_donate_redirect_url', '');
+    if ($redirect_url !== '') {
+      // 302 so search engines don't permanently cache the indirection if
+      // the operator later flips back to the in-page form.
+      return new RedirectResponse($redirect_url, 302);
+    }
+
     $pathways_block = [];
     if ($this->blockManager->hasDefinition('saho_donate_pathways')) {
       $block = $this->blockManager->createInstance('saho_donate_pathways', []);


### PR DESCRIPTION
Follow-ups to the multisite donate + pricing story. Two unrelated changes intentionally bundled because both touch saho_donate and both unblock prod.

## A) Site-aware redirect for /donate

\`DonateController::page()\` now short-circuits with a 302 when \`\$settings['saho_donate_redirect_url']\` is set. Default behaviour (render the in-page PayFast form) is unchanged.

After this lands, drop into the **main site's** \`webroot/sites/default/settings.php\`:

\`\`\`php
\$settings['saho_donate_redirect_url'] = 'https://shop.sahistory.org.za/donate';
\`\`\`

and main-site \`/donate\` redirects to shop \`/donate\`, which has commerce_payfast credentials and the four-pathway block already wired. One source of truth, zero credential duplication across multisite DBs, no PayfastCredentials cross-DB lookup needed.

The shop's settings.php leaves the setting **unset** so shop \`/donate\` still renders the in-page form (working today).

302 (not 301) so search engines don't permanently cache the indirection if the operator flips back to the in-page form later.

## B) Post-update for Champion prices

The v1.12.0 plan lowered \`CHAMPION-MONTHLY\` R200 -> R100 and \`CHAMPION-ANNUAL\` R2,000 -> R1,000 via a one-off drush eval that only ran on local. Prod still has the old prices (confirmed by checkout showing \`Subtotal: ZAR 2 200,00 = R200 + R2 000\`).

New \`saho_donate.post_update.php\` hook bakes the price drop in. Operators just run \`drush updb -y\` after deploy and the variations get the right prices.

Properties:
- **Idempotent** - already-correct prices are skipped (respects manual admin edits since first run).
- **Multisite-safe** - effective on the shop where the variations exist; no-op on the main site where \`loadByProperties\` returns empty.
- **One-shot** - hook name is \`saho_donate_post_update_lower_champion_prices\`. After a successful run it's recorded in the schema version table and Drupal won't run it again on subsequent updb cycles.

Local verify run:

\`\`\`
> [notice] Update started: saho_donate_post_update_lower_champion_prices
> [notice] Lowered Champion prices: 2 variation(s) updated, 0 already at target, 0 not found.
> [notice] Update completed: saho_donate_post_update_lower_champion_prices
\`\`\`

## Operator steps after merge

1. Pull on prod.
2. Add the redirect line to **main**'s \`webroot/sites/default/settings.php\`:

   \`\`\`php
   \$settings['saho_donate_redirect_url'] = 'https://shop.sahistory.org.za/donate';
   \`\`\`

3. \`drush --uri=https://sahistory.org.za cr\`
4. \`drush --uri=https://shop.sahistory.org.za updb -y\` (runs the price post-update)
5. Confirm:
   - https://sahistory.org.za/donate -> redirects to shop /donate
   - https://shop.sahistory.org.za/donate -> in-page form works
   - Champion prices show R100 / R1,000 in the catalog

## Related

- #350 (separate PR) fixes "No payment gateway selected" by stopping champion_membership from routing through commerce_recurring. Both PRs together unblock the full champion flow.
- v1.12.4 #347 PayfastCredentials helper becomes redundant for the main site once the redirect is in place, but stays for any environment that prefers the in-page form.