### PR TITLE
fix(donate): land "Choose your own amount" on a focused custom-amount field

### DIFF
--- a/webroot/modules/custom/saho_donate/js/donate.js
+++ b/webroot/modules/custom/saho_donate/js/donate.js
@@ -161,4 +161,37 @@
     }
   };
 
+  /**
+   * Deep-link into the custom-amount field.
+   *
+   * When /donate is opened with the #donate-form fragment - e.g. from a
+   * "Choose your own amount" button - select the "Other amount" preset and
+   * focus the custom-amount input so the visitor lands ready to type.
+   * Setting `checked` covers the case where Drupal's states.js attaches
+   * after this behaviour; dispatching `change` covers the reverse ordering.
+   */
+  Drupal.behaviors.sahoDonateDeepLink = {
+    attach: function (context) {
+      if (window.location.hash !== '#donate-form') {
+        return;
+      }
+      once('saho-donate-deeplink', '#donate-form', context).forEach(function (card) {
+        var otherRadio = card.querySelector('input[name="preset"][value="0"]');
+        var customInput = card.querySelector('.saho-donate-custom-amount');
+        if (otherRadio && !otherRadio.checked) {
+          otherRadio.checked = true;
+          otherRadio.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        // Defer a tick so states.js finishes revealing the custom-amount
+        // field before we scroll to it and move focus.
+        window.setTimeout(function () {
+          card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          if (customInput) {
+            customInput.focus({ preventScroll: true });
+          }
+        }, 0);
+      });
+    }
+  };
+
 })(Drupal, once);

--- a/webroot/modules/custom/saho_donate/saho_donate.module
+++ b/webroot/modules/custom/saho_donate/saho_donate.module
@@ -44,7 +44,7 @@ function saho_donate_theme(): array {
         'monthly_url' => 'https://shop.sahistory.org.za/product/saho-champion-monthly-support',
         'annual_url' => 'https://shop.sahistory.org.za/product/saho-champion-annual-support',
         'patron_url' => 'https://shop.sahistory.org.za/champion#patron',
-        'donate_url' => 'https://sahistory.org.za/donate',
+        'donate_url' => 'https://sahistory.org.za/donate#donate-form',
       ],
     ],
   ];

--- a/webroot/modules/custom/saho_donate/src/Plugin/Block/ChampionTiersBlock.php
+++ b/webroot/modules/custom/saho_donate/src/Plugin/Block/ChampionTiersBlock.php
@@ -30,8 +30,11 @@ class ChampionTiersBlock extends BlockBase {
       // Custom-amount escape hatch points back at the main site donate page.
       // Defaults to the prod URL but is overridable via settings.php so a
       // local DDEV env can point at sahistory-web.ddev.site instead of
-      // exiting to the real prod site during testing.
-      '#donate_url' => Settings::get('saho_main_donate_url', 'https://sahistory.org.za/donate'),
+      // exiting to the real prod site during testing. The #donate-form
+      // fragment lands the visitor on the donation form with the "Other
+      // amount" field selected and focused (see saho_donate/js/donate.js);
+      // a URL fragment survives the main-site -> shop 302 redirect intact.
+      '#donate_url' => Settings::get('saho_main_donate_url', 'https://sahistory.org.za/donate') . '#donate-form',
       '#attached' => [
         'library' => ['saho_donate/donate-page'],
       ],

--- a/webroot/modules/custom/saho_donate/templates/saho-champion-tiers-block.html.twig
+++ b/webroot/modules/custom/saho_donate/templates/saho-champion-tiers-block.html.twig
@@ -95,7 +95,7 @@
     <p class="donate-tiers-block__custom-amount-lead">
       {{ 'Prefer a different amount, or want to give once-off?'|t }}
     </p>
-    <a href="{{ donate_url|default('https://sahistory.org.za/donate') }}"
+    <a href="{{ donate_url|default('https://sahistory.org.za/donate#donate-form') }}"
        class="donate-btn donate-btn--outline-red">
       {{ 'Choose your own amount'|t }} →
     </a>

--- a/webroot/modules/custom/saho_donate/templates/saho-donate-page.html.twig
+++ b/webroot/modules/custom/saho_donate/templates/saho-donate-page.html.twig
@@ -21,7 +21,11 @@
         </p>
       </div>
 
-      <div class="saho-donate-card card shadow-sm">
+      {# id="donate-form" is the deep-link target for "Choose your own
+         amount" buttons (/donate#donate-form). saho_donate/js/donate.js
+         picks up the fragment to select the "Other amount" preset and
+         focus the custom-amount input. #}
+      <div id="donate-form" class="saho-donate-card card shadow-sm">
         <div class="card-body p-4">
           {{ form }}
         </div>

--- a/webroot/themes/custom/saho_shop/includes/page.inc
+++ b/webroot/themes/custom/saho_shop/includes/page.inc
@@ -15,6 +15,7 @@ use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\layout_builder\Entity\LayoutEntityDisplayInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Site\Settings;
 
 /**
  * Implements hook_preprocess_HOOK() for page templates.
@@ -24,6 +25,12 @@ function saho_shop_preprocess_page(&$variables) {
   if (\Drupal::service('path.matcher')->isFrontPage()) {
     $variables['latest_publications'] = _saho_shop_get_latest_publications(3);
   }
+
+  // Main archive site URL for cross-site footer links. Overridable via
+  // settings.php ($settings['saho_main_url']) so a local DDEV env can point
+  // at sahistory-web.ddev.site instead of the real prod site.
+  $main_url = Settings::get('saho_main_url', 'https://sahistory.org.za');
+  $variables['main_site_url'] = rtrim($main_url, '/');
 
   // Main container
   if (theme_get_setting('main_container_class')) {

--- a/webroot/themes/custom/saho_shop/templates/page/_champion-tiers.html.twig
+++ b/webroot/themes/custom/saho_shop/templates/page/_champion-tiers.html.twig
@@ -57,15 +57,17 @@
 
 </div>
 
-{# Custom-amount escape hatch promoted to a real button. The donate page
-   on the main site lets visitors enter any once-off or custom recurring
-   amount via PayFast or PayPal, so we point at it as a peer option to
-   the three preset tiers above. #}
+{# Custom-amount escape hatch promoted to a real button. The shop's own
+   /donate page runs the same PayFast donation form, so we link there as a
+   peer option to the three preset tiers above - relative, so the visitor
+   stays on-site with no cross-site redirect hop. The #donate-form fragment
+   lands them on the form with the "Other amount" field selected and
+   focused (see saho_donate/js/donate.js). #}
 <div class="tier-grid__custom-amount mt-4 text-center">
   <p class="tier-grid__custom-amount-lead">
     {{ 'Prefer a different amount or a once-off donation?'|t }}
   </p>
-  <a href="https://sahistory.org.za/donate"
+  <a href="/donate#donate-form"
      class="support-btn support-btn--outline tier-grid__custom-amount-btn">
     {{ 'Choose your own amount'|t }} →
   </a>

--- a/webroot/themes/custom/saho_shop/templates/page/_footer-shared.html.twig
+++ b/webroot/themes/custom/saho_shop/templates/page/_footer-shared.html.twig
@@ -46,10 +46,10 @@
       <div class="col-lg-2 col-md-6 col-6">
         <h6 class="text-uppercase fw-bold mb-3 text-white" style="letter-spacing: .08em; font-size: .75rem;">{{ 'Support'|t }}</h6>
         <ul class="list-unstyled mb-0">
-          <li class="mb-2"><a href="https://sahistory.org.za/donate" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">{{ 'Donate'|t }}</a></li>
-          <li class="mb-2"><a href="https://sahistory.org.za" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">{{ 'Main archive'|t }} ↗</a></li>
-          <li class="mb-2"><a href="https://sahistory.org.za/contact-us" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">{{ 'Contact us'|t }}</a></li>
-          <li class="mb-2"><a href="https://sahistory.org.za/policy" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">{{ 'Copyright &amp; policy'|t }}</a></li>
+          <li class="mb-2"><a href="{{ main_site_url }}/donate" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">{{ 'Donate'|t }}</a></li>
+          <li class="mb-2"><a href="{{ main_site_url }}" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">{{ 'Main archive'|t }} ↗</a></li>
+          <li class="mb-2"><a href="{{ main_site_url }}/contact-us" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">{{ 'Contact us'|t }}</a></li>
+          <li class="mb-2"><a href="{{ main_site_url }}/policy" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">{{ 'Copyright &amp; policy'|t }}</a></li>
         </ul>
       </div>
 
@@ -79,7 +79,7 @@
         </p>
       </div>
       <div class="col-md-6 text-center text-md-end mt-2 mt-md-0">
-        <a href="https://sahistory.org.za" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">
+        <a href="{{ main_site_url }}" target="_blank" rel="noopener" class="text-white-50 footer-link text-decoration-none small">
           sahistory.org.za ↗
         </a>
       </div>

--- a/webroot/themes/custom/saho_shop/templates/page/page--path--champion.html.twig
+++ b/webroot/themes/custom/saho_shop/templates/page/page--path--champion.html.twig
@@ -286,7 +286,7 @@
             </a>
           </div>
           <p class="champion-final-cta__alt mt-4">
-            <a href="https://sahistory.org.za/donate"
+            <a href="/donate#donate-form"
                class="support-btn support-btn--outline-white">
               {{ 'Choose your own amount'|t }} →
             </a>


### PR DESCRIPTION
## Problem

The **"Choose your own amount"** buttons on the shop champion page (and the main-site champion tiers block) linked to a bare `/donate` URL. Visitors clicking them arrived on the donation form with no indication of *where* to enter a non-preset amount - a UX dead-end. Reported on `shop.sahistory.org.za/champion`.

## Fix

A `#donate-form` deep-link that drops the visitor straight onto the form with the **"Other amount"** preset selected and the custom-amount input focused.

| File | Change |
|---|---|
| `saho-donate-page.html.twig` | `id="donate-form"` anchor on the form card |
| `js/donate.js` | New `sahoDonateDeepLink` behaviour. `once` is anchored on the "Other amount" radio - **not** the `#donate-form` card - because the donation form is streamed in by BigPipe *after* the static card markup. Scroll + focus are deferred to the window `load` event, because BigPipe bounces focus back to `<body>` while the page is still streaming. |
| `saho_donate.libraries.yml` | Bump the `donate` library version (`1.x` -> `1.1`) so the changed JS busts returning visitors' browser cache |
| `_champion-tiers.html.twig`, `page--path--champion.html.twig` | Shop CYO buttons -> relative `/donate#donate-form`. The shop runs its own donation form, so this also drops the needless cross-site redirect hop |
| `ChampionTiersBlock.php`, `saho_donate.module`, `saho-champion-tiers-block.html.twig` | Main-site Layout Builder block donate URL gets `#donate-form` appended; a URL fragment survives the main-site -> shop 302 redirect intact |
| `page.inc`, `_footer-shared.html.twig` | Expose `Settings::get('saho_main_url')` as `main_site_url` for the shop footer's 5 cross-site links, so a local DDEV env can point them at `sahistory-web.ddev.site` instead of prod (defaults to the current prod URL - no behaviour change unless the setting is set) |

## Testing - verified with Playwright on local DDEV

Cold-cache click-through: `shop/champion` -> click "Choose your own amount" -> lands on `/donate#donate-form` with:
- "Other amount" preset selected
- custom-amount field revealed (states.js) and **focused** (focus stable, confirmed past 1s)
- page scrolled to the form

Also: `phpcs --standard=Drupal` clean on `saho_donate` + the changed `page.inc` lines; `node --check` clean on `donate.js`.

Follow-up to PR #348 (champion signup gift messaging). The champion-gift order-confirmation note from the original task scope already shipped in #348.