### PR TITLE
feat(champions): capture Wall opt-in on the order completion page

### DIFF
--- a/webroot/modules/custom/saho_utils/wall_of_champions/src/Controller/OptInController.php
+++ b/webroot/modules/custom/saho_utils/wall_of_champions/src/Controller/OptInController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\wall_of_champions\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * One-click "opt me in to the Wall of Champions" handler.
+ *
+ * Used from the order-completion page after a Champion signup, where we
+ * want to capture the opt-in in the moment - the visitor would otherwise
+ * have to discover the user profile form to flip
+ * field_champion_wall_opt_in themselves. This controller flips it for
+ * them and lands them on /champions so they see the wall they're on.
+ *
+ * The route requires _csrf_token + _user_is_logged_in, so an attacker
+ * cannot opt a victim in via a forged link.
+ */
+class OptInController extends ControllerBase {
+
+  /**
+   * Sets field_champion_wall_opt_in = 1 on the current user.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirect to /champions, with a status flash on success.
+   */
+  public function optIn(): RedirectResponse {
+    $uid = (int) $this->currentUser()->id();
+    /** @var \Drupal\user\UserInterface|null $user */
+    $user = $this->entityTypeManager()->getStorage('user')->load($uid);
+
+    if ($user && $user->hasField('field_champion_wall_opt_in')) {
+      $current = (int) $user->get('field_champion_wall_opt_in')->value;
+      if ($current !== 1) {
+        $user->set('field_champion_wall_opt_in', 1);
+        $user->save();
+        $this->messenger()->addStatus(
+          $this->t('Thank you - your name will appear on the Wall of Champions.')
+        );
+      }
+    }
+
+    return $this->redirect('wall_of_champions.page');
+  }
+
+}

--- a/webroot/modules/custom/saho_utils/wall_of_champions/wall_of_champions.module
+++ b/webroot/modules/custom/saho_utils/wall_of_champions/wall_of_champions.module
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\user\Entity\User;
 
 /**
  * Implements hook_form_FORM_ID_alter() for user_form.
@@ -41,6 +43,57 @@ function wall_of_champions_form_user_form_alter(&$form, FormStateInterface $form
       ],
     ];
   }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for commerce_checkout_completion_message.
+ *
+ * Injects a one-click Wall of Champions opt-in CTA into the order
+ * completion page when:
+ *   - the order contains a champion_membership variation,
+ *   - the buyer is authenticated, and
+ *   - they have not already opted in.
+ *
+ * The template renders `{{ wall_opt_in_url }}` if present. The URL points
+ * at the wall_of_champions.opt_in route, which requires _csrf_token, so
+ * the link cannot be forged from another site.
+ */
+function wall_of_champions_preprocess_commerce_checkout_completion_message(array &$variables): void {
+  $current = \Drupal::currentUser();
+  if ($current->isAnonymous()) {
+    return;
+  }
+
+  $order = $variables['order_entity'] ?? NULL;
+  if (!$order || !method_exists($order, 'getItems')) {
+    return;
+  }
+
+  // Only champion signups get the opt-in CTA.
+  $has_champion = FALSE;
+  foreach ($order->getItems() as $item) {
+    $variation = $item->getPurchasedEntity();
+    if ($variation && $variation->bundle() === 'champion_membership') {
+      $has_champion = TRUE;
+      break;
+    }
+  }
+  if (!$has_champion) {
+    return;
+  }
+
+  // Skip if already opted in - no point asking again.
+  $user = User::load($current->id());
+  if (!$user || !$user->hasField('field_champion_wall_opt_in')) {
+    return;
+  }
+  if ((int) $user->get('field_champion_wall_opt_in')->value === 1) {
+    return;
+  }
+
+  // Url::fromRoute automatically appends the CSRF token query for routes
+  // that declare `_csrf_token: 'TRUE'`.
+  $variables['wall_opt_in_url'] = Url::fromRoute('wall_of_champions.opt_in')->toString();
 }
 
 /**

--- a/webroot/modules/custom/saho_utils/wall_of_champions/wall_of_champions.routing.yml
+++ b/webroot/modules/custom/saho_utils/wall_of_champions/wall_of_champions.routing.yml
@@ -5,3 +5,18 @@ wall_of_champions.page:
     _title: 'Wall of Champions'
   requirements:
     _permission: 'access content'
+
+# One-click opt-in to the Wall of Champions. Linked from the order
+# completion page after a Champion signup so the buyer can flip
+# field_champion_wall_opt_in without hunting for the profile form.
+# _csrf_token: the route requires a `token` query param matched against
+# the path; Url::fromRoute() generates one automatically.
+wall_of_champions.opt_in:
+  path: '/champions/opt-in'
+  defaults:
+    _controller: '\Drupal\wall_of_champions\Controller\OptInController::optIn'
+    _title: 'Opt in to the Wall of Champions'
+  requirements:
+    _user_is_logged_in: 'TRUE'
+    _csrf_token: 'TRUE'
+  methods: [GET]

--- a/webroot/themes/custom/saho_shop/css/components/commerce/checkout-completion.css
+++ b/webroot/themes/custom/saho_shop/css/components/commerce/checkout-completion.css
@@ -164,6 +164,51 @@
   font-size: 0.9rem;
   line-height: 1.5;
 }
+.checkout-completion__wall-opt-in {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  background: rgba(153, 0, 0, 0.05);
+  border: 1px solid rgba(153, 0, 0, 0.25);
+  border-left-width: 4px;
+  border-left-color: #900;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  margin: 1rem 0 1.5rem;
+}
+.checkout-completion__wall-opt-in-icon {
+  flex: 0 0 auto;
+  font-size: 1.5rem;
+  color: #900;
+  line-height: 1;
+}
+.checkout-completion__wall-opt-in-body {
+  flex: 1 1 auto;
+}
+.checkout-completion__wall-opt-in-title {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 0.25rem;
+}
+.checkout-completion__wall-opt-in-text {
+  margin: 0 0 0.75rem;
+  color: #1e293b;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.checkout-completion__wall-opt-in-cta {
+  background: #900;
+  border-color: #900;
+  color: #fff;
+  font-weight: 600;
+}
+.checkout-completion__wall-opt-in-cta:hover, .checkout-completion__wall-opt-in-cta:focus {
+  background: #700;
+  border-color: #700;
+  color: #fff;
+}
 
 .checkout-completion--minimal {
   background: transparent;
@@ -204,5 +249,3 @@
     margin-bottom: 0;
   }
 }
-
-/*# sourceMappingURL=checkout-completion.css.map */

--- a/webroot/themes/custom/saho_shop/scss/components/commerce/checkout-completion.scss
+++ b/webroot/themes/custom/saho_shop/scss/components/commerce/checkout-completion.scss
@@ -218,6 +218,63 @@
     font-size: 0.9rem;
     line-height: 1.5;
   }
+
+  // Wall of Champions opt-in callout - rendered by wall_of_champions
+  // module's preprocess hook on any champion_membership order where the
+  // buyer is not already opted in. SAHO-red accent to mark it as the
+  // brand's call to action, distinct from the gold gift callout above.
+  &__wall-opt-in {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    background: rgba(153, 0, 0, 0.05);
+    border: 1px solid rgba(153, 0, 0, 0.25);
+    border-left-width: 4px;
+    border-left-color: #900;
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0 1.5rem;
+  }
+
+  &__wall-opt-in-icon {
+    flex: 0 0 auto;
+    font-size: 1.5rem;
+    color: #900;
+    line-height: 1;
+  }
+
+  &__wall-opt-in-body {
+    flex: 1 1 auto;
+  }
+
+  &__wall-opt-in-title {
+    display: block;
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: #1e293b;
+    margin-bottom: 0.25rem;
+  }
+
+  &__wall-opt-in-text {
+    margin: 0 0 0.75rem;
+    color: #1e293b;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  &__wall-opt-in-cta {
+    background: #900;
+    border-color: #900;
+    color: #fff;
+    font-weight: 600;
+
+    &:hover,
+    &:focus {
+      background: #700;
+      border-color: #700;
+      color: #fff;
+    }
+  }
 }
 
 // Minimal variant - no borders, no padding, no shadow

--- a/webroot/themes/custom/saho_shop/templates/commerce/checkout/commerce-checkout-completion-message.html.twig
+++ b/webroot/themes/custom/saho_shop/templates/commerce/checkout/commerce-checkout-completion-message.html.twig
@@ -34,14 +34,14 @@
   </div>
 
   {# Champion signup-gift note - only Annual + Patron tiers get one.
-     Detects by product bundle (`champion_subscription`) plus title match,
+     Detects by variation bundle (`champion_membership`) plus title match,
      so the note survives SKU renames as long as the title still says
      Annual or Patron. Fulfillment is manual: SAHO staff emails the buyer. #}
   {% set has_signup_gift = false %}
   {% if order_entity %}
     {% for item in order_entity.getItems() %}
       {% set variation = item.getPurchasedEntity() %}
-      {% if variation and variation.bundle() == 'champion_subscription' %}
+      {% if variation and variation.bundle() == 'champion_membership' %}
         {% set product_title = (variation.getTitle() ?: variation.getProduct().label())|lower %}
         {% if 'annual' in product_title or 'patron' in product_title %}
           {% set has_signup_gift = true %}
@@ -65,6 +65,31 @@
           <p class="checkout-completion__signup-gift-text">
             {{ 'A SAHO team member will email you within five working days to arrange delivery of your Champion signup gift. Thank you for supporting South African history.'|t }}
           </p>
+        </div>
+      </div>
+    {% endif %}
+
+    {# Wall of Champions opt-in. Rendered by wall_of_champions module's
+       preprocess hook only when:
+       - the order contains a champion_membership variation,
+       - the buyer is authenticated, and
+       - they have not already opted in.
+       The link carries a CSRF token from the route's _csrf_token
+       requirement, so a single click flips field_champion_wall_opt_in
+       and redirects to /champions where they see themselves listed. #}
+    {% if wall_opt_in_url %}
+      <div class="checkout-completion__wall-opt-in" role="status">
+        <div class="checkout-completion__wall-opt-in-icon" aria-hidden="true">★</div>
+        <div class="checkout-completion__wall-opt-in-body">
+          <strong class="checkout-completion__wall-opt-in-title">
+            {{ 'Be recognised on our Wall of Champions'|t }}
+          </strong>
+          <p class="checkout-completion__wall-opt-in-text">
+            {{ 'Add your name to our public Wall of Champions. You can change this anytime in your profile.'|t }}
+          </p>
+          <a href="{{ wall_opt_in_url }}" class="btn btn-primary checkout-completion__wall-opt-in-cta">
+            {{ 'Yes, add me to the Wall'|t }}
+          </a>
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
## Why

`field_champion_wall_opt_in` was only capturable on the **user profile edit form**, so a freshly-signed-up Champion who never visited their profile would never appear on the Wall, even with an active `champion_membership` subscription. This is the gap flagged in PR #353 - the Wall query itself is correct, but with no in-flow capture the production Wall renders empty.

This PR surfaces a one-click opt-in inline on the order completion page, immediately after a successful Champion signup.

## What

- New CSRF-protected route `GET /champions/opt-in` (`_csrf_token: TRUE` + `_user_is_logged_in: TRUE`).
- `OptInController::optIn()` flips `field_champion_wall_opt_in = 1` on the current user, flashes a thank-you status, redirects to `/champions` so the buyer immediately sees the wall they're now on.
- `wall_of_champions_preprocess_commerce_checkout_completion_message()` injects `$variables['wall_opt_in_url']` **only** when:
  - the order contains a `champion_membership` variation,
  - the buyer is authenticated, and
  - they have not already opted in.
  `Url::fromRoute()` auto-generates the per-session CSRF token.
- `commerce-checkout-completion-message.html.twig` renders the inline CTA block when the URL is present.
- SCSS + regenerated CSS add a SAHO-red accent block, visually distinct from the gold Champion-gift callout above it.

## Bonus fix: PR #348's silently-inactive gift note

While here, the signup-gift detection in the same template was checking `variation.bundle() == 'champion_subscription'` - but the actual variation type in `commerce_product_variation` is `champion_membership` (verified via `DESCRIBE`). So the Annual/Patron gift note has been **silently inactive** since #348 merged. One-token fix bundled in this PR since it's the same template + same checkout-flow concern.

## Verification (local DDEV)

- Route is registered: `\Drupal::service('router.route_provider')->getRouteByName('wall_of_champions.opt_in')->getPath() === '/champions/opt-in'`.
- CSRF wall enforced: logged in as admin, hitting `/champions/opt-in` with no token / wrong-session token returns "Access denied".
- Controller logic verified: direct invocation flips `field_champion_wall_opt_in` from 0 to 1 and redirects to `/champions`, with the thank-you status message.
- `phpcs --standard=Drupal` clean on the `wall_of_champions` module.
- SCSS round-trips cleanly through `sass` + `postcss`; `signup-gift` styling preserved.

A full end-to-end through a real Champion checkout (PayFast sandbox) is outside this PR's scope but the integration points are minimal: the preprocess hook on the standard `commerce_checkout_completion_message` template hook.