### PR TITLE
fix(shop-shipping): silence 'non-existent config entity' noise on shipments field

### DIFF
--- a/config/shop/field.field.commerce_order.default.shipments.yml
+++ b/config/shop/field.field.commerce_order.default.shipments.yml
@@ -1,0 +1,23 @@
+uuid: 5da7a5c3-00c8-4792-8a87-57f8fbb116d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - commerce_order.commerce_order_type.default
+    - field.storage.commerce_order.shipments
+  module:
+    - commerce_shipping
+id: commerce_order.default.shipments
+field_name: shipments
+entity_type: commerce_order
+bundle: default
+label: Shipments
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:commerce_shipment'
+  handler_settings: {  }
+field_type: entity_reference

--- a/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.install
+++ b/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.install
@@ -188,13 +188,17 @@ function saho_shop_shipping_install(): void {
 /**
  * Provisions the `shipments` field on the default commerce_order bundle.
  *
- * Commerce Shipping adds the field via entity_bundle_field_info() when
- * the order type carries the third-party setting
- * commerce_shipping.shipment_type. Setting that flag via config sync
- * declares the field in entity definitions but does NOT create the
- * underlying storage table - that has to be installed explicitly.
- * Without this, isShippable() throws because the shipments column is
- * missing, and the shipping pane silently disappears at checkout.
+ * The SAHO shop manages `shipments` through config sync - both
+ * field.storage.commerce_order.shipments.yml AND
+ * field.field.commerce_order.default.shipments.yml exist in
+ * config/shop/. After cim runs, the FieldStorageConfig + FieldConfig
+ * pair is in place and this routine is a no-op.
+ *
+ * The safety net below handles the edge case where the field doesn't
+ * exist yet at hook_install time - e.g. someone manually disabled and
+ * re-enabled the module after deleting one of the config rows. In
+ * that case we fall back to commerce_shipping's BaseFieldDefinition
+ * via installFieldStorageDefinition().
  */
 function _saho_shop_shipping_install_shipments_field(): void {
   $update_manager = \Drupal::entityDefinitionUpdateManager();


### PR DESCRIPTION
## What this fixes

After PR #359 (Phase 0 shipping) landed, every deploy + cache rebuild logged this **3-4 times** on both staging and production:

\`\`\`
[error] A non-existent config entity name returned by
FieldStorageConfigInterface::getBundles(): entity type: commerce_order,
bundle: default, field name: shipments
\`\`\`

It was **non-fatal** (shipping methods installed, 'Shop deployed' green) but spammed deploy logs and indicated a broken config state.

## Root cause

\`config/shop/field.storage.commerce_order.shipments.yml\` predates Phase 0 - a leftover from an earlier shipping setup attempt. It defines a \`FieldStorageConfig\` for \`shipments\` but the corresponding \`FieldConfig\` instance (\`field.field.commerce_order.default.shipments.yml\`) was never created. When Drupal walked field storages and asked \"what bundles use this?\", \`getBundles()\` returned \`['default']\` but no config entity backed the claim - hence the error.

## Why route (b), not delete

Two paths to fix:

| Route | Risk |
|---|---|
| (a) delete the FieldStorageConfig YAML and let \`hook_install\`'s BaseFieldDefinition fallback take over | drush cim deletes the FieldStorageConfig; depending on Drupal internals, the underlying \`commerce_order__shipments\` table could go with it. Production has live order data + a populated shipments column. Not worth the risk. |
| **(b) add the missing FieldConfig instance** to complete the pair | Pure additive change. No deletes. Storage table is untouched. config sync manages the field end-to-end. |

This PR is route (b).

## What lands

- **NEW**: \`config/shop/field.field.commerce_order.default.shipments.yml\` - canonical entity_reference / target_type \`commerce_shipment\` / cardinality unlimited, mirroring \`Shipment::buildShipmentsFieldDefinition()\`.
- **DOCS**: \`saho_shop_shipping.install\` docstring updated to acknowledge config sync as the primary source of truth. The BaseFieldDefinition auto-install path stays as a safety net for the edge case where someone manually disabled+re-enabled the module after deleting a config row.

## Verified locally on shop.ddev.site

\`\`\`
$ ddev drush --uri=https://shop.ddev.site cim --partial -y --source=/var/www/html/config/shop
  [notice] Synchronized configuration: create field.field.commerce_order.default.shipments.
  [success] The configuration was imported successfully.

$ ddev drush --uri=https://shop.ddev.site cr        →  no error
$ ddev drush --uri=https://shop.ddev.site updb -y   →  no error
$ ddev drush --uri=https://shop.ddev.site deploy:hook → no error
\`\`\`

All 5 shipping methods still intact. phpcs (with CI flags \`--extensions=php,module,inc,install,test,theme --warning-severity=0\`) clean.