### PR TITLE
fix(shop-shipping): backfill publication weights via post_update (visible-on-prod bug)

### DIFF
--- a/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.install
+++ b/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.install
@@ -325,6 +325,18 @@ function _saho_shop_shipping_install_free_shipping_promotion(): void {
  * saved AFTER the field was added. We touch existing variations so
  * the weight conditions on shipping methods (<= 5 kg / <= 10 kg)
  * don't filter them out entirely.
+ *
+ * Important timing note: when this module is installed via
+ * `drush config:import`, the module-install step fires hook_install
+ * BEFORE the weight field's storage + instance configs have been
+ * imported. In that path, $variation->hasField('weight') returns
+ * FALSE and this routine is a no-op - but the matching
+ * hook_post_update_backfill_publication_weights() in
+ * saho_shop_shipping.post_update.php picks up the work during
+ * `drush deploy:hook`, which runs after config:import.
+ *
+ * For a manual `drush en saho_shop_shipping` install (where field
+ * configs already exist) this routine fills weights immediately.
  */
 function _saho_shop_shipping_backfill_publication_weights(): void {
   $storage = \Drupal::entityTypeManager()->getStorage('commerce_product_variation');

--- a/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.post_update.php
+++ b/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.post_update.php
@@ -3,10 +3,77 @@
 /**
  * @file
  * Post-update hooks for SAHO Shop Shipping.
- *
- * The Phase 0 shipping methods, free-shipping promotion, and weight
- * backfill are all set up in hook_install (see saho_shop_shipping.install).
- *
- * This file exists for future incremental updates (Phase 1 Bob Go,
- * Phase 3 tracking) - keep updates idempotent and small.
  */
+
+/**
+ * Backfill publication weights that hook_install missed (race condition).
+ *
+ * When saho_shop_shipping is installed via drush config:import, the
+ * module-enable step fires hook_install BEFORE the field.storage +
+ * field.field configs for `weight` have been imported. The backfill
+ * inside hook_install checks $variation->hasField('weight') and
+ * silently skips every variation when the field doesn't exist yet -
+ * so on Phase 0's production deploy (v1.15.0), every publication
+ * ended up with an empty weight column.
+ *
+ * Symptom on production: shipping pane appears at checkout, but the
+ * 5 shipping methods never list - because DefaultPacker can't compute
+ * a shipment weight when every order item's purchased entity has an
+ * empty weight, so isShippable() returns false.
+ *
+ * post_update hooks run during `drush deploy:hook`, which is the
+ * fourth step of `drush deploy`, after config:import has finished
+ * importing all field configs. By the time this runs, the weight
+ * field is guaranteed to exist. Safe + idempotent: if a variation
+ * already has a weight, we leave it alone.
+ *
+ * 0.5 kg is a conservative starting point that maps to a typical
+ * paperback. Editors should refine weights for hardcovers / heavy
+ * academic volumes via the variation edit form.
+ */
+function saho_shop_shipping_post_update_backfill_publication_weights(array &$sandbox): string {
+  $storage = \Drupal::entityTypeManager()->getStorage('commerce_product_variation');
+
+  if (!isset($sandbox['ids'])) {
+    $sandbox['ids'] = array_values($storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'publication')
+      ->execute());
+    $sandbox['total'] = count($sandbox['ids']);
+    $sandbox['processed'] = 0;
+    $sandbox['updated'] = 0;
+  }
+
+  if ($sandbox['total'] === 0) {
+    $sandbox['#finished'] = 1;
+    return 'No publication variations found - nothing to backfill.';
+  }
+
+  $batch = array_slice($sandbox['ids'], $sandbox['processed'], 50);
+  foreach ($storage->loadMultiple($batch) as $variation) {
+    /** @var \Drupal\commerce_product\Entity\ProductVariationInterface $variation */
+    if (!$variation->hasField('weight')) {
+      // Field still missing - bail loud so the operator notices and
+      // imports the shop config before re-running drush updb.
+      throw new \RuntimeException('The weight field is missing on commerce_product_variation.publication. Run drush cim --uri=https://shop.sahistory.org.za before this post_update.');
+    }
+    if ($variation->get('weight')->isEmpty()) {
+      $variation->set('weight', ['number' => '0.500', 'unit' => 'kg']);
+      $variation->save();
+      $sandbox['updated']++;
+    }
+    $sandbox['processed']++;
+  }
+
+  $sandbox['#finished'] = $sandbox['processed'] / $sandbox['total'];
+
+  if ($sandbox['#finished'] >= 1) {
+    return sprintf(
+      'Backfilled weight on %d of %d publication variations (already-weighted variations were left alone).',
+      $sandbox['updated'],
+      $sandbox['total']
+    );
+  }
+
+  return sprintf('Processed %d / %d publication variations.', $sandbox['processed'], $sandbox['total']);
+}


### PR DESCRIPTION
## TL;DR

Phase 0 (PR #359) deployed successfully but **no shipping options appear at checkout on production**. Root cause is a config-import race condition: my install-time backfill ran before the weight field was created, so every publication ended up with an empty weight and `DefaultPacker` discards them all. Fix moves the backfill to `hook_post_update_NAME`, which runs **after** config import.

## Production log — the smoking gun

\`\`\`
14:00:01  > Synchronized extensions: installed saho_shop_shipping.     ← hook_install fires
14:00:02  > Synchronized configuration: create field.storage.commerce_product_variation.weight
14:00:03  > Synchronized configuration: create field.field.commerce_product_variation.publication.weight
\`\`\`

My install-time backfill:

\`\`\`php
if (\$variation->hasField('weight') && \$variation->get('weight')->isEmpty()) {
  \$variation->set('weight', ['number' => '0.500', 'unit' => 'kg']);
  \$variation->save();
}
\`\`\`

At 14:00:01, \`hasField('weight')\` returns FALSE for every variation (the field doesn't exist yet), so the loop silently skips all 35+ publications. A second later the field gets created — empty for all existing rows.

## Why the rest of the deploy looked fine

`saho_shop_shipping module installed`, all 5 shipping methods got created, the promotion got created — those steps don't depend on the weight field existing. So the deploy reported success and nothing flagged the silent miss.

At checkout though: `DefaultPacker` reads each item's weight, finds empty, skips it. No shippable items → no shipment → `isShippable()` returns false → shipping pane stays blank. The 5 methods are sitting there in `commerce_shipping_method` but never get a chance to render.

## The fix

Backfill in `hook_post_update_NAME` instead of `hook_install`. `post_update` hooks run during `drush deploy:hook`, which is step 4 of `drush deploy` (after `config:import`). The weight field is guaranteed to exist by the time the post_update fires.

The install-hook backfill stays in place to cover the manual-install path (`drush en saho_shop_shipping` against a site whose field configs already exist) — its docstring is updated to flag the config-import timing caveat and point at the post_update for the CI deploy path.

## What lands

| File | Change |
|---|---|
| \`saho_shop_shipping.post_update.php\` | new \`saho_shop_shipping_post_update_backfill_publication_weights()\` — sandboxed batch (50/pass), idempotent, throws if the field is still missing |
| \`saho_shop_shipping.install\` | docstring update on \`_saho_shop_shipping_backfill_publication_weights()\` explaining the dual-path setup |

## Verified locally

\`\`\`
$ ddev drush --uri=https://shop.ddev.site updb --no-cache-clear -y
> [notice] Update started: saho_shop_shipping_post_update_backfill_publication_weights
> [notice] Backfilled weight on 0 of 35 publication variations (already-weighted variations were left alone).
> [notice] Update completed.
\`\`\`

Reports 0 of 35 here because local was already weighted via the manual install path. **Production deploy will report a non-zero count** (probably 35-ish — the full publication catalogue).

phpcs (with CI flags \`--extensions=php,module,inc,install,test,theme --warning-severity=0\`) clean, drupal-check clean.

## After merge

1. Squash-merge to main → staging deploy fires → post_update runs → staging shipping shows.
2. Tag v1.15.2 → production deploy fires → post_update runs against production → publications get \`weight = 0.5\` → next checkout actually shows the 4 ZA shipping options.