### PR TITLE
fix(shop-shipping): walk publication products to find prod variation bundle

### DIFF
--- a/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.post_update.php
+++ b/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.post_update.php
@@ -6,74 +6,90 @@
  */
 
 /**
- * Backfill publication weights that hook_install missed (race condition).
+ * Backfill weight on variations attached to Publication products.
  *
- * When saho_shop_shipping is installed via drush config:import, the
- * module-enable step fires hook_install BEFORE the field.storage +
- * field.field configs for `weight` have been imported. The backfill
- * inside hook_install checks $variation->hasField('weight') and
- * silently skips every variation when the field doesn't exist yet -
- * so on Phase 0's production deploy (v1.15.0), every publication
- * ended up with an empty weight column.
+ * Replaces the earlier post_update that only matched
+ * commerce_product_variation.type = 'publication'. The production
+ * deploy of v1.15.2 reported "No publication variations found":
+ * production has Publication PRODUCTS (commerce_product bundle =
+ * publication) but the matching VARIATIONS are not in the
+ * `publication` variation bundle. Different sites have ended up
+ * with different variation bundles attached to the same product
+ * type over the years, and we don't want a single bundle assumption
+ * to silently miss every shippable item.
  *
- * Symptom on production: shipping pane appears at checkout, but the
- * 5 shipping methods never list - because DefaultPacker can't compute
- * a shipment weight when every order item's purchased entity has an
- * empty weight, so isShippable() returns false.
+ * This version walks from the product side: find every product of
+ * bundle `publication`, load its variations regardless of their
+ * bundle, fill weight = 0.5 kg on any variation that exposes a
+ * weight field. The final notice lists the variation bundles we
+ * saw so the deploy log records exactly what's in the wild - if
+ * the count of "with weight field" is lower than the total, a
+ * follow-up PR will attach the weight field to the missing bundle.
  *
- * post_update hooks run during `drush deploy:hook`, which is the
- * fourth step of `drush deploy`, after config:import has finished
- * importing all field configs. By the time this runs, the weight
- * field is guaranteed to exist. Safe + idempotent: if a variation
- * already has a weight, we leave it alone.
- *
- * 0.5 kg is a conservative starting point that maps to a typical
- * paperback. Editors should refine weights for hardcovers / heavy
- * academic volumes via the variation edit form.
+ * Idempotent: already-weighted variations are left alone.
  */
-function saho_shop_shipping_post_update_backfill_publication_weights(array &$sandbox): string {
-  $storage = \Drupal::entityTypeManager()->getStorage('commerce_product_variation');
+function saho_shop_shipping_post_update_backfill_publication_weights_via_products(array &$sandbox): string {
+  $product_storage = \Drupal::entityTypeManager()->getStorage('commerce_product');
+  $variation_storage = \Drupal::entityTypeManager()->getStorage('commerce_product_variation');
 
-  if (!isset($sandbox['ids'])) {
-    $sandbox['ids'] = array_values($storage->getQuery()
+  if (!isset($sandbox['product_ids'])) {
+    $sandbox['product_ids'] = array_values($product_storage->getQuery()
       ->accessCheck(FALSE)
       ->condition('type', 'publication')
       ->execute());
-    $sandbox['total'] = count($sandbox['ids']);
-    $sandbox['processed'] = 0;
+    $sandbox['total'] = count($sandbox['product_ids']);
+    $sandbox['processed_products'] = 0;
     $sandbox['updated'] = 0;
+    $sandbox['skipped_no_weight_field'] = 0;
+    $sandbox['skipped_already_weighted'] = 0;
+    $sandbox['bundles_seen'] = [];
   }
 
   if ($sandbox['total'] === 0) {
     $sandbox['#finished'] = 1;
-    return 'No publication variations found - nothing to backfill.';
+    return 'No Publication products found - nothing to backfill.';
   }
 
-  $batch = array_slice($sandbox['ids'], $sandbox['processed'], 50);
-  foreach ($storage->loadMultiple($batch) as $variation) {
-    /** @var \Drupal\commerce_product\Entity\ProductVariationInterface $variation */
-    if (!$variation->hasField('weight')) {
-      // Field still missing - bail loud so the operator notices and
-      // imports the shop config before re-running drush updb.
-      throw new \RuntimeException('The weight field is missing on commerce_product_variation.publication. Run drush cim --uri=https://shop.sahistory.org.za before this post_update.');
-    }
-    if ($variation->get('weight')->isEmpty()) {
+  $batch = array_slice($sandbox['product_ids'], $sandbox['processed_products'], 25);
+  /** @var \Drupal\commerce_product\Entity\ProductInterface $product */
+  foreach ($product_storage->loadMultiple($batch) as $product) {
+    foreach ($product->getVariations() as $variation) {
+      $bundle = $variation->bundle();
+      $sandbox['bundles_seen'][$bundle] = ($sandbox['bundles_seen'][$bundle] ?? 0) + 1;
+      if (!$variation->hasField('weight')) {
+        $sandbox['skipped_no_weight_field']++;
+        continue;
+      }
+      if (!$variation->get('weight')->isEmpty()) {
+        $sandbox['skipped_already_weighted']++;
+        continue;
+      }
       $variation->set('weight', ['number' => '0.500', 'unit' => 'kg']);
       $variation->save();
       $sandbox['updated']++;
     }
-    $sandbox['processed']++;
+    $sandbox['processed_products']++;
   }
 
-  $sandbox['#finished'] = $sandbox['processed'] / $sandbox['total'];
+  $sandbox['#finished'] = $sandbox['processed_products'] / $sandbox['total'];
 
   if ($sandbox['#finished'] >= 1) {
+    $bundle_summary = empty($sandbox['bundles_seen'])
+      ? 'no variations'
+      : implode(', ', array_map(
+        static fn($b, $c) => "$b: $c",
+        array_keys($sandbox['bundles_seen']),
+        array_values($sandbox['bundles_seen'])
+      ));
     return sprintf(
-      'Backfilled weight on %d of %d publication variations (already-weighted variations were left alone).',
+      'Processed %d Publication products. Variation bundles seen: [%s]. Updated %d, already weighted %d, skipped (no weight field) %d.',
+      $sandbox['total'],
+      $bundle_summary,
       $sandbox['updated'],
-      $sandbox['total']
+      $sandbox['skipped_already_weighted'],
+      $sandbox['skipped_no_weight_field']
     );
   }
 
-  return sprintf('Processed %d / %d publication variations.', $sandbox['processed'], $sandbox['total']);
+  return sprintf('Processed %d / %d Publication products.', $sandbox['processed_products'], $sandbox['total']);
 }


### PR DESCRIPTION
## Why the v1.15.2 backfill silently no-op'd on prod

v1.15.2 ran cleanly but production reported:

\`\`\`
[notice] No publication variations found - nothing to backfill.
\`\`\`

while the production shop clearly has Publication-bundle products at \`/product/true-confessions-unrehabilitated-terrorist\` etc. The earlier post_update assumed \`commerce_product_variation.type = 'publication'\` which presupposes the variation bundle matches the product bundle. On this shop's older production data, that's apparently not the case — the variations under Publication products live in a different bundle (probably \`default\` from before the Publication variation type was added in Jan 2026 commit \`a6acd650\`).

## The fix

Walk from the product side instead of guessing the variation bundle:

1. Find every \`commerce_product\` of bundle \`publication\`.
2. Iterate its variations regardless of variation bundle.
3. For each variation that exposes a \`weight\` field, backfill \`0.5 kg\` if empty.
4. Record every variation bundle we encounter and report the distribution in the final notice.

The completion notice now looks like:

\`\`\`
Processed N Publication products. Variation bundles seen:
[bundle_a: count, bundle_b: count]. Updated U, already weighted A,
skipped (no weight field) S.
\`\`\`

That's diagnostic + corrective in one pass:

- If **Updated > 0**: production books just got weights, the 4 ZA shipping options will start appearing at checkout.
- If **skipped (no weight field) > 0**: a real variation bundle is missing the field. The "bundles seen" list pinpoints which bundle — a follow-up PR will attach the field there.
- If both are 0: production has no Publication products at all (highly unlikely given the shop is live with books visible).

## Why a fresh function name

Drupal records completed post_update hooks in the \`key_value\` table and won't rerun them. The existing \`saho_shop_shipping_post_update_backfill_publication_weights\` is marked complete on production from the v1.15.2 deploy — so the new logic ships as \`saho_shop_shipping_post_update_backfill_publication_weights_via_products\` instead.

## Verified locally

\`\`\`
$ ddev drush --uri=https://shop.ddev.site updb --no-cache-clear -y
> [notice] Processed 38 Publication products. Variation bundles seen:
  [publication: 35]. Updated 0, already weighted 35, skipped
  (no weight field) 0.
\`\`\`

Local has all 35 variations in the \`publication\` bundle, already weighted from earlier runs. The production deploy will report the actual bundle distribution there.

## Code quality

phpcs (with CI flags \`--extensions=php,module,inc,install,test,theme --warning-severity=0\`) clean. drupal-check clean.