### PR TITLE
fix(shop-shipping): migrate production book variations from default to publication bundle

### DIFF
--- a/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.post_update.php
+++ b/webroot/modules/custom/saho_shop_shipping/saho_shop_shipping.post_update.php
@@ -5,6 +5,8 @@
  * Post-update hooks for SAHO Shop Shipping.
  */
 
+use Drupal\Core\Cache\Cache;
+
 /**
  * Backfill weight on variations attached to Publication products.
  *
@@ -92,4 +94,127 @@ function saho_shop_shipping_post_update_backfill_publication_weights_via_product
   }
 
   return sprintf('Processed %d / %d Publication products.', $sandbox['processed_products'], $sandbox['total']);
+}
+
+/**
+ * Migrate default-bundle book variations to the publication bundle.
+ *
+ * Production has 33 commerce_product_variation entities of bundle
+ * `default` that are attached to commerce_product entities of bundle
+ * `publication`. They predate the publication variation type
+ * (created in commit a6acd650, Jan 2026) and have been quietly
+ * coexisting with the new schema ever since. The weight field is
+ * attached to the publication variation bundle only, so as long as
+ * these books stay in `default` they have no weight, no shipment
+ * weight gets calculated, and the new shipping methods never fire
+ * at checkout - which is exactly the production-only bug the team
+ * surfaced after the v1.15.0 deploy.
+ *
+ * This post_update brings production in line with the intended
+ * schema by reassigning those variations to the publication bundle,
+ * then backfilling weight = 0.5 kg on each one. champion membership
+ * variations (also bundle `default` but attached to `default`-bundle
+ * products) are deliberately untouched.
+ *
+ * Bundle is normally immutable through the entity API, so the
+ * reassignment is done via raw UPDATE statements against both the
+ * base table (commerce_product_variation) and the data table
+ * (commerce_product_variation_field_data). After the bundle change
+ * we write the weight rows directly via MERGE so we never have to
+ * re-load entities with a stale-bundle in-memory cache.
+ *
+ * Idempotent: if no default-bundle variations remain under
+ * Publication products, the routine reports "nothing to migrate"
+ * and exits.
+ */
+function saho_shop_shipping_post_update_migrate_default_book_variations(array &$sandbox): string {
+  $product_storage = \Drupal::entityTypeManager()->getStorage('commerce_product');
+  $variation_storage = \Drupal::entityTypeManager()->getStorage('commerce_product_variation');
+  $db = \Drupal::database();
+
+  if (!isset($sandbox['ids'])) {
+    $product_ids = $product_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'publication')
+      ->execute();
+    $sandbox['ids'] = [];
+    if (!empty($product_ids)) {
+      $sandbox['ids'] = array_values($variation_storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('product_id', array_values($product_ids), 'IN')
+        ->condition('type', 'default')
+        ->execute());
+    }
+    $sandbox['total'] = count($sandbox['ids']);
+    $sandbox['migrated'] = 0;
+    $sandbox['weighted'] = 0;
+    $sandbox['processed'] = 0;
+  }
+
+  if ($sandbox['total'] === 0) {
+    $sandbox['#finished'] = 1;
+    return 'No default-bundle variations found under Publication products - nothing to migrate.';
+  }
+
+  $batch = array_slice($sandbox['ids'], $sandbox['processed'], 25);
+  foreach ($batch as $vid) {
+    // Reassign bundle on both base table and data table.
+    $db->update('commerce_product_variation')
+      ->fields(['type' => 'publication'])
+      ->condition('variation_id', $vid)
+      ->condition('type', 'default')
+      ->execute();
+    $db->update('commerce_product_variation_field_data')
+      ->fields(['type' => 'publication'])
+      ->condition('variation_id', $vid)
+      ->condition('type', 'default')
+      ->execute();
+    $sandbox['migrated']++;
+
+    // Insert (or update) the weight row directly. commerce_product_variation
+    // is not revisionable, so revision_id == variation_id by convention.
+    $existing = $db->select('commerce_product_variation__weight', 'w')
+      ->fields('w', ['entity_id'])
+      ->condition('entity_id', $vid)
+      ->condition('deleted', 0)
+      ->condition('delta', 0)
+      ->execute()
+      ->fetchField();
+    if (!$existing) {
+      $db->insert('commerce_product_variation__weight')
+        ->fields([
+          'bundle' => 'publication',
+          'deleted' => 0,
+          'entity_id' => $vid,
+          'revision_id' => $vid,
+          'langcode' => 'en',
+          'delta' => 0,
+          'weight_number' => '0.500000',
+          'weight_unit' => 'kg',
+        ])
+        ->execute();
+      $sandbox['weighted']++;
+    }
+    $sandbox['processed']++;
+  }
+
+  $sandbox['#finished'] = $sandbox['processed'] / $sandbox['total'];
+
+  if ($sandbox['#finished'] >= 1) {
+    // Invalidate entity caches so the reassigned variations are
+    // re-loaded with their new bundle on next access. Raw UPDATEs
+    // skipped Drupal's save lifecycle so we explicitly drop the
+    // static + persistent caches for each touched entity.
+    $variation_storage->resetCache($sandbox['ids']);
+    $tags = array_map(static fn($id) => 'commerce_product_variation:' . $id, $sandbox['ids']);
+    Cache::invalidateTags($tags);
+
+    return sprintf(
+      'Migrated %d default-bundle variations to publication; backfilled weight on %d of them.',
+      $sandbox['migrated'],
+      $sandbox['weighted']
+    );
+  }
+
+  return sprintf('Migrated %d / %d variations.', $sandbox['processed'], $sandbox['total']);
 }


### PR DESCRIPTION
## TL;DR

The v1.15.3 diagnostic confirmed: production has **33 \`commerce_product_variation\` entities with bundle=\`default\`** attached to \`commerce_product\` entities of bundle=\`publication\`. They predate the Publication variation type (commit \`a6acd650\`, Jan 2026) and have been quietly coexisting with the new schema ever since. The \`weight\` field is attached to the \`publication\` variation bundle only — so production books have no weight, no shipment weight, no shipping rates.

This post_update reassigns those 33 variations to the \`publication\` bundle and backfills \`weight = 0.5 kg\` on each. Champion membership variations (also bundle \`default\` but attached to \`default\`-bundle products) are deliberately untouched — the query filters specifically on **product** bundle = \`publication\`.

## Why raw UPDATE instead of the entity API

Bundle is immutable through Drupal's entity API. The only safe way to reassign a bundle is via raw UPDATE statements against both:

- the base table (\`commerce_product_variation.type\`)
- the data table (\`commerce_product_variation_field_data.type\`)

Weight rows are then inserted directly into \`commerce_product_variation__weight\` (commerce_product_variation isn't revisionable so \`revision_id = variation_id\`). Cache tags for each variation are invalidated at the end so subsequent loads pick up the new bundle.

## Verified locally

I simulated the production state by reverting one local variation to \`default\` + deleting its weight row, clearing the post_update key_value entry, then re-running:

\`\`\`
> [notice] Migrated 1 default-bundle variations to publication;
          backfilled weight on 1 of them.

-- after migration --
variation 1: type='publication'
weight row:  bundle='publication' number=0.500000 unit='kg'
\`\`\`

Idempotent: re-running once everything is \`publication\`-bundle reports "No default-bundle variations found under Publication products - nothing to migrate."

## What lands

| File | Change |
|---|---|
| \`saho_shop_shipping.post_update.php\` | new \`saho_shop_shipping_post_update_migrate_default_book_variations()\` |

## Code quality

phpcs (with CI flags) clean, drupal-check clean.

## After merge

Tag v1.15.4 → production deploy runs \`drush deploy:hook\` → the migration moves 33 variations and adds weight. Next cart with a book should show all 4 ZA shipping options + free-over-R750.