### PR TITLE
Fix: Hero Banner cannot be saved in Graphic Mode

### DIFF
--- a/webroot/modules/custom/saho_utils/hero_banner/src/Plugin/Block/HeroBannerBlock.php
+++ b/webroot/modules/custom/saho_utils/hero_banner/src/Plugin/Block/HeroBannerBlock.php
@@ -115,7 +115,6 @@ class HeroBannerBlock extends BlockBase implements ContainerFactoryPluginInterfa
       '#type' => 'textfield',
       '#title' => $this->t('Title'),
       '#default_value' => $config['title'],
-      '#required' => TRUE,
       '#maxlength' => 255,
       '#states' => [
         'visible' => [
@@ -231,6 +230,19 @@ class HeroBannerBlock extends BlockBase implements ContainerFactoryPluginInterfa
     ];
 
     return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockValidate($form, FormStateInterface $form_state) {
+    parent::blockValidate($form, $form_state);
+    // Title is only required in Standard mode. Graphic mode hides all text
+    // fields, so it must not trigger the required check (#states is
+    // client-side only and cannot relax #required on the server).
+    if ($form_state->getValue('display_mode') === 'standard' && trim((string) $form_state->getValue('title')) === '') {
+      $form_state->setErrorByName('title', $this->t('Title is required in Standard display mode.'));
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

Editors adding a **Hero Banner Block** in Layout Builder could not save it when selecting **Graphic Mode** before filling in the Title. The only workaround was to stay in Standard mode, type a title, then switch to Graphic Mode and save.

## Root cause

Introduced in 0f302f43: the hero Title field had both a static `#required => TRUE` (server-side) and `#states` rules hiding it in Graphic Mode (client-side only). Drupal's #states API never relaxes server-side validation, so the AJAX submit failed on a field that was invisible to the editor.

## Fix

- Remove the static `#required` from the Title element (the #states visible/required rules remain, so Standard mode still shows the asterisk and enforces it in the browser).
- Add a `blockValidate()` override enforcing the title server-side only when Display Mode is Standard, with the message "Title is required in Standard display mode."

Stored title/subtitle/body values are kept when saving in Graphic mode (build() already suppresses them), so switching back to Standard restores the text.

## Verification (Playwright on local DDEV)

- Graphic Mode + empty title + Add block: saves successfully (previously failed)
- Standard mode + empty title: browser blocks submit on the visible Title field
- Standard mode with HTML5 validation bypassed: server-side check rejects the submit and flags the Title field
- phpcs (CI flags) and drupal-check pass clean