### PR TITLE
SEO Release 2: Interlinking + Image Sitemap

### DIFF
--- a/config/sync/core.entity_view_display.node.image.default.yml
+++ b/config/sync/core.entity_view_display.node.image.default.yml
@@ -56,18 +56,32 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_feature_parent:
+    type: entity_reference_label
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_people_related_tab:
+    type: entity_reference_label
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
 hidden:
   comment_node_image: true
   field_african_country: true
   field_archive_image: true
   field_feature_link: true
-  field_feature_parent: true
   field_file_upload: true
   field_gallery_tag: true
   field_home_page_feature: true
   field_media_library_type: true
   field_organizations_related_tab: true
-  field_people_related_tab: true
   field_search_words: true
   field_status_value: true
   field_topics_related_tab: true

--- a/config/sync/simple_sitemap.bundle_settings.default.node.archive.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.archive.yml
@@ -1,4 +1,4 @@
 index: true
-priority: '0.5'
-changefreq: ''
-include_images: false
+priority: '0.8'
+changefreq: monthly
+include_images: true

--- a/config/sync/simple_sitemap.bundle_settings.default.node.article.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.article.yml
@@ -1,4 +1,4 @@
 index: true
-priority: '0.5'
-changefreq: ''
-include_images: false
+priority: '0.7'
+changefreq: weekly
+include_images: true

--- a/config/sync/simple_sitemap.bundle_settings.default.node.biography.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.biography.yml
@@ -1,4 +1,4 @@
 index: true
-priority: '0.5'
-changefreq: ''
-include_images: false
+priority: '0.8'
+changefreq: monthly
+include_images: true

--- a/config/sync/simple_sitemap.bundle_settings.default.node.image.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.image.yml
@@ -1,4 +1,4 @@
 index: true
 priority: '0.5'
-changefreq: ''
-include_images: false
+changefreq: yearly
+include_images: true

--- a/config/sync/simple_sitemap.bundle_settings.default.node.place.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.node.place.yml
@@ -1,4 +1,4 @@
 index: true
-priority: '0.5'
-changefreq: ''
-include_images: false
+priority: '0.6'
+changefreq: yearly
+include_images: true

--- a/webroot/modules/custom/saho_suggested_reading/saho_suggested_reading.module
+++ b/webroot/modules/custom/saho_suggested_reading/saho_suggested_reading.module
@@ -14,8 +14,15 @@ use Drupal\node\NodeInterface;
 function saho_suggested_reading_preprocess_node(array &$variables) {
   $node = $variables['node'];
 
-  // Only process full view mode for articles and archives.
-  if ($variables['view_mode'] !== 'full' || !in_array($node->bundle(), ['article', 'archive'])) {
+  // Only process full view mode for the supported content types.
+  $supported_bundles = [
+    'article',
+    'archive',
+    'biography',
+    'event',
+    'place',
+  ];
+  if ($variables['view_mode'] !== 'full' || !in_array($node->bundle(), $supported_bundles)) {
     return;
   }
 

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/BreadcrumbSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/BreadcrumbSchemaBuilder.php
@@ -67,15 +67,18 @@ class BreadcrumbSchemaBuilder implements SchemaOrgBuilderInterface {
       // canonical landing page path. Google voids any BreadcrumbList item
       // whose 'item' URL is not a live 200 response, so the paths below are
       // verified-200 landing pages on production (not the bare node-type
-      // machine name, which 404s or 301s). Node types without a stable 200
-      // landing page (for example 'image') are intentionally omitted: it is
-      // better to drop one breadcrumb level than to void the entire
-      // BreadcrumbList with a 404/301 URL.
+      // machine name, which 404s or 301s). Image nodes have no dedicated
+      // images landing (the /images path 301s to the home page), so they
+      // share the verified-200 /archives landing alongside archive nodes.
+      // Node types without any stable 200 landing page are intentionally
+      // omitted: it is better to drop one breadcrumb level than to void the
+      // entire BreadcrumbList with a 404/301 URL.
       $type_landings = [
         'article' => ['name' => 'Politics & Society', 'path' => 'politics-society'],
         'biography' => ['name' => 'Biographies', 'path' => 'biographies'],
         'event' => ['name' => 'This Day in History', 'path' => 'this-day-in-history'],
         'archive' => ['name' => 'Archives', 'path' => 'archives'],
+        'image' => ['name' => 'Archives', 'path' => 'archives'],
         'place' => ['name' => 'Places', 'path' => 'places'],
       ];
 

--- a/webroot/themes/custom/saho/templates/content/node--biography.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--biography.html.twig
@@ -14,6 +14,116 @@
 {# Related-cards footer renders .saho-button as static spans; ensure its CSS loads. #}
 {{ attach_library('saho/saho-button') }}
 
+{# Macro: enhanced suggested-reading cards (shared markup with article template). #}
+{% macro suggested_reading_section(suggested_reading) %}
+  <div class="saho-context-sections saho-context-bottom saho-suggested-reading-enhanced">
+    <h3>Related Content & Topics</h3>
+
+    {% for section_title, items in suggested_reading %}
+      <div class="saho-related-content-section">
+        <h4>{{ section_title }}</h4>
+        <div class="saho-cards-grid">
+          {% for item in items %}
+            {% set entity = item.entity %}
+            {% set image_url = null %}
+
+{# Get image URL based on content type and available fields #}
+            {% set bundle = entity.bundle %}
+
+            {# Content-type specific image field priority #}
+            {% if bundle == 'biography' %}
+              {% if entity.field_bio_pic.entity %}
+                {% set image_url = file_url(entity.field_bio_pic.entity.uri.value) %}
+                {% set image_alt = entity.field_bio_pic.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'article' %}
+              {% if entity.field_article_image.entity %}
+                {% set image_url = file_url(entity.field_article_image.entity.uri.value) %}
+                {% set image_alt = entity.field_article_image.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'archive' %}
+              {% if entity.field_archive_image.entity %}
+                {% set image_url = file_url(entity.field_archive_image.entity.uri.value) %}
+                {% set image_alt = entity.field_archive_image.alt %}
+              {% elseif entity.field_image.entity %}
+                {% set image_url = file_url(entity.field_image.entity.uri.value) %}
+                {% set image_alt = entity.field_image.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'place' %}
+              {% if entity.field_place_image.entity %}
+                {% set image_url = file_url(entity.field_place_image.entity.uri.value) %}
+                {% set image_alt = entity.field_place_image.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'event' %}
+              {% if entity.field_event_image.entity %}
+                {% set image_url = file_url(entity.field_event_image.entity.uri.value) %}
+                {% set image_alt = entity.field_event_image.alt %}
+              {% elseif entity.field_tdih_image.entity %}
+                {% set image_url = file_url(entity.field_tdih_image.entity.uri.value) %}
+                {% set image_alt = entity.field_tdih_image.alt %}
+              {% endif %}
+
+            {% else %}
+              {# Fallback for other content types #}
+              {% if entity.field_image.entity %}
+                {% set image_url = file_url(entity.field_image.entity.uri.value) %}
+                {% set image_alt = entity.field_image.alt %}
+              {% elseif entity.field_article_image.entity %}
+                {% set image_url = file_url(entity.field_article_image.entity.uri.value) %}
+                {% set image_alt = entity.field_article_image.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+            {% endif %}
+
+            <div class="saho-card">
+              <a href="{{ path('entity.node.canonical', {'node': entity.id()}) }}" class="saho-card-link">
+                {% if image_url %}
+                <div class="saho-card-image">
+                  <img src="{{ image_url }}" alt="{{ image_alt }}" loading="lazy" decoding="async">
+                </div>
+                {% endif %}
+                <div class="saho-card-content">
+                  <h5 class="saho-card-title">{{ entity.label }}</h5>
+                  {% if entity.field_synopsis.value %}
+                    <p class="saho-card-description">{{ entity.field_synopsis.value|striptags|truncate(120) }}</p>
+                  {% elseif entity.body.value %}
+                    <p class="saho-card-description">{{ entity.body.value|striptags|truncate(120) }}</p>
+                  {% endif %}
+                  <div class="saho-card-footer">
+                    <span class="saho-button saho-button--primary saho-button--small saho-button--with-icon">
+                      <span class="saho-button__text">Read More</span>
+                      <svg class="saho-button__icon saho-button__icon--arrow-right" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z"/>
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+              </a>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+{% endmacro %}
+
+{% import _self as suggested %}
+
 <article{{ attributes.addClass('saho-article-wrapper') }}>
 
   <div class="saho-article-grid">
@@ -307,6 +417,11 @@
   </div>
 
 </article>
+
+{# Enhanced suggested reading - crawlable contextual cards (~6-12 related items). #}
+{% if suggested_reading is defined and suggested_reading is not empty %}
+  {{ suggested.suggested_reading_section(suggested_reading) }}
+{% endif %}
 
 {# Related Content section - Feature Parent Links displayed as cards #}
 {% if grouped_feature_parents is not empty %}

--- a/webroot/themes/custom/saho/templates/content/node--event.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--event.html.twig
@@ -11,6 +11,119 @@
 {# Variable to track if sidebar has content #}
 {% set sidebar_has_content = false %}
 
+{# Related-cards footer renders .saho-button as static spans; ensure its CSS loads. #}
+{{ attach_library('saho/saho-button') }}
+
+{# Macro: enhanced suggested-reading cards (shared markup with article template). #}
+{% macro suggested_reading_section(suggested_reading) %}
+  <div class="saho-context-sections saho-context-bottom saho-suggested-reading-enhanced">
+    <h3>Related Content & Topics</h3>
+
+    {% for section_title, items in suggested_reading %}
+      <div class="saho-related-content-section">
+        <h4>{{ section_title }}</h4>
+        <div class="saho-cards-grid">
+          {% for item in items %}
+            {% set entity = item.entity %}
+            {% set image_url = null %}
+
+{# Get image URL based on content type and available fields #}
+            {% set bundle = entity.bundle %}
+
+            {# Content-type specific image field priority #}
+            {% if bundle == 'biography' %}
+              {% if entity.field_bio_pic.entity %}
+                {% set image_url = file_url(entity.field_bio_pic.entity.uri.value) %}
+                {% set image_alt = entity.field_bio_pic.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'article' %}
+              {% if entity.field_article_image.entity %}
+                {% set image_url = file_url(entity.field_article_image.entity.uri.value) %}
+                {% set image_alt = entity.field_article_image.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'archive' %}
+              {% if entity.field_archive_image.entity %}
+                {% set image_url = file_url(entity.field_archive_image.entity.uri.value) %}
+                {% set image_alt = entity.field_archive_image.alt %}
+              {% elseif entity.field_image.entity %}
+                {% set image_url = file_url(entity.field_image.entity.uri.value) %}
+                {% set image_alt = entity.field_image.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'place' %}
+              {% if entity.field_place_image.entity %}
+                {% set image_url = file_url(entity.field_place_image.entity.uri.value) %}
+                {% set image_alt = entity.field_place_image.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'event' %}
+              {% if entity.field_event_image.entity %}
+                {% set image_url = file_url(entity.field_event_image.entity.uri.value) %}
+                {% set image_alt = entity.field_event_image.alt %}
+              {% elseif entity.field_tdih_image.entity %}
+                {% set image_url = file_url(entity.field_tdih_image.entity.uri.value) %}
+                {% set image_alt = entity.field_tdih_image.alt %}
+              {% endif %}
+
+            {% else %}
+              {# Fallback for other content types #}
+              {% if entity.field_image.entity %}
+                {% set image_url = file_url(entity.field_image.entity.uri.value) %}
+                {% set image_alt = entity.field_image.alt %}
+              {% elseif entity.field_article_image.entity %}
+                {% set image_url = file_url(entity.field_article_image.entity.uri.value) %}
+                {% set image_alt = entity.field_article_image.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+            {% endif %}
+
+            <div class="saho-card">
+              <a href="{{ path('entity.node.canonical', {'node': entity.id()}) }}" class="saho-card-link">
+                {% if image_url %}
+                <div class="saho-card-image">
+                  <img src="{{ image_url }}" alt="{{ image_alt }}" loading="lazy" decoding="async">
+                </div>
+                {% endif %}
+                <div class="saho-card-content">
+                  <h5 class="saho-card-title">{{ entity.label }}</h5>
+                  {% if entity.field_synopsis.value %}
+                    <p class="saho-card-description">{{ entity.field_synopsis.value|striptags|truncate(120) }}</p>
+                  {% elseif entity.body.value %}
+                    <p class="saho-card-description">{{ entity.body.value|striptags|truncate(120) }}</p>
+                  {% endif %}
+                  <div class="saho-card-footer">
+                    <span class="saho-button saho-button--primary saho-button--small saho-button--with-icon">
+                      <span class="saho-button__text">Read More</span>
+                      <svg class="saho-button__icon saho-button__icon--arrow-right" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z"/>
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+              </a>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+{% endmacro %}
+
+{% import _self as suggested %}
+
 <article{{ attributes.addClass('saho-article-wrapper') }}>
 
   <div class="saho-article-grid">
@@ -253,3 +366,8 @@
   </div>
 
 </article>
+
+{# Enhanced suggested reading - crawlable contextual cards (~6-12 related items). #}
+{% if suggested_reading is defined and suggested_reading is not empty %}
+  {{ suggested.suggested_reading_section(suggested_reading) }}
+{% endif %}

--- a/webroot/themes/custom/saho/templates/content/node--image.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--image.html.twig
@@ -1,0 +1,110 @@
+{#
+/**
+ * @file
+ * Custom SAHO node template for Image content type.
+ *
+ * Surfaces the relationship fields (field_feature_parent and
+ * field_people_related_tab) as crawlable <a> links so image nodes are no
+ * longer dead-end pages for users or search engines.
+ *
+ * Title is handled globally and not rendered here.
+ * Layout Builder is disabled - fields are output directly via Twig.
+ */
+#}
+
+{# Variable to track if sidebar has content #}
+{% set sidebar_has_content = false %}
+
+<article{{ attributes.addClass('saho-article-wrapper') }}>
+
+  <div class="saho-article-grid">
+
+    {# LEFT: Main content column #}
+    <div class="saho-main-content">
+
+      {% if content.field_image %}
+        <div class="saho-image-detail">
+          {{ content.field_image }}
+        </div>
+      {% endif %}
+
+      <div class="saho-article-meta">
+        {% if node.getCreatedTime() %}
+          <span>Published {{ node.getCreatedTime()|date("j F Y") }}</span>
+        {% endif %}
+        {% if node.getChangedTime() != node.getCreatedTime() %}
+          <span>Updated {{ node.getChangedTime()|date("j F Y") }}</span>
+        {% endif %}
+        <div class="saho-tools-wrapper">
+          {% if citation_button %}
+            <div class="saho-citation-wrapper">
+              {{ citation_button }}
+            </div>
+          {% endif %}
+          {% if sharing_button %}
+            <div class="saho-sharing-wrapper">
+              {{ sharing_button }}
+            </div>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if content.body %}
+        <div class="saho-article-body">
+          {# Remove the label by accessing the content directly #}
+          {{ content.body.0 }}
+        </div>
+      {% endif %}
+
+      {% if content.field_source|render|trim %}
+        <div class="saho-image-source">
+          {{ content.field_source }}
+        </div>
+      {% endif %}
+
+      {# Render remaining fields not already shown manually #}
+      {{ content|without(
+        'body',
+        'field_image',
+        'field_source',
+        'field_feature_parent',
+        'field_people_related_tab'
+      ) }}
+
+    </div>
+
+    {# RIGHT: Sidebar #}
+    {% if content.field_feature_parent is defined and content.field_feature_parent|render|trim %}
+      {% set sidebar_has_content = true %}
+    {% endif %}
+
+    {% if content.field_people_related_tab is defined and content.field_people_related_tab|render|trim %}
+      {% set sidebar_has_content = true %}
+    {% endif %}
+
+    {% if sidebar_has_content %}
+    <aside class="saho-article-sidebar">
+
+      {# Featured in: link back to the parent feature/article this image
+         belongs to, keeping the image node connected to the wider archive. #}
+      {% if content.field_feature_parent is defined and content.field_feature_parent|render|trim %}
+        <div class="saho-taxonomy-group">
+          <h4>Featured in</h4>
+          {{ content.field_feature_parent }}
+        </div>
+      {% endif %}
+
+      {# Related people referenced by this image. #}
+      {% if content.field_people_related_tab is defined and content.field_people_related_tab|render|trim %}
+        <div class="saho-taxonomy-group">
+          <h4>Related People</h4>
+          {{ content.field_people_related_tab }}
+        </div>
+      {% endif %}
+
+    </aside>
+    {% endif %}
+
+  </div>
+
+</article>

--- a/webroot/themes/custom/saho/templates/content/node--place.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--place.html.twig
@@ -11,6 +11,119 @@
 {# Variable to track if sidebar has content #}
 {% set sidebar_has_content = false %}
 
+{# Related-cards footer renders .saho-button as static spans; ensure its CSS loads. #}
+{{ attach_library('saho/saho-button') }}
+
+{# Macro: enhanced suggested-reading cards (shared markup with article template). #}
+{% macro suggested_reading_section(suggested_reading) %}
+  <div class="saho-context-sections saho-context-bottom saho-suggested-reading-enhanced">
+    <h3>Related Content & Topics</h3>
+
+    {% for section_title, items in suggested_reading %}
+      <div class="saho-related-content-section">
+        <h4>{{ section_title }}</h4>
+        <div class="saho-cards-grid">
+          {% for item in items %}
+            {% set entity = item.entity %}
+            {% set image_url = null %}
+
+{# Get image URL based on content type and available fields #}
+            {% set bundle = entity.bundle %}
+
+            {# Content-type specific image field priority #}
+            {% if bundle == 'biography' %}
+              {% if entity.field_bio_pic.entity %}
+                {% set image_url = file_url(entity.field_bio_pic.entity.uri.value) %}
+                {% set image_alt = entity.field_bio_pic.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'article' %}
+              {% if entity.field_article_image.entity %}
+                {% set image_url = file_url(entity.field_article_image.entity.uri.value) %}
+                {% set image_alt = entity.field_article_image.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'archive' %}
+              {% if entity.field_archive_image.entity %}
+                {% set image_url = file_url(entity.field_archive_image.entity.uri.value) %}
+                {% set image_alt = entity.field_archive_image.alt %}
+              {% elseif entity.field_image.entity %}
+                {% set image_url = file_url(entity.field_image.entity.uri.value) %}
+                {% set image_alt = entity.field_image.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'place' %}
+              {% if entity.field_place_image.entity %}
+                {% set image_url = file_url(entity.field_place_image.entity.uri.value) %}
+                {% set image_alt = entity.field_place_image.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+
+            {% elseif bundle == 'event' %}
+              {% if entity.field_event_image.entity %}
+                {% set image_url = file_url(entity.field_event_image.entity.uri.value) %}
+                {% set image_alt = entity.field_event_image.alt %}
+              {% elseif entity.field_tdih_image.entity %}
+                {% set image_url = file_url(entity.field_tdih_image.entity.uri.value) %}
+                {% set image_alt = entity.field_tdih_image.alt %}
+              {% endif %}
+
+            {% else %}
+              {# Fallback for other content types #}
+              {% if entity.field_image.entity %}
+                {% set image_url = file_url(entity.field_image.entity.uri.value) %}
+                {% set image_alt = entity.field_image.alt %}
+              {% elseif entity.field_article_image.entity %}
+                {% set image_url = file_url(entity.field_article_image.entity.uri.value) %}
+                {% set image_alt = entity.field_article_image.alt %}
+              {% elseif entity.field_feature_banner.entity %}
+                {% set image_url = file_url(entity.field_feature_banner.entity.uri.value) %}
+                {% set image_alt = entity.field_feature_banner.alt %}
+              {% endif %}
+            {% endif %}
+
+            <div class="saho-card">
+              <a href="{{ path('entity.node.canonical', {'node': entity.id()}) }}" class="saho-card-link">
+                {% if image_url %}
+                <div class="saho-card-image">
+                  <img src="{{ image_url }}" alt="{{ image_alt }}" loading="lazy" decoding="async">
+                </div>
+                {% endif %}
+                <div class="saho-card-content">
+                  <h5 class="saho-card-title">{{ entity.label }}</h5>
+                  {% if entity.field_synopsis.value %}
+                    <p class="saho-card-description">{{ entity.field_synopsis.value|striptags|truncate(120) }}</p>
+                  {% elseif entity.body.value %}
+                    <p class="saho-card-description">{{ entity.body.value|striptags|truncate(120) }}</p>
+                  {% endif %}
+                  <div class="saho-card-footer">
+                    <span class="saho-button saho-button--primary saho-button--small saho-button--with-icon">
+                      <span class="saho-button__text">Read More</span>
+                      <svg class="saho-button__icon saho-button__icon--arrow-right" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M1 8a.5.5 0 0 1 .5-.5h11.793l-3.147-3.146a.5.5 0 0 1 .708-.708l4 4a.5.5 0 0 1 0 .708l-4 4a.5.5 0 0 1-.708-.708L13.293 8.5H1.5A.5.5 0 0 1 1 8z"/>
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+              </a>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+{% endmacro %}
+
+{% import _self as suggested %}
+
 <article{{ attributes.addClass('saho-article-wrapper') }}>
 
   <div class="saho-article-grid">
@@ -347,3 +460,8 @@
   </div>
 
 </article>
+
+{# Enhanced suggested reading - crawlable contextual cards (~6-12 related items). #}
+{% if suggested_reading is defined and suggested_reading is not empty %}
+  {{ suggested.suggested_reading_section(suggested_reading) }}
+{% endif %}


### PR DESCRIPTION
## Why
Phase 2 of the SEO work (blueprint in \`seo/reports/\`). Activates interlinking machinery that already existed but was gated off, and exposes SAHO's visual archive to Google Images. Two of SAHO's largest content types (event 17,654 and image 18,324) were near-orphans with no outbound links.

## What changed
- **saho_suggested_reading**: display gate widened from \`article+archive\` to also **biography, event, place** (~30k nodes). The query engine + image-field joins already supported these bundles; only the display gate + templates needed changes.
- **node--biography/event/place.html.twig**: render the \`suggested_reading\` block (copied from node--article). Event keeps its R1 related-links sidebar.
- **node--image.html.twig** (new): "Featured in" link from \`field_feature_parent\` + related people - pulls 18k dead-end image pages into the link graph.
- **core.entity_view_display.node.image.default**: unhide \`field_feature_parent\`.
- **BreadcrumbSchemaBuilder**: add \`image\` -> \`/archives\` (verified 200) breadcrumb level.
- **simple_sitemap**: \`include_images: true\` on image/archive/biography/article/place (4.x auto-includes all image fields) + per-bundle priority/changefreq. Exposes 18k+ images to Google Images.

## Verification (local DDEV)
| Check | Result |
|---|---|
| suggested_reading on biography/event/place | renders, 11 crawlable links on bio page |
| node--image "Featured in" | renders on /image/dorothy-masuka |
| image breadcrumb landing | /archives -> 200 |
| image sitemap | \`<image:image>\` present in 80 chunks |
| phpcs | clean |
| config import | clean |

## Notes
- Event bundle was intentionally left out of the image-sitemap change (events are date entries, image value is lower); revisit if wanted.
- Image breadcrumb shares \`/archives\` with archive nodes; revisit if a dedicated images landing is built.