### PR TITLE
perf(cdn): unblock Cloudflare edge caching (remove Vary: User-Agent + Cookie)

### DIFF
--- a/.htaccess.custom
+++ b/.htaccess.custom
@@ -347,5 +347,9 @@ RewriteRule ^(.+)\.(jpe?g|png)$ $1.webp [T=image/webp,E=accept:1,L]
   BrowserMatch ^Mozilla/4 gzip-only-text/html
   BrowserMatch ^Mozilla/4\.0[678] no-gzip
   BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
-  Header append Vary User-Agent
+  # NOTE: "Header append Vary User-Agent" intentionally removed. It is a legacy
+  # workaround for Mozilla/4-era gzip bugs (browsers long dead) and it adds
+  # "Vary: User-Agent" to every response, which makes Cloudflare refuse to cache
+  # any HTML (CDN only caches when Vary is absent or Accept-Encoding only). Do
+  # not re-add it; anonymous-page caching at the edge depends on this being gone.
 </IfModule>

--- a/webroot/modules/custom/saho_performance/src/EventSubscriber/ResponseSubscriber.php
+++ b/webroot/modules/custom/saho_performance/src/EventSubscriber/ResponseSubscriber.php
@@ -42,6 +42,30 @@ class ResponseSubscriber implements EventSubscriberInterface {
       $response->headers->set('Cache-Control', 'public, max-age=300, s-maxage=3600');
     }
 
+    // Normalize the Vary header so a CDN (Cloudflare) can actually cache
+    // anonymous HTML. Drupal emits "Vary: Cookie" (and a downstream layer adds
+    // "User-Agent"); Cloudflare refuses to cache any response whose Vary header
+    // contains anything other than Accept-Encoding, so those pages always hit
+    // the origin. We only collapse Vary to Accept-Encoding when the response is
+    // a public-cacheable GET with NO Drupal session cookie present, i.e. a true
+    // anonymous page. Authenticated users keep the original Vary, and the
+    // Cloudflare cache rule additionally bypasses cache on the SESS cookie, so
+    // logged-in visitors can never be served a shared cached page.
+    $cache_control = (string) $response->headers->get('Cache-Control', '');
+    $is_public = strpos($cache_control, 'public') !== FALSE
+      && strpos($cache_control, 'private') === FALSE
+      && strpos($cache_control, 'no-store') === FALSE;
+    $has_session = FALSE;
+    foreach ($request->cookies->keys() as $cookie_name) {
+      if (strpos($cookie_name, 'SESS') !== FALSE) {
+        $has_session = TRUE;
+        break;
+      }
+    }
+    if ($request->isMethodCacheable() && $is_public && !$has_session) {
+      $response->headers->set('Vary', 'Accept-Encoding');
+    }
+
     // Add performance hints.
     $this->addLinkHeaders($response, $request);
 


### PR DESCRIPTION
## Why
Prod Core Web Vitals **fail** on mobile (LCP 4.0s, TTFB 2.4s) and desktop (LCP 2.8s, TTFB 1.9s). Root cause is **not** front-end - it's that Cloudflare serves every page as \`cf-cache-status: DYNAMIC\` (uncached), so real South African mobile users round-trip to a distant origin on every page load.

Cloudflare refuses to cache any HTML whose \`Vary\` header contains anything other than \`Accept-Encoding\`. SAHO sent \`Vary: Cookie,Accept-Encoding,User-Agent\`. This PR removes the two problematic values at the origin.

## Changes
- **`.htaccess.custom`**: removed \`Header append Vary User-Agent\` - a legacy Mozilla/4-era gzip-bug workaround (browsers long dead) that added \`Vary: User-Agent\` to **every** response. Deploys to \`webroot/.htaccess\` via the existing composer \`drupal-scaffold\` file-mapping.
- **`saho_performance/ResponseSubscriber`**: collapse \`Vary\` to \`Accept-Encoding\` on public-cacheable GET responses with **no Drupal session cookie** (true anonymous pages). Triple-guarded (public cache-control + cacheable method + no \`SESS\` cookie) so authenticated users are never affected.

## Pairs with infra
A Cloudflare **Cache Rule** ("Cache anonymous HTML", Eligible for cache, respect origin TTL, bypass on \`SESS\` cookie) is already deployed and currently idle because of the Vary header. This PR activates it.

## Expected on prod (post-deploy)
- \`cf-cache-status\`: DYNAMIC -> **HIT** for anonymous
- TTFB 2.4s -> ~0.1s (edge), mobile LCP under 2.5s
- **CWV Failed -> Passed** (field data moves over the CrUX 28-day window; lab/TTFB immediately)

## Verification
- Local: \`Vary: User-Agent\` removed (anon pages return no Vary header with page cache off); phpcs clean.
- Post-deploy check: \`curl -sI https://sahistory.org.za/ | grep -i cf-cache-status\` twice -> HIT; with \`-H "Cookie: SSESSx=1"\` -> BYPASS.

## Safety / rollback
Logged-in editors are protected two ways (origin subscriber skips when SESS present + CF rule bypasses on SESS). Rollback = revert this PR or toggle the CF cache rule off (instant).