### PR TITLE
perf(cdn): strip server-injected Vary: User-Agent (follow-up to #379)

### DIFF
--- a/.htaccess.custom
+++ b/.htaccess.custom
@@ -353,3 +353,14 @@ RewriteRule ^(.+)\.(jpe?g|png)$ $1.webp [T=image/webp,E=accept:1,L]
   # any HTML (CDN only caches when Vary is absent or Accept-Encoding only). Do
   # not re-add it; anonymous-page caching at the edge depends on this being gone.
 </IfModule>
+
+# Strip "Vary: User-Agent" injected by the server-level (cPanel/EasyApache)
+# mod_deflate config, which .htaccess cannot delete. We cannot remove that
+# server directive, but mod_headers runs .htaccess edits AFTER server config,
+# so we surgically drop User-Agent from the final Vary value while preserving
+# Accept-Encoding (and Accept, for WebP negotiation). Without this, Cloudflare
+# refuses to cache anonymous HTML (every response stays cf-cache-status: DYNAMIC).
+<IfModule mod_headers.c>
+  Header edit Vary "(,\s*)?User-Agent" ""
+  Header always edit Vary "(,\s*)?User-Agent" ""
+</IfModule>


### PR DESCRIPTION
The cPanel/EasyApache **server-level** mod_deflate config injects `Vary: User-Agent` on every response (confirmed: even static `/core/misc/drupal.js` carries it), which `.htaccess` cannot delete. Since mod_headers applies `.htaccess` edits after server config, this surgically strips `User-Agent` from the final `Vary` value while keeping `Accept-Encoding`. Without it, Cloudflare stays `DYNAMIC` on anon HTML. Validated locally: `Header edit` strips it, all pages HTTP 200. Deploys to `webroot/.htaccess` via composer scaffold.