### PR TITLE
security(commerce): drupal/commerce 3.3.5 -> 3.3.6 (SA-CONTRIB-2026-041)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2470,17 +2470,17 @@
         },
         {
             "name": "drupal/commerce",
-            "version": "3.3.5",
+            "version": "3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/commerce.git",
-                "reference": "3.3.5"
+                "reference": "3.3.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/commerce-3.3.5.zip",
-                "reference": "3.3.5",
-                "shasum": "fc970e106c47c47cb9ea1215c73115b1ed402e9a"
+                "url": "https://ftp.drupal.org/files/projects/commerce-3.3.6.zip",
+                "reference": "3.3.6",
+                "shasum": "f24284baa909731a047dfdbadde03099ca79a3f0"
             },
             "require": {
                 "commerceguys/intl": "^2.0.6",
@@ -2516,8 +2516,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.3.5",
-                    "datestamp": "1776700408",
+                    "version": "3.3.6",
+                    "datestamp": "1780503017",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5569,17 +5569,17 @@
         },
         {
             "name": "drupal/inline_entity_form",
-            "version": "3.0.0-rc21",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/inline_entity_form.git",
-                "reference": "3.0.0-rc21"
+                "reference": "3.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-3.0.0-rc21.zip",
-                "reference": "3.0.0-rc21",
-                "shasum": "bbfb99be0ee35ad197556b2aa02f6e181e34ff1f"
+                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "43417cf232df36d6a621151dffa569b77dfd9725"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9 || ^10 || ^11",
@@ -5592,11 +5592,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.0-rc21",
-                    "datestamp": "1746459780",
+                    "version": "3.0.0",
+                    "datestamp": "1780695753",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "RC releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },


### PR DESCRIPTION
Follow-up to #386. The commerce bump was committed to that branch but dropped from its squash-merge (GitHub merged the core-only commit before the second push registered), so main landed core 11.3.12 with commerce still at 3.3.5. This re-applies it.

## What
`drupal/commerce` **3.3.5 -> 3.3.6** — fixes **SA-CONTRIB-2026-041** (CVE-2026-10769), a moderately critical stored XSS in Commerce Core (affected `>= 3.3.0 < 3.3.6`). Runs on the shop multisite.

## Scope
- `composer.lock` only; root constraint already `^3.0`.

## Verification
- `drush updb` (main + shop) -> no pending updates (no schema changes)
- `drush cr` both sites -> OK; main + shop homepages return HTTP 200
- `composer validate` -> OK