### PR TITLE
perf(cdn): strip legacy Expires on HTML so Cloudflare caches it

### DIFF
--- a/.htaccess.custom
+++ b/.htaccess.custom
@@ -364,3 +364,14 @@ RewriteRule ^(.+)\.(jpe?g|png)$ $1.webp [T=image/webp,E=accept:1,L]
   Header edit Vary "(,\s*)?User-Agent" ""
   Header always edit Vary "(,\s*)?User-Agent" ""
 </IfModule>
+
+# Drupal emits "Expires: Sun, 19 Nov 1978" (a legacy "already stale" header) on
+# rendered HTML pages. Cloudflare honors that past Expires and refuses to edge-
+# cache the page even when the Cache Rule forces an Edge TTL ("Ignore cache-
+# control header" ignores Cache-Control but NOT Expires). Strip Expires on HTML
+# responses only, so the page's "Cache-Control: public, max-age=1800" governs;
+# static assets keep their own far-future Expires. This is what finally lets
+# anonymous HTML reach cf-cache-status: HIT.
+<IfModule mod_headers.c>
+  Header always unset Expires "expr=%{CONTENT_TYPE} =~ m#text/html#"
+</IfModule>


### PR DESCRIPTION
Folds the last un-merged piece of the CWV edge-caching work into git so production can deploy again.

## Why this exists
Production has been **frozen on v1.17.0** since ~June 14: the `v1.18.0` and `v1.18.1` tag deploys both failed at `git checkout` because prod has **uncommitted hand-edits** to `.htaccess.custom` and `saho_performance/.../ResponseSubscriber.php` (the Vary/CWV firefighting was applied directly on the server). #379/#380 captured most of that into git, but the **strip-Expires** block (commit `4cfc3eec`) was never merged — so no tag matched prod's live state.

## What
Cherry-picks `4cfc3eec` onto main: an 11-line `.htaccess.custom` block that strips Drupal's legacy `Expires: 1978` header on HTML responses so Cloudflare will edge-cache anonymous HTML (`cf-cache-status: HIT`).

Once this is tagged (v1.18.2), the tag's two files will **exactly match** prod's live edits, so `git checkout` stops failing (git permits the switch when the local change equals the target) and nothing is lost.

## Scope
- `.htaccess.custom` only (11 lines). `ResponseSubscriber.php` is unchanged — its committed form (from #379) is already in v1.18.x.

Related: [[project_saho_cwv_edge_caching]], #379, #380.