### PR TITLE
ci(a11y): scheduled pa11y/axe WCAG2AA guardrail

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,37 @@
+name: Accessibility (pa11y / axe)
+
+# Why scheduled, not on PR: the build pipeline never boots Drupal, so there is no
+# rendered URL to scan inside a PR. This monitors the LIVE site for WCAG 2.1 AA
+# regressions on a cadence, plus on-demand via "Run workflow". The per-URL
+# thresholds in tests/a11y/pa11yci.config.cjs freeze the current backlog and fail
+# on any NEW regression above it.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to scan'
+        required: false
+        default: 'https://sahistory.org.za'
+
+jobs:
+  pa11y:
+    name: WCAG 2.1 AA scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run pa11y-ci (axe, WCAG2AA) against the live site
+        working-directory: webroot/themes/custom/saho
+        env:
+          A11Y_BASE_URL: ${{ github.event.inputs.base_url || 'https://sahistory.org.za' }}
+        run: npx --yes pa11y-ci@4.1.1 -c tests/a11y/pa11yci.config.cjs

--- a/docs/2026-ROADMAP.md
+++ b/docs/2026-ROADMAP.md
@@ -31,7 +31,7 @@ full rationale (incl. what was deliberately rejected) is the approved plan.
 | W3 | Speculation Rules (instant nav) | DONE - prefetch-only (no prerender, avoids GA double-count) | #280 |
 | W3 | Revive dead LCP image preload | DONE - was in `hook_page_attachments()` which themes never run; moved to `_alter` | - |
 | W3 | Wire `responsive_image` into image fields | DEFERRED to staging - styles are sound, but would misalign the revived hero LCP preload and can't be verified on local image routing; apply to non-LCP in-page images | - |
-| W3 | axe/pa11y in CI | TODO | - |
+| W3 | axe/pa11y in CI | DONE - scheduled `a11y.yml` runs pa11y-ci/axe (WCAG2AA) vs the live site; per-URL ratchet thresholds freeze the legacy backlog | - |
 | W3 | PWA (manifest + install SW) | DEFERRED to Phase 2 - Speculation Rules covers ~80% of perceived speed now | #280 |
 | W4 | Interlink orphaned image nodes | DONE - `image` bundle added to saho_suggested_reading + shared partial in `node--image`; verified 6 internal links on an orphan node | #139 |
 | W4 | Extend contextual interlink quality + verify events render | TODO - many image nodes fall back to "Popular Content" (same links); add contextual relations; `event` already renders the block (verify data) | #139 |

--- a/docs/ACCESSIBILITY-AUDIT.md
+++ b/docs/ACCESSIBILITY-AUDIT.md
@@ -730,7 +730,28 @@ All components meet or exceed WCAG 2.5.5 minimum of 44×44px.
   active trail. Uses server-side `in_active_trail` (url cache context), so it is
   safe under the newly-enabled page cache.
 
-### Still open
-- No automated a11y testing in CI - add `@axe-core/playwright` (Playwright already
-  in the stack) over a few representative URLs to lock in the above and catch
-  regressions.
+### Automated guardrail (added 2026-06)
+- `npm run a11y` (in the theme) and the scheduled `.github/workflows/a11y.yml` run
+  **pa11y-ci with the axe engine** (WCAG2AA) over representative URLs. Config:
+  `webroot/themes/custom/saho/tests/a11y/pa11yci.config.cjs`. The tool is invoked
+  via `npx` (not a committed dependency) so its puppeteer chain never enters the
+  lockfile. It scans the **live site** because CI never boots Drupal.
+- Per-URL **ratchet thresholds** freeze the current backlog and fail on new
+  regressions. Lower them as issues are fixed.
+
+### Legacy backlog surfaced by the first axe scan (to work down)
+Baseline axe error counts (NOT introduced by recent work - pre-existing debt):
+
+| URL | axe errors |
+|-----|-----------|
+| `/` (home) | 53 |
+| `/people/dr-abdullah-abdurahman` (biography) | 32 |
+| `/article/cradle-humankind` (article) | 26 |
+| `/biographies` (section) | 19 |
+| `/politics-society` (section) | 18 |
+| `/node/37872` (image) | 16 |
+
+Likely categories: colour contrast (accent/gold on light), images missing `alt`
+in migrated body content, ARIA on legacy/third-party widgets, form labels. Next
+step: triage the home page's 53 by axe rule id and fix the highest-frequency rules
+first, then ratchet the thresholds down.

--- a/webroot/themes/custom/saho/package.json
+++ b/webroot/themes/custom/saho/package.json
@@ -22,6 +22,7 @@
 		"stylelint:fix": "stylelint '**/*.scss' --fix",
 		"lint": "npm run biome:check && npm run stylelint",
 		"lint:fix": "npm run biome:check && npm run stylelint:fix",
+		"a11y": "npx --yes pa11y-ci@4.1.1 -c tests/a11y/pa11yci.config.cjs",
 		"build:prod": "npm run production && npm run compress",
 		"compress": "find dist -name '*.css' -type f ! -name '*.gz' -exec sh -c 'gzip -k -9 \"$1\" 2>/dev/null || true' _ {} \\; && find dist -name '*.js' -type f ! -name '*.gz' -exec sh -c 'gzip -k -9 \"$1\" 2>/dev/null || true' _ {} \\;",
 		"ci": "npm ci && npm run production",

--- a/webroot/themes/custom/saho/tests/a11y/pa11yci.config.cjs
+++ b/webroot/themes/custom/saho/tests/a11y/pa11yci.config.cjs
@@ -1,0 +1,38 @@
+/**
+ * pa11y-ci config - WCAG 2.1 AA guardrail for SAHO (axe engine).
+ *
+ * Runs against A11Y_BASE_URL (defaults to local DDEV). CI points it at the live
+ * site on a schedule, because the build pipeline never boots Drupal - there is
+ * no live URL to test inside a PR.
+ *
+ *   Local: npx pa11y-ci -c tests/a11y/pa11yci.config.cjs
+ *   Prod:  A11Y_BASE_URL=https://sahistory.org.za npx pa11y-ci -c tests/a11y/pa11yci.config.cjs
+ *
+ * The per-URL thresholds are the current axe baseline (+ a small buffer for
+ * dynamic blocks). They are a RATCHET: they freeze the legacy a11y backlog so it
+ * cannot grow, and any NEW regression above the baseline fails the run. Lower
+ * them as legacy issues are fixed. They are not an endorsement of the backlog.
+ */
+const base = process.env.A11Y_BASE_URL || 'https://sahistory-web.ddev.site';
+
+const targets = [
+  { path: '/', threshold: 55 },
+  { path: '/politics-society', threshold: 20 },
+  { path: '/biographies', threshold: 21 },
+  { path: '/people/dr-abdullah-abdurahman', threshold: 35 },
+  { path: '/article/cradle-humankind', threshold: 28 },
+  { path: '/node/37872', threshold: 18 },
+];
+
+module.exports = {
+  defaults: {
+    standard: 'WCAG2AA',
+    runners: ['axe'],
+    timeout: 60000,
+    chromeLaunchConfig: {
+      ignoreHTTPSErrors: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    },
+  },
+  urls: targets.map((t) => ({ url: `${base}${t.path}`, threshold: t.threshold })),
+};


### PR DESCRIPTION
## Summary

Adds an automated WCAG 2.1 AA guardrail (pa11y-ci + axe). Locks in the skip-link / aria-current work from #398 and catches future a11y regressions.

**Why scheduled, not a PR gate:** the build pipeline never boots Drupal, so there is no rendered URL to scan inside a PR. The workflow runs on a weekly cron + manual dispatch against the **live site**.

## What's included
- `.github/workflows/a11y.yml` - scheduled (Mon 06:00 UTC) + `workflow_dispatch` scan of the live site.
- `webroot/themes/custom/saho/tests/a11y/pa11yci.config.cjs` - axe engine, WCAG2AA, 6 representative URLs (home, two sections, biography, article, image node).
- `npm run a11y` (theme) for local runs against DDEV.
- Docs: guardrail usage + the baseline backlog surfaced by the first scan.

## Deliberate choices
- **No committed dependency.** pa11y-ci is invoked via `npx --yes pa11y-ci@4.1.1`, so its puppeteer chain (which carries known dev-only advisories) never enters `package-lock.json` and the security audit stays clean.
- **Ratchet thresholds.** Per-URL thresholds = current axe baseline + small buffer. They freeze the legacy backlog (they do not endorse it) and fail on any NEW regression. Lower them as issues are fixed.

## Baseline backlog (pre-existing, to work down)
home 53 · biography 32 · article 26 · /biographies 19 · /politics-society 18 · image node 16 (axe errors). Likely colour-contrast / missing alt in migrated content / legacy-widget ARIA. Next: triage home's 53 by axe rule id, fix highest-frequency first, ratchet down.

## Verify
Actions -> "Accessibility (pa11y / axe)" -> Run workflow (defaults to https://sahistory.org.za). Green = within baseline; red = a regression above baseline.
