### PR TITLE
perf(images): sized derivatives on homepage cards (PSI: -982 KiB)

### DIFF
--- a/webroot/modules/custom/saho_utils/entity_overview/src/Plugin/Block/EntityOverviewBlock.php
+++ b/webroot/modules/custom/saho_utils/entity_overview/src/Plugin/Block/EntityOverviewBlock.php
@@ -411,8 +411,12 @@ class EntityOverviewBlock extends BlockBase implements ContainerFactoryPluginInt
    *   The entity item data.
    */
   protected function buildEntityItem(NodeInterface $node) {
-    // Use EntityItemBuilderService for consistent item building.
-    $item = $this->entityItemBuilder->buildFullItem($node);
+    // Use EntityItemBuilderService for consistent item building. Pass a sized
+    // image style so cards render a ~650px derivative (covers 2x retina for the
+    // ~306px card slots) instead of the raw full-size original - the latter was
+    // shipping 0.5-2 MB images per card. The .htaccess WebP rewrite serves the
+    // WebP variant of the derivative on top.
+    $item = $this->entityItemBuilder->buildFullItem($node, ['image_style' => 'max_650x650']);
 
     // Ensure backward compatibility with legacy field names.
     if (isset($item['image_url'])) {

--- a/webroot/themes/custom/saho/templates/block/block--inline-block--history-in-pictures.html.twig
+++ b/webroot/themes/custom/saho/templates/block/block--inline-block--history-in-pictures.html.twig
@@ -8,7 +8,7 @@
       caption_title: item['#node'].title.value,
       caption_content: item['#node'].body.summary ?? '',
       image_src: item['#node'].field_event_image.entity.uri.value
-        ? file_url(item['#node'].field_event_image.entity.uri.value)
+        ? item['#node'].field_event_image.entity.uri.value|image_style('max_1300x1300')
         : '/themes/custom/saho/images/default-image.jpg'
     }]) %}
   {% endfor %}

--- a/webroot/themes/custom/saho/templates/views/views-view--featured-content--unified.html.twig
+++ b/webroot/themes/custom/saho/templates/views/views-view--featured-content--unified.html.twig
@@ -48,8 +48,12 @@
       {% if not image_data and node.hasField(field_name) and not node.get(field_name).isEmpty() %}
         {% set file_entity = node.get(field_name).entity %}
         {% if file_entity %}
+          {# Use a sized image-style derivative, not the raw original. The cards
+             display ~306x204, so a 650px-max derivative (covers 2x retina) cuts
+             the worst offenders from ~550 KiB to ~50 KiB, and the .htaccess WebP
+             rewrite serves the WebP variant on top. #}
           {% set image_data = {
-            'url': file_url(file_entity.uri.value),
+            'url': file_entity.uri.value|image_style('max_650x650'),
             'alt': node_title
           } %}
         {% endif %}


### PR DESCRIPTION
## Summary

Fixes the **#1 PageSpeed finding** on the homepage: **"Improve image delivery — 982 KiB"**. The worst single offender was a **552 KiB raw 2048×1368 JPG** rendered into a **306×204** card.

**Root cause:** homepage cards rendered the *original* file URL instead of an image-style derivative.

## Changes
- **`EntityOverviewBlock::buildEntityItem`** — pass `image_style: 'max_650x650'` to `buildFullItem()` (was `NULL` → raw original). This is the bulk fix: the overview card grids are most of the homepage cards (articles, places, etc.). **Verified locally: 9 cards switch from raw to `max_650x650` derivatives.**
- **`views-view--featured-content--unified.twig`** and **`history-in-pictures` carousel** — replace raw `file_url(uri.value)` with twig_tweak `|image_style` (`max_650x650` / `max_1300x1300` for the full-width carousel).
- The existing `.htaccess` WebP rewrite serves the WebP variant of each derivative on top, so this compounds with the WebP work.

## Expected impact
~0.5–2 MB → ~50 KB per oversized card. Helps **mobile LCP** (the failing CWV metric) and total page weight. Re-run PageSpeed after deploy to confirm the "Improve image delivery" savings drop.

## Deferred (follow-up)
- **History Through Pictures gallery** (`saho_statistics`): builds the raw path at `HistoryThroughPicturesBlock.php:436-438`, but `item.image` is reused for **both** the grid thumbnail *and* the lightbox full-size — needs a thumbnail/full-size split before sizing it, or the lightbox degrades.
- Broader: many `node--*` card blocks still use raw `file_url(uri.value)` (incl. the suggested-reading partial) — same `|image_style` treatment can follow.

## Verify
Local: homepage now emits `styles/max_650x650` derivatives instead of raw `/sites/default/files/*.jpg` for overview cards. Post-deploy: PageSpeed "Improve image delivery" savings should drop sharply.
