### PR TITLE
Add image corruption restoration plan and Phase A/B diagnostics

### DIFF
--- a/docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md
+++ b/docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md
@@ -1,0 +1,188 @@
+# Image Corruption Restoration Plan
+
+Status: PLAN (not yet executed)
+Author: investigation 2026-06-27
+Trigger: dblog flooded with `image` errors - "ImageMagick error 1: identify: Not a JPEG file"
+
+## 1. Summary
+
+The recurring ImageMagick errors in the admin log are the visible symptom of a
+large-scale image corruption introduced during the D7 -> D11 migration. A batch
+of image files had their real bytes replaced by tiny placeholders (about 320
+bytes of HTML "page not found" markup, or 0 bytes). Every time a visitor or
+crawler requests an image style derivative of one of these files, ImageMagick's
+`identify` fails and Drupal logs an error.
+
+Because dblog self-caps at 1,000 rows (`dblog.settings:row_limit = 1000`), these
+errors evict genuinely useful log entries. That is the "clutter".
+
+This document is the plan to fix the root cause (restore the images), not just
+clear the log.
+
+## 2. Confirmed findings (from local DDEV against a prod DB mirror)
+
+- Total image file entities: 119,617
+- Corrupt (filesize < 1500 bytes, mime image/*): 7,324  (6.1%)
+  - 0 bytes (empty): 50
+  - 1-399 bytes (HTML error page): 3,310
+  - 400-1499 bytes: 3,964
+- Referenced in live content (file_usage > 0): 6,255  -> users see broken images
+- Orphaned (no file_usage): 1,069
+- Have a healthy same-name copy elsewhere in DB: only 177 (and generic names like
+  `1.jpg` collide, so this is NOT a safe blanket repoint)
+- Corruption window: created timestamps cluster in 2019-05 .. 2019-06
+  (about 6,943 of 7,324). This was a single bad migration batch.
+- Top affected directories: images_new (3,430), images (926), field (237),
+  event_pics (108), archive-files (64), plus a public:/// root batch (238).
+- Mime split: gif 4,771, jpeg 2,462, png 91.
+
+### Why config cannot suppress it
+The errors come from `ImagemagickExecManager::sendCommand()` line ~223, the
+`$this->logger->error(...)` branch (return code != 0 AND stderr non-empty).
+This path is NOT gated by `imagemagick.settings:log_warnings`. Toggling that
+setting does nothing. The only ways to stop the errors are: remove/replace the
+corrupt source files, or stop the requests (not controllable - crawlers).
+
+## 3. Important caveat: DB filesize is a proxy
+
+The 7,324 count is based on the `file_managed.filesize` column, recorded at
+migration time. The authoritative truth is the actual bytes on the production
+disk - a file may have been re-uploaded since, or the recorded size may be stale.
+Phase A re-establishes ground truth before any destructive action.
+
+## 4. Recovery sources (to be discovered - no backup inventory exists yet)
+
+In priority order of quality:
+
+1. Image-style derivatives already on disk.
+   Drupal stores generated derivatives at
+   `sites/default/files/styles/<style>/public/<original-relative-path>`.
+   If a derivative was generated BEFORE the original was corrupted, it is a
+   valid (if downscaled) copy we can promote back to the original path.
+   This is the most promising no-backup source. Pick the largest-dimension
+   style available per file.
+2. Healthy duplicates within the current files tree (same content, different
+   path; or a larger same-name file). Verify by image dimensions / content, not
+   just name (names collide).
+3. Pre-migration backups: D7 site files archive, hosting snapshots, or any
+   `files` tarball from before 2019-05. Locate by auditing the production server
+   and the hosting provider's backups.
+4. Re-harvest from the live web: the SAHO Archive Factory pipeline
+   (`~/saho-archive-import/`) and/or web.archive.org for the original article
+   pages. Last resort, lower fidelity, but covers files with no other source.
+
+## 5. Per-file recovery decision tree
+
+For each confirmed-corrupt original:
+
+```
+is there a valid style derivative on disk?
+  yes -> promote largest derivative to original path (note: upscaled-from-thumb
+         quality; acceptable for icons/logos, flag larger images for review)
+  no  -> is there a verified healthy duplicate (by dimensions/content)?
+           yes -> copy duplicate bytes to original path
+           no  -> is there a pre-2019-05 backup original?
+                    yes -> restore from backup
+                    no  -> re-harvest (Archive Factory / Wayback)
+                             found    -> install
+                             not found-> mark unrecoverable: replace with a
+                                         neutral placeholder + record in a
+                                         "lost-media" report; remove file_usage
+                                         so no derivative is attempted
+```
+
+## 6. Execution phases
+
+All work developed and dry-run on local DDEV first, then applied to prod with
+explicit confirmation. Every write is additive and reversible; nothing is
+deleted until its replacement is verified.
+
+### Phase A - Ground truth (read-only, run on PROD)
+- Scan every `image/*` file_managed entry: stat real disk size + probe real
+  type (finfo / getimagesize).
+- Output authoritative CSV: fid, uri, db_size, disk_size, real_mime, verdict
+  (ok | empty | html | truncated | missing).
+- This replaces the DB-filesize proxy with reality. Deliverable: the definitive
+  corrupt list.
+
+### Phase B - Source discovery (read-only, run on PROD)
+- For each confirmed-corrupt file, locate recovery candidates per section 4:
+  scan styles/ derivatives, find healthy duplicates, audit server + hosting for
+  backups, queue the remainder for re-harvest.
+- Output: recovery-plan CSV mapping each corrupt fid -> chosen source + method.
+
+### Phase C - Repair (staged writes, dry-run local first)
+- For each file with a chosen source: write recovered bytes to the original
+  path, flush that file's style derivatives (`image_path_flush` /
+  delete styles/*/<path>), update file_managed.filesize, run `identify` to
+  confirm it now passes.
+- Batch by directory/source; checkpoint after each batch.
+- Keep a per-file before/after manifest for rollback.
+
+### Phase D - Unrecoverable handling
+- Files with no source: install a neutral placeholder so pages do not show a
+  broken image, record them in `docs/lost-media-report.csv`, and detach
+  file_usage so no further derivative attempts (no more log errors).
+
+### Phase E - Stop the log bleeding (do early as interim relief)
+- Clear current image errors: `drush watchdog:delete --type=image` (prod).
+- Optional interim: a cron `drush watchdog:delete --type=image` until repair is
+  complete, so the 1,000-row log stays usable. Remove once Phase C/D finish.
+
+### Phase F - Validation
+- Re-run an `identify` sweep across all originals: target zero failures.
+- Confirm dblog `image` errors stop accruing over 48h.
+- Spot-check a sample of restored pages in the browser (Playwright screenshots).
+
+## 7. Safety
+
+- Production is live. No destructive op runs on prod without a local dry-run and
+  explicit confirmation.
+- All repairs are additive (write bytes, then flush derivatives). The original
+  corrupt bytes are preserved in the manifest until validation passes.
+- Work in batches with checkpoints; never a single 7,000-file sweep.
+
+## 8. Open questions
+
+- Where do the most complete pre-2019-05 file backups live? (hosting snapshots,
+  old D7 server, local archive) - audit needed in Phase B.
+- For files recoverable only from low-res derivatives, is upscaled quality
+  acceptable, or should those go to re-harvest for full resolution?
+
+## 9. Scripts
+
+- `scripts/image-audit-disk.php`    - Phase A ground-truth scanner (read-only)
+  BUILT + validated locally. Run: `drush php:script scripts/image-audit-disk.php`
+- `scripts/image-source-finder.php` - Phase B recovery-source mapper (read-only)
+  BUILT + validated locally. Run:
+  `drush php:script scripts/image-source-finder.php <audit.csv>`
+- `scripts/image-repair.php`         - Phase C staged repair executor (TO BUILD)
+  Design after the prod Phase B numbers are known. Dry-run by default,
+  `--apply` to write; min-dimension threshold to reject tiny "duplicates".
+
+## 10. Validation status (2026-06-27, local DDEV)
+
+- Phase A scanned all 119,617 image entities. Key discovery: the on-disk truth
+  differs from the DB filesize proxy. Example: `event_pics/deklerk-fw3.jpg` has
+  db_size 36,979 but is 0 bytes on disk and is referenced 5 times - the
+  filesize<1500 query would have missed it. The real corrupt set must be
+  measured on the PROD disk, not inferred from the DB.
+- Phase B correctly located recovery sources for sample corrupt files, e.g.
+  `u3/chris-hani.jpg` (empty) -> healthy duplicate `field/image/chris-hani.jpg`
+  at 678x829. It also exposed the quality caveat: a `floods.jpg` duplicate was
+  only 45x45, so the repair phase must enforce a minimum-dimension threshold and
+  not blindly trust same-name duplicates.
+
+## 11. Next action (requires PROD)
+
+The local files dir is only a partial mirror, so the authoritative corrupt count
+and the real recoverable-vs-needs-backup split can only come from production.
+Run, on prod (both read-only):
+
+```
+drush php:script scripts/image-audit-disk.php
+drush php:script scripts/image-source-finder.php <the-audit.csv-just-written>
+```
+
+Then we size Phase C/D from real numbers. Interim log relief is safe any time:
+`drush watchdog:delete --type=image`.

--- a/scripts/image-audit-disk.php
+++ b/scripts/image-audit-disk.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * @file
+ * Phase A - Image corruption ground-truth scanner (read-only).
+ *
+ * Scans every image/* file_managed entity and compares the DB-recorded size to
+ * the ACTUAL bytes on disk, probing the real file type. This replaces the
+ * stale file_managed.filesize proxy with reality before any repair.
+ *
+ * Safe to run on production - it only reads files and writes one CSV report.
+ *
+ * Usage:
+ *   ddev drush php:script scripts/image-audit-disk.php
+ *   # on prod:
+ *   drush php:script scripts/image-audit-disk.php
+ *
+ * Output: scratch CSV path is printed at the end. Columns:
+ *   fid,uri,db_size,disk_size,real_mime,verdict,referenced
+ * Verdicts: ok | empty | html | truncated | not_image | missing
+ *
+ * See docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md.
+ */
+
+use Drupal\Core\Database\Database;
+
+$file_system = \Drupal::service('file_system');
+$connection = Database::getConnection();
+
+// Where to write the report. Use the public files dir so it works everywhere.
+$out_rel = 'private://image-audit-' . date('Ymd-His') . '.csv';
+$out_abs = $file_system->realpath('private://') ? $file_system->realpath('private://') . '/image-audit-' . date('Ymd-His') . '.csv'
+  : $file_system->realpath('public://') . '/image-audit-' . date('Ymd-His') . '.csv';
+
+$fh = fopen($out_abs, 'w');
+fputcsv($fh, ['fid', 'uri', 'db_size', 'disk_size', 'real_mime', 'verdict', 'referenced']);
+
+// Pull usage counts once (fid => count) to avoid a query per file.
+$usage = [];
+foreach ($connection->query("SELECT fid, COUNT(*) c FROM {file_usage} GROUP BY fid") as $row) {
+  $usage[$row->fid] = (int) $row->c;
+}
+
+$finfo = function_exists('finfo_open') ? finfo_open(FILEINFO_MIME_TYPE) : NULL;
+
+$stats = [
+  'ok' => 0,
+  'empty' => 0,
+  'html' => 0,
+  'truncated' => 0,
+  'not_image' => 0,
+  'missing' => 0,
+];
+
+// Iterate image entities in id order, streaming to keep memory flat.
+$query = $connection->query("SELECT fid, uri, filesize FROM {file_managed} WHERE filemime LIKE 'image/%' ORDER BY fid");
+$n = 0;
+foreach ($query as $row) {
+  $n++;
+  $real = $file_system->realpath($row->uri);
+  $db_size = (int) $row->filesize;
+  $ref = $usage[$row->fid] ?? 0;
+
+  if ($real === FALSE || !file_exists($real)) {
+    fputcsv($fh, [$row->fid, $row->uri, $db_size, '', '', 'missing', $ref]);
+    $stats['missing']++;
+    continue;
+  }
+
+  $disk_size = filesize($real);
+
+  if ($disk_size === 0) {
+    fputcsv($fh, [$row->fid, $row->uri, $db_size, 0, '', 'empty', $ref]);
+    $stats['empty']++;
+    continue;
+  }
+
+  // Read a small header to detect HTML masquerading as an image.
+  $head = file_get_contents($real, FALSE, NULL, 0, 16);
+  $real_mime = $finfo ? finfo_file($finfo, $real) : 'unknown';
+
+  $is_html = (stripos($head, '<!') === 0) || (stripos($head, '<htm') !== FALSE) || (stripos($head, '<?xm') === 0 && stripos($real_mime, 'svg') === FALSE);
+
+  if ($is_html || $real_mime === 'text/html') {
+    fputcsv($fh, [$row->fid, $row->uri, $db_size, $disk_size, $real_mime, 'html', $ref]);
+    $stats['html']++;
+    continue;
+  }
+
+  if (strpos((string) $real_mime, 'image/') !== 0) {
+    fputcsv($fh, [$row->fid, $row->uri, $db_size, $disk_size, $real_mime, 'not_image', $ref]);
+    $stats['not_image']++;
+    continue;
+  }
+
+  // Real image mime, but is it actually decodable? getimagesize returns FALSE
+  // on truncated/corrupt image data.
+  $info = @getimagesize($real);
+  if ($info === FALSE) {
+    fputcsv($fh, [$row->fid, $row->uri, $db_size, $disk_size, $real_mime, 'truncated', $ref]);
+    $stats['truncated']++;
+    continue;
+  }
+
+  fputcsv($fh, [$row->fid, $row->uri, $db_size, $disk_size, $real_mime, 'ok', $ref]);
+  $stats['ok']++;
+
+  if ($n % 5000 === 0) {
+    echo "  scanned $n ...\n";
+  }
+}
+
+fclose($fh);
+if ($finfo) {
+  finfo_close($finfo);
+}
+
+$bad = $stats['empty'] + $stats['html'] + $stats['truncated'] + $stats['not_image'] + $stats['missing'];
+echo "\n=== Image audit complete ===\n";
+echo "Total image entities scanned: $n\n";
+foreach ($stats as $k => $v) {
+  echo sprintf("  %-10s %d\n", $k, $v);
+}
+echo "Corrupt/unusable total: $bad\n";
+echo "Report written to: $out_abs\n";

--- a/scripts/image-source-finder.php
+++ b/scripts/image-source-finder.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * @file
+ * Phase B - Image recovery source finder (read-only).
+ *
+ * Takes the Phase A audit CSV and, for every corrupt file, looks for a usable
+ * recovery source - in priority order:
+ *   1. A surviving image-style derivative on disk
+ *      (styles/<style>/public/<path>) that is itself a valid image. Picks the
+ *      largest by pixel area.
+ *   2. A healthy duplicate elsewhere in the files tree with the same basename
+ *      that is a valid image (dimensions reported so collisions can be judged).
+ * Backups and re-harvest (sources 3 and 4 in the plan) are out of scope for
+ * this script - the remainder are flagged "needs_backup_or_reharvest".
+ *
+ * Safe on production - reads files only, writes one CSV.
+ *
+ * Usage:
+ *   drush php:script scripts/image-source-finder.php <path-to-audit.csv>
+ *
+ * Output columns:
+ *   fid,uri,verdict,referenced,source_method,source_path,source_dimensions
+ * source_method: derivative | duplicate | needs_backup_or_reharvest
+ *
+ * See docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md.
+ */
+
+use Drupal\Core\Database\Database;
+
+$audit_csv = $extra[0] ?? ($args[0] ?? NULL);
+if (!$audit_csv || !file_exists($audit_csv)) {
+  echo "ERROR: pass the Phase A audit CSV path as an argument.\n";
+  echo "  drush php:script scripts/image-source-finder.php /path/to/image-audit-*.csv\n";
+  return;
+}
+
+$file_system = \Drupal::service('file_system');
+$connection = Database::getConnection();
+
+$files_root = $file_system->realpath('public://');
+$styles_root = $files_root . '/styles';
+
+// Enumerate available style machine names once.
+$styles = [];
+if (is_dir($styles_root)) {
+  foreach (scandir($styles_root) as $s) {
+    if ($s !== '.' && $s !== '..' && is_dir("$styles_root/$s/public")) {
+      $styles[] = $s;
+    }
+  }
+}
+echo 'Found ' . count($styles) . " style directories on disk.\n";
+
+// Output next to the audit file.
+$out_abs = dirname($audit_csv) . '/image-recovery-plan-' . date('Ymd-His') . '.csv';
+$out = fopen($out_abs, 'w');
+fputcsv($out, ['fid', 'uri', 'verdict', 'referenced', 'source_method', 'source_path', 'source_dimensions']);
+
+/**
+ * Return [width, height, abs_path] for the largest valid image in the set.
+ */
+$best_image = function (array $candidates) {
+  $best = NULL;
+  foreach ($candidates as $path) {
+    if (!is_file($path)) {
+      continue;
+    }
+    $info = @getimagesize($path);
+    if ($info === FALSE) {
+      continue;
+    }
+    $area = $info[0] * $info[1];
+    if ($best === NULL || $area > $best['area']) {
+      $best = ['area' => $area, 'w' => $info[0], 'h' => $info[1], 'path' => $path];
+    }
+  }
+  return $best;
+};
+
+$in = fopen($audit_csv, 'r');
+$header = fgetcsv($in);
+$col = array_flip($header);
+
+$counts = ['derivative' => 0, 'duplicate' => 0, 'needs_backup_or_reharvest' => 0];
+$rows = 0;
+
+while (($r = fgetcsv($in)) !== FALSE) {
+  $verdict = $r[$col['verdict']];
+  // Only chase recovery for genuinely broken files.
+  if (in_array($verdict, ['ok'], TRUE)) {
+    continue;
+  }
+  $rows++;
+  $fid = $r[$col['fid']];
+  $uri = $r[$col['uri']];
+  $ref = $r[$col['referenced']];
+
+  // Relative path inside the public scheme, e.g. "images_new/foo.jpg".
+  $rel = preg_replace('#^public://#', '', $uri);
+  $rel = ltrim($rel, '/');
+  $basename = basename($rel);
+
+  // 1. Surviving derivatives for this exact relative path.
+  $deriv_candidates = [];
+  foreach ($styles as $s) {
+    $deriv_candidates[] = "$styles_root/$s/public/$rel";
+  }
+  $best = $best_image($deriv_candidates);
+
+  if ($best) {
+    fputcsv($out, [$fid, $uri, $verdict, $ref, 'derivative', $best['path'], $best['w'] . 'x' . $best['h']]);
+    $counts['derivative']++;
+    continue;
+  }
+
+  // 2. Healthy duplicate by basename anywhere in file_managed (valid on disk).
+  $dupe_paths = [];
+  $q = $connection->query("SELECT uri FROM {file_managed} WHERE uri LIKE :p AND uri <> :self", [
+    ':p' => '%/' . $basename,
+    ':self' => $uri,
+  ]);
+  foreach ($q as $d) {
+    $p = $file_system->realpath($d->uri);
+    if ($p) {
+      $dupe_paths[] = $p;
+    }
+  }
+  $best = $best_image($dupe_paths);
+
+  if ($best) {
+    fputcsv($out, [$fid, $uri, $verdict, $ref, 'duplicate', $best['path'], $best['w'] . 'x' . $best['h']]);
+    $counts['duplicate']++;
+    continue;
+  }
+
+  // 3. Nothing usable on disk.
+  fputcsv($out, [$fid, $uri, $verdict, $ref, 'needs_backup_or_reharvest', '', '']);
+  $counts['needs_backup_or_reharvest']++;
+
+  if ($rows % 2000 === 0) {
+    echo "  processed $rows corrupt files ...\n";
+  }
+}
+
+fclose($in);
+fclose($out);
+
+echo "\n=== Recovery source scan complete ===\n";
+echo "Corrupt files examined: $rows\n";
+foreach ($counts as $k => $v) {
+  echo sprintf("  %-26s %d\n", $k, $v);
+}
+$recoverable = $counts['derivative'] + $counts['duplicate'];
+echo "On-disk recoverable (no backup needed): $recoverable\n";
+echo "Recovery plan written to: $out_abs\n";


### PR DESCRIPTION
## Summary

The `image` dblog errors ("ImageMagick error 1: identify: Not a JPEG file") are the symptom of a May-June 2019 migration batch that replaced ~7,000+ image files with HTML error pages or 0-byte placeholders. The errors come from the ungated `error()` path in `ImagemagickExecManager`, so `log_warnings` cannot suppress them - the only fix is restoring the images.

## Changes (all read-only / docs)
- `docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md` - findings, recovery decision tree, phased execution, safety model.
- `scripts/image-audit-disk.php` - Phase A on-disk ground-truth scanner (DB filesize is a stale proxy; disk bytes are authoritative).
- `scripts/image-source-finder.php` - Phase B recovery-source mapper (surviving style derivatives, healthy duplicates).

Both scripts validated locally. Authoritative counts to be gathered on production; Phase C (repair executor) follows.