### PR TITLE
feat(image-repair): Phase C repair executor + prod A/B numbers

### DIFF
--- a/docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md
+++ b/docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md
@@ -1,8 +1,38 @@
 # Image Corruption Restoration Plan
 
-Status: PLAN (not yet executed)
+Status: IN PROGRESS - Phase A + B run on prod; Phase C (repair) built + validated
 Author: investigation 2026-06-27
 Trigger: dblog flooded with `image` errors - "ImageMagick error 1: identify: Not a JPEG file"
+
+## 0. Authoritative production numbers (Phase A + B, 2026-06-28)
+
+Phase A on-disk scan of all 119,617 image entities:
+
+| verdict   | count   | meaning                                            |
+|-----------|---------|----------------------------------------------------|
+| ok        | 102,702 | valid, decodable images                            |
+| html      | 2,493   | HTML error pages with image extension (log cause)  |
+| empty     | 58      | 0-byte files                                        |
+| truncated | 4       | corrupt/incomplete image bytes                      |
+| missing   | 14,360  | file_managed points to a path absent from disk     |
+
+Two distinct problems:
+- LOG SPAM = the 2,555 files that exist-but-are-bad-bytes (html+empty+truncated).
+  ImageMagick can only fail `identify` on a present file, so this exact set
+  drives the dblog clutter. (Much smaller than the 7,324 DB-filesize estimate.)
+- DATA LOSS = 14,360 missing files (~12% of refs point at nothing). Separate
+  track; does not cause ImageMagick errors.
+
+Phase B recovery-source scan of the 16,915 broken files:
+
+| source_method             | count | meaning                                  |
+|---------------------------|-------|------------------------------------------|
+| duplicate                 | 8,435 | healthy same-name image on disk - fix now |
+| needs_backup_or_reharvest | 8,480 | no on-disk copy - backup / re-harvest     |
+| derivative                | 0     | none (cannot derive from a corrupt source)|
+
+So ~half are recoverable from on-disk twins (the legacy/modern path redundancy),
+half are genuinely lost and need backups or Archive Factory re-harvest.
 
 ## 1. Summary
 
@@ -156,9 +186,15 @@ deleted until its replacement is verified.
 - `scripts/image-source-finder.php` - Phase B recovery-source mapper (read-only)
   BUILT + validated locally. Run:
   `drush php:script scripts/image-source-finder.php <audit.csv>`
-- `scripts/image-repair.php`         - Phase C staged repair executor (TO BUILD)
-  Design after the prod Phase B numbers are known. Dry-run by default,
-  `--apply` to write; min-dimension threshold to reject tiny "duplicates".
+- `scripts/image-repair.php`         - Phase C staged repair executor.
+  BUILT + validated locally (corrupt->healthy copy, metadata corrected,
+  derivative flush, reversible backup manifest). DRY-RUN by default; append
+  `apply` to write. Positional tokens: `apply`, `unreferenced`, `min=<int>`,
+  `limit=<int>`. Quality guards: min-dimension (default 200) rejects junk
+  same-name matches; post-write getimagesize verify with rollback; referenced
+  files only unless `unreferenced` given. Run:
+  `drush php:script scripts/image-repair.php <recovery-plan.csv>` (dry-run),
+  then `... <recovery-plan.csv> apply limit=200` for a careful first batch.
 
 ## 10. Validation status (2026-06-27, local DDEV)
 

--- a/scripts/image-repair.php
+++ b/scripts/image-repair.php
@@ -1,0 +1,281 @@
+<?php
+
+/**
+ * @file
+ * Phase C - Image repair executor (dry-run by default).
+ *
+ * Consumes the Phase B recovery-plan CSV and, for every file with an on-disk
+ * recovery source (source_method = duplicate or derivative), copies the healthy
+ * bytes onto the broken original path, flushes that file's style derivatives,
+ * and corrects file_managed.filesize / filemime.
+ *
+ * SAFE BY DEFAULT: with no "apply" argument it only reports what it WOULD do
+ * and writes a categorized action CSV - it changes nothing. Pass "apply" to
+ * write the repairs.
+ * Every applied repair first copies the broken original into a manifest backup
+ * dir, so any change is reversible.
+ *
+ * Quality guards (because "same basename" can be a junk or unrelated match):
+ *   - min dimension: a source smaller than min(W,H) is skipped (default 200).
+ *   - self-match and missing-source are skipped.
+ *   - post-write getimagesize() verification; a failed verify is rolled back.
+ *
+ * Usage (drush, NOT ./):
+ *   # dry-run report (writes nothing):
+ *   drush php:script scripts/image-repair.php <recovery-plan.csv>
+ *   # tune the minimum acceptable dimension and cap the batch:
+ *   drush php:script scripts/image-repair.php <plan.csv> min=300 limit=200
+ *   # actually write the repairs:
+ *   drush php:script scripts/image-repair.php <recovery-plan.csv> apply
+ *   # include files with no usage (default = referenced files only):
+ *   drush php:script scripts/image-repair.php <plan.csv> apply unreferenced
+ *
+ * Tokens are positional (no leading dashes) to avoid drush option parsing:
+ *   apply | unreferenced | min=<int> | limit=<int>
+ *
+ * See docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md.
+ */
+
+use Drupal\Core\Database\Database;
+use Drupal\image\Entity\ImageStyle;
+
+$tokens = $extra ?? ($args ?? []);
+$plan_csv = NULL;
+$apply = FALSE;
+$include_unreferenced = FALSE;
+$min_dim = 200;
+$limit = 0;
+foreach ($tokens as $t) {
+  if ($t === 'apply') {
+    $apply = TRUE;
+  }
+  elseif ($t === 'unreferenced') {
+    $include_unreferenced = TRUE;
+  }
+  elseif (strpos($t, 'min=') === 0) {
+    $min_dim = (int) substr($t, 4);
+  }
+  elseif (strpos($t, 'limit=') === 0) {
+    $limit = (int) substr($t, 6);
+  }
+  elseif ($t !== '' && $t[0] !== '-') {
+    $plan_csv = $t;
+  }
+}
+
+if (!$plan_csv || !file_exists($plan_csv)) {
+  echo "ERROR: pass the Phase B recovery-plan CSV path as the first argument.\n";
+  echo "  drush php:script scripts/image-repair.php /path/to/image-recovery-plan-*.csv\n";
+  return;
+}
+
+$file_system = \Drupal::service('file_system');
+$connection = Database::getConnection();
+
+$public_root = rtrim($file_system->realpath('public://'), '/');
+$private_root = $file_system->realpath('private://');
+$private_root = $private_root ? rtrim($private_root, '/') : NULL;
+
+// Manifest + backup live next to the plan so they travel together.
+$run_id = date('Ymd-His');
+$backup_dir = dirname($plan_csv) . '/image-repair-backup-' . $run_id;
+$manifest_path = dirname($plan_csv) . '/image-repair-manifest-' . $run_id . '.csv';
+$action_path = dirname($plan_csv) . '/image-repair-actions-' . $run_id . '.csv';
+
+if ($apply && !is_dir($backup_dir)) {
+  mkdir($backup_dir, 0775, TRUE);
+}
+
+$action = fopen($action_path, 'w');
+fputcsv($action, ['fid', 'uri', 'source_path', 'source_dimensions', 'referenced', 'decision', 'note']);
+
+$manifest = NULL;
+if ($apply) {
+  $manifest = fopen($manifest_path, 'w');
+  fputcsv($manifest, [
+    'fid', 'uri', 'target_abs', 'backup_abs', 'source_path',
+    'old_filesize', 'new_filesize', 'new_filemime',
+  ]);
+}
+
+/**
+ * Maps a public://|private:// uri to an absolute path.
+ *
+ * Does not require the file to exist (realpath returns FALSE for missing
+ * files, which we must still be able to repair).
+ */
+$to_abs = function (string $uri) use ($public_root, $private_root) {
+  if (strpos($uri, 'public://') === 0) {
+    return $public_root . '/' . substr($uri, strlen('public://'));
+  }
+  if (strpos($uri, 'private://') === 0 && $private_root) {
+    return $private_root . '/' . substr($uri, strlen('private://'));
+  }
+  return NULL;
+};
+
+$counts = [
+  'repaired' => 0,
+  'would_repair' => 0,
+  'skip_too_small' => 0,
+  'skip_unreferenced' => 0,
+  'skip_no_source' => 0,
+  'skip_source_missing' => 0,
+  'skip_self_match' => 0,
+  'failed_verify' => 0,
+  'failed_write' => 0,
+];
+
+$in = fopen($plan_csv, 'r');
+$header = fgetcsv($in);
+$col = array_flip($header);
+$processed = 0;
+
+while (($r = fgetcsv($in)) !== FALSE) {
+  $method = $r[$col['source_method']] ?? '';
+  if ($method !== 'duplicate' && $method !== 'derivative') {
+    // needs_backup_or_reharvest - nothing to do here.
+    continue;
+  }
+
+  $fid = $r[$col['fid']];
+  $uri = $r[$col['uri']];
+  $ref = (int) ($r[$col['referenced']] ?? 0);
+  $source = $r[$col['source_path']] ?? '';
+  $dims = $r[$col['source_dimensions']] ?? '';
+
+  if ($limit && $processed >= $limit) {
+    break;
+  }
+
+  // Referenced-only by default (those are what users see / what spams the log).
+  if ($ref === 0 && !$include_unreferenced) {
+    fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'skip_unreferenced', 'use "unreferenced" to include']);
+    $counts['skip_unreferenced']++;
+    continue;
+  }
+
+  if ($source === '') {
+    fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'skip_no_source', '']);
+    $counts['skip_no_source']++;
+    continue;
+  }
+  if (!is_file($source)) {
+    fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'skip_source_missing', 'source gone since Phase B']);
+    $counts['skip_source_missing']++;
+    continue;
+  }
+
+  // Dimension guard.
+  [$sw, $sh] = array_map('intval', explode('x', $dims . 'x0'));
+  if ($sw < $min_dim || $sh < $min_dim) {
+    fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'skip_too_small', "below min=$min_dim"]);
+    $counts['skip_too_small']++;
+    continue;
+  }
+
+  $target = $to_abs($uri);
+  if ($target === NULL) {
+    fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'skip_no_source', 'unmappable uri scheme']);
+    $counts['skip_no_source']++;
+    continue;
+  }
+  if (realpath($source) !== FALSE && realpath($source) === realpath($target)) {
+    fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'skip_self_match', '']);
+    $counts['skip_self_match']++;
+    continue;
+  }
+
+  $processed++;
+
+  if (!$apply) {
+    fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'would_repair', '']);
+    $counts['would_repair']++;
+    continue;
+  }
+
+  // --- APPLY ---
+  $old_size = is_file($target) ? filesize($target) : 0;
+
+  // 1. Back up the broken original (if present) for rollback.
+  $backup_abs = '';
+  if (is_file($target)) {
+    $backup_abs = $backup_dir . '/' . $fid . '-' . basename($target);
+    @copy($target, $backup_abs);
+  }
+
+  // 2. Ensure the target directory exists, then copy healthy bytes in.
+  $tdir = dirname($target);
+  if (!is_dir($tdir)) {
+    mkdir($tdir, 0775, TRUE);
+  }
+  if (!@copy($source, $target)) {
+    fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'failed_write', 'copy failed']);
+    $counts['failed_write']++;
+    continue;
+  }
+
+  // 3. Verify the written file is a decodable image.
+  $info = @getimagesize($target);
+  if ($info === FALSE) {
+    // Roll back from backup if we had one.
+    if ($backup_abs && is_file($backup_abs)) {
+      @copy($backup_abs, $target);
+    }
+    fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'failed_verify', 'rolled back']);
+    $counts['failed_verify']++;
+    continue;
+  }
+
+  $new_size = filesize($target);
+  $new_mime = $info['mime'] ?? 'image/jpeg';
+
+  // 4. Correct the file_managed metadata.
+  $connection->update('file_managed')
+    ->fields(['filesize' => $new_size, 'filemime' => $new_mime])
+    ->condition('fid', $fid)
+    ->execute();
+
+  // 5. Flush stale style derivatives for this uri so new ones regenerate.
+  try {
+    foreach (ImageStyle::loadMultiple() as $style) {
+      $style->flush($uri);
+    }
+  }
+  catch (\Throwable $e) {
+    // Non-fatal: derivatives will regenerate on next request regardless.
+  }
+
+  fputcsv($manifest, [$fid, $uri, $target, $backup_abs, $source, $old_size, $new_size, $new_mime]);
+  fputcsv($action, [$fid, $uri, $source, $dims, $ref, 'repaired', $info[0] . 'x' . $info[1]]);
+  $counts['repaired']++;
+
+  if ($counts['repaired'] % 500 === 0) {
+    echo '  repaired ' . $counts['repaired'] . " ...\n";
+  }
+}
+
+fclose($in);
+fclose($action);
+if ($manifest) {
+  fclose($manifest);
+}
+
+echo "\n=== Image repair " . ($apply ? 'APPLY' : 'DRY-RUN') . " complete ===\n";
+echo "Mode: " . ($apply ? 'APPLY (files written)' : 'DRY-RUN (nothing changed)') . "\n";
+echo "min dimension: $min_dim   referenced-only: " . ($include_unreferenced ? 'no' : 'yes');
+echo ($limit ? "   limit: $limit" : '') . "\n";
+foreach ($counts as $k => $v) {
+  if ($v > 0 || in_array($k, ['repaired', 'would_repair'], TRUE)) {
+    echo sprintf("  %-20s %d\n", $k, $v);
+  }
+}
+echo "Action report: $action_path\n";
+if ($apply) {
+  echo "Rollback manifest: $manifest_path\n";
+  echo "Backups of originals: $backup_dir\n";
+  echo "(to roll back: copy each backup_abs back over target_abs from the manifest)\n";
+}
+else {
+  echo "Re-run with 'apply' appended to write these repairs.\n";
+}


### PR DESCRIPTION
## Production findings (Phase A + B)
Of 119,617 image entities: **2,555 corrupt-bytes** (html/empty/truncated - the log-spam cause) and **14,360 missing** from disk. Of the 16,915 broken files, **8,435** have a healthy same-name on-disk twin (recoverable now), **8,480** need backup/re-harvest.

## Phase C - `scripts/image-repair.php`
Consumes the Phase B recovery-plan CSV and restores healthy bytes onto broken originals.
- **DRY-RUN by default**; append `apply` to write.
- Positional tokens: `apply`, `unreferenced`, `min=<int>`, `limit=<int>`.
- Guards: min-dimension (default 200) rejects junk matches; post-write getimagesize verify with rollback; referenced files only unless `unreferenced`.
- Every applied repair backs up the broken original to a manifest dir (fully reversible).
- Validated locally end to end: corrupt 31-byte HTML -> valid 22,675-byte JPEG, file_managed corrected.