### PR TITLE
feat(image-restore): local->prod backup restore pipeline + media migration prep

### DIFF
--- a/docs/IMAGE-BACKUP-RESTORE-AND-MEDIA-MIGRATION.md
+++ b/docs/IMAGE-BACKUP-RESTORE-AND-MEDIA-MIGRATION.md
@@ -1,0 +1,128 @@
+# Image Backup Restore (local -> prod) + Media Migration Prep
+
+Companion to `docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md`. Covers two things:
+1. Restoring the ~8,558 still-broken prod images from the Feb-2018 D7 backup,
+   pushed from local over SSH.
+2. Preparing for a proper migration of images into Drupal Media entities.
+
+## Source of truth
+
+- Pre-corruption backup: `~/000 SAHO WEBSITE 2018/sites/default/files`
+  (27 GB, 103,268 image files, 48,623 distinct names; Feb-2018 D7 site).
+- Prod still-broken set: the latest Phase A audit CSV on prod
+  (`private/image-audit-*.csv`), verdicts html / empty / truncated / missing.
+- Key fact: prod `file_managed.filesize` kept the ORIGINAL (pre-corruption)
+  size, so a backup file whose byte size equals `db_size` is provably the same
+  image - a collision-proof match.
+
+## Part 1 - Restore pipeline (3 stages)
+
+All staging/matching happens LOCAL (where the 27 GB backup lives). Only a small
+matched subset is pushed to prod. Both scripts are dry-run / read-only first.
+
+### Stage 1 (LOCAL): pull the prod audit CSV down
+
+```bash
+# from your local machine; fill in the SSH host
+scp sahistrg878@PROD_HOST:/home/sahistrg878/public_html/sahistory.org.za/private/image-audit-20260630-164831.csv \
+  ~/saho-image-audit.csv
+```
+
+### Stage 2 (LOCAL): match against the 2018 backup and stage originals
+
+```bash
+cd ~/ddev-projects/sahistory-web
+php scripts/backup-restore-stage.php \
+  ~/saho-image-audit.csv \
+  "~/000 SAHO WEBSITE 2018/sites/default/files" \
+  ~/saho-restore-staging \
+  min=100
+```
+
+Output: `~/saho-restore-staging/` containing the matched originals laid out by
+their target relative path, plus `restore-manifest.csv`. The summary prints
+matched_exact / matched_largest / miss_no_name / miss_too_small - i.e. exactly
+how many of the broken set the 2018 backup can recover.
+
+### Stage 3a (TRANSPORT): push the staging tree to prod over SSH
+
+```bash
+# dry-run first to see what would transfer
+rsync -avz --dry-run ~/saho-restore-staging/ \
+  sahistrg878@PROD_HOST:/home/sahistrg878/public_html/sahistory.org.za/private/saho-restore-staging/
+
+# then for real (drop --dry-run)
+rsync -avz ~/saho-restore-staging/ \
+  sahistrg878@PROD_HOST:/home/sahistrg878/public_html/sahistory.org.za/private/saho-restore-staging/
+```
+
+### Stage 3b (PROD over SSH): apply into place
+
+```bash
+ssh sahistrg878@PROD_HOST
+cd ~/public_html/sahistory.org.za
+
+# dry-run (writes nothing)
+vendor/bin/drush php:script scripts/backup-restore-apply.php private/saho-restore-staging
+
+# careful first batch, then full
+vendor/bin/drush php:script scripts/backup-restore-apply.php private/saho-restore-staging apply limit=200
+# spot-check a few image URLs in a browser, then:
+vendor/bin/drush php:script scripts/backup-restore-apply.php private/saho-restore-staging apply
+```
+
+Each apply backs up the file it overwrites (rollback manifest in the staging
+dir), validates with getimagesize, updates file_managed.filesize/filemime, and
+flushes that file's style derivatives.
+
+### Verify + close out
+
+```bash
+vendor/bin/drush php:script scripts/image-audit-disk.php   # corrupt count -> ~0
+vendor/bin/drush watchdog:delete --type=image              # clear the log
+```
+
+## Part 2 - Media migration prep
+
+DO THIS AFTER restoration. Migrating corrupt/placeholder files into Media would
+just enshrine the breakage; the restore above is the prerequisite, and the audit
+CSV is the clean inventory the migration consumes.
+
+### Target state
+- Each healthy image file -> a `media` entity of bundle `image`.
+- Legacy file/image fields on nodes -> entity-reference (media) fields.
+- Inline `<img src="/sites/default/files/...">` in body HTML -> `<drupal-media>`
+  embeds (CKEditor 5 media library).
+- The legacy redundant triple-path duplicates collapse to one reusable media
+  entity (see the duplicate clusters surfaced during restoration).
+
+### Modules
+- Core: `media`, `media_library` (enabled?), `migrate`, `migrate_plus`,
+  `migrate_tools`.
+- Embeds: CKEditor 5 media embed; optionally `linkit`.
+
+### Approach (staged, reversible)
+1. INVENTORY: from the final audit CSV, list every `ok` image file_managed
+   entity (post-restore) with its referencing entities/fields.
+2. DEDUPE: group by content hash (sha1 of bytes) so the triple-path duplicates
+   become one media entity; keep a canonical path per group.
+3. CREATE MEDIA: batch-create one `media:image` per canonical file (idempotent;
+   skip if a media entity already wraps that fid).
+4. REWRITE REFERENCES:
+   - file/image fields -> media reference fields (add new field, backfill,
+     then switch display; keep old field until verified).
+   - inline body `<img>` -> `<drupal-media data-entity-uuid=...>` via a guarded
+     body rewriter (same pattern as saho_linkfix's BodyLinkRewriter:
+     additive, tested, dry-run).
+5. VERIFY: render sampled nodes (Playwright), confirm images + responsive styles.
+6. CUTOVER: switch theme/templates to media render; retire legacy fields.
+
+### Sequencing
+restore (Part 1) -> dedupe inventory -> media create -> reference rewrite ->
+verify -> cutover. Each step ships behind its own PR + tag, dry-run first.
+
+## Safety
+- Production is live. Every write step is dry-run by default and backs up what
+  it overwrites.
+- Matching/staging is fully local; only a vetted subset is transported.
+- No legacy field is dropped until its media replacement is verified.

--- a/scripts/backup-restore-apply.php
+++ b/scripts/backup-restore-apply.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * @file
+ * Backup restore - PROD apply step (dry-run by default).
+ *
+ * Consumes a staging tree produced by backup-restore-stage.php (transported
+ * to prod) and copies each staged original onto its live target path,
+ * validates it, flushes that file's style derivatives, and corrects
+ * file_managed.filesize / filemime.
+ *
+ * SAFE BY DEFAULT: with no "apply" token it only reports - changes nothing.
+ * Every applied restore first backs up the existing file for rollback.
+ *
+ *   drush php:script scripts/backup-restore-apply.php <staging-root>
+ *   drush php:script scripts/backup-restore-apply.php <staging-root> apply
+ *   drush php:script scripts/backup-restore-apply.php <staging-root> apply limit=200
+ *
+ * <staging-root> must contain restore-manifest.csv and the staged files laid
+ * out by their target relative path.
+ *
+ * See docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md.
+ */
+
+use Drupal\Core\Database\Database;
+use Drupal\image\Entity\ImageStyle;
+
+$tokens = $extra ?? ($args ?? []);
+$staging = NULL;
+$apply = FALSE;
+$limit = 0;
+foreach ($tokens as $t) {
+  if ($t === 'apply') {
+    $apply = TRUE;
+  }
+  elseif (strpos($t, 'limit=') === 0) {
+    $limit = (int) substr($t, 6);
+  }
+  elseif ($t !== '' && $t[0] !== '-') {
+    $staging = rtrim($t, '/');
+  }
+}
+
+$manifest_csv = $staging ? $staging . '/restore-manifest.csv' : NULL;
+if (!$staging || !is_dir($staging) || !is_file($manifest_csv)) {
+  echo "ERROR: pass the staging-root dir (must contain restore-manifest.csv).\n";
+  echo "  drush php:script scripts/backup-restore-apply.php /path/to/staging\n";
+  return;
+}
+
+$file_system = \Drupal::service('file_system');
+$connection = Database::getConnection();
+$public_root = rtrim($file_system->realpath('public://'), '/');
+
+$run_id = date('Ymd-His');
+$backup_dir = $staging . '/applied-backup-' . $run_id;
+$applied_manifest = $staging . '/applied-manifest-' . $run_id . '.csv';
+$action_path = $staging . '/apply-actions-' . $run_id . '.csv';
+
+if ($apply && !is_dir($backup_dir)) {
+  mkdir($backup_dir, 0775, TRUE);
+}
+
+$action = fopen($action_path, 'w');
+fputcsv($action, ['target_uri', 'staged_file', 'match_type', 'decision', 'note']);
+
+$man = NULL;
+if ($apply) {
+  $man = fopen($applied_manifest, 'w');
+  fputcsv($man, [
+    'target_uri', 'target_abs', 'backup_abs', 'staged_file',
+    'old_filesize', 'new_filesize', 'new_filemime',
+  ]);
+}
+
+$counts = [
+  'restored' => 0,
+  'would_restore' => 0,
+  'skip_staged_missing' => 0,
+  'skip_staged_invalid' => 0,
+  'failed_write' => 0,
+  'failed_verify' => 0,
+  'skip_no_fid' => 0,
+];
+
+$in = fopen($manifest_csv, 'r');
+$header = fgetcsv($in);
+$col = array_flip($header);
+$processed = 0;
+
+while (($r = fgetcsv($in)) !== FALSE) {
+  if ($limit && $processed >= $limit) {
+    break;
+  }
+  $uri = $r[$col['target_uri']];
+  $rel = $r[$col['target_rel']];
+  $match_type = $r[$col['match_type']] ?? '';
+  $staged_file = $staging . '/' . $rel;
+
+  if (!is_file($staged_file)) {
+    fputcsv($action, [$uri, $staged_file, $match_type, 'skip_staged_missing', '']);
+    $counts['skip_staged_missing']++;
+    continue;
+  }
+  $info = @getimagesize($staged_file);
+  if ($info === FALSE) {
+    fputcsv($action, [$uri, $staged_file, $match_type, 'skip_staged_invalid', '']);
+    $counts['skip_staged_invalid']++;
+    continue;
+  }
+
+  // Confirm a file_managed row exists for this uri.
+  $fid = $connection->query('SELECT fid FROM {file_managed} WHERE uri = :u', [':u' => $uri])->fetchField();
+  if (!$fid) {
+    fputcsv($action, [$uri, $staged_file, $match_type, 'skip_no_fid', 'no file_managed row']);
+    $counts['skip_no_fid']++;
+    continue;
+  }
+
+  $processed++;
+  $target = $public_root . '/' . $rel;
+
+  if (!$apply) {
+    fputcsv($action, [$uri, $staged_file, $match_type, 'would_restore', $info[0] . 'x' . $info[1]]);
+    $counts['would_restore']++;
+    continue;
+  }
+
+  // --- APPLY ---
+  $old_size = is_file($target) ? filesize($target) : 0;
+  $backup_abs = '';
+  if (is_file($target)) {
+    $backup_abs = $backup_dir . '/' . $fid . '-' . basename($target);
+    @copy($target, $backup_abs);
+  }
+  $tdir = dirname($target);
+  if (!is_dir($tdir)) {
+    mkdir($tdir, 0775, TRUE);
+  }
+  if (!@copy($staged_file, $target)) {
+    fputcsv($action, [$uri, $staged_file, $match_type, 'failed_write', '']);
+    $counts['failed_write']++;
+    continue;
+  }
+  $verify = @getimagesize($target);
+  if ($verify === FALSE) {
+    if ($backup_abs && is_file($backup_abs)) {
+      @copy($backup_abs, $target);
+    }
+    fputcsv($action, [$uri, $staged_file, $match_type, 'failed_verify', 'rolled back']);
+    $counts['failed_verify']++;
+    continue;
+  }
+
+  $new_size = filesize($target);
+  $new_mime = $verify['mime'] ?? 'image/jpeg';
+  $connection->update('file_managed')
+    ->fields(['filesize' => $new_size, 'filemime' => $new_mime])
+    ->condition('fid', $fid)
+    ->execute();
+
+  try {
+    foreach (ImageStyle::loadMultiple() as $style) {
+      $style->flush($uri);
+    }
+  }
+  catch (\Throwable $e) {
+    // Non-fatal: derivatives regenerate on next request.
+  }
+
+  fputcsv($man, [$uri, $target, $backup_abs, $staged_file, $old_size, $new_size, $new_mime]);
+  fputcsv($action, [$uri, $staged_file, $match_type, 'restored', $verify[0] . 'x' . $verify[1]]);
+  $counts['restored']++;
+  if ($counts['restored'] % 500 === 0) {
+    echo '  restored ' . $counts['restored'] . " ...\n";
+  }
+}
+
+fclose($in);
+fclose($action);
+if ($man) {
+  fclose($man);
+}
+
+echo "\n=== Backup restore " . ($apply ? 'APPLY' : 'DRY-RUN') . " complete ===\n";
+foreach ($counts as $k => $v) {
+  if ($v > 0 || in_array($k, ['restored', 'would_restore'], TRUE)) {
+    echo sprintf("  %-20s %d\n", $k, $v);
+  }
+}
+echo "Action report: $action_path\n";
+if ($apply) {
+  echo "Rollback manifest: $applied_manifest\n";
+  echo "Backups: $backup_dir\n";
+}
+else {
+  echo "Re-run with 'apply' appended to write these restores.\n";
+}

--- a/scripts/backup-restore-stage.php
+++ b/scripts/backup-restore-stage.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * @file
+ * Backup restore - LOCAL staging step (read-only against prod; standalone PHP).
+ *
+ * Matches the still-broken production images (from a Phase A audit CSV) against
+ * a pre-corruption files backup tree (e.g. the Feb-2018 D7 files tree), and
+ * copies the matched ORIGINALS into a staging directory laid out by their
+ * target relative path - ready to transport to prod and copy into place.
+ *
+ * Runs with plain PHP (no Drupal needed): the audit CSV already carries the uri
+ * and the original db_size, which is all the matcher needs.
+ *
+ *   php scripts/backup-restore-stage.php \
+ *     <audit.csv> <backup-files-root> <staging-out> [min=100]
+ *
+ * Match priority (per broken file, by basename):
+ *   1. EXACT db_size match - a backup file whose byte size equals the size
+ *      Drupal recorded before corruption. Provably the same image, collision
+ *      proof. (db_size must be > 0.)
+ *   2. Largest valid image >= min dimension, when no exact-size match exists.
+ * Files with no same-name candidate, or only sub-min candidates, are misses.
+ *
+ * Only public:// images are handled. Writes a manifest CSV next to the staging
+ * dir: target_uri,target_rel,source_path,matched_size,match_type,dimensions.
+ *
+ * See docs/IMAGE-CORRUPTION-RESTORATION-PLAN.md.
+ */
+
+$audit = $argv[1] ?? NULL;
+$backup_root = isset($argv[2]) ? rtrim($argv[2], '/') : NULL;
+$staging = isset($argv[3]) ? rtrim($argv[3], '/') : NULL;
+$min_dim = 100;
+foreach (array_slice($argv, 4) as $a) {
+  if (strpos($a, 'min=') === 0) {
+    $min_dim = (int) substr($a, 4);
+  }
+}
+
+if (!$audit || !is_file($audit) || !$backup_root || !is_dir($backup_root) || !$staging) {
+  fwrite(STDERR, "Usage: php scripts/backup-restore-stage.php <audit.csv> <backup-files-root> <staging-out> [min=100]\n");
+  exit(1);
+}
+
+@mkdir($staging, 0775, TRUE);
+$manifest_path = $staging . '/restore-manifest.csv';
+
+// 1. Index the backup tree by basename -> list of absolute paths.
+fwrite(STDERR, "Indexing backup tree under $backup_root ...\n");
+$index = [];
+$exts = ['jpg' => 1, 'jpeg' => 1, 'png' => 1, 'gif' => 1];
+$it = new RecursiveIteratorIterator(
+  new RecursiveDirectoryIterator($backup_root, FilesystemIterator::SKIP_DOTS),
+  RecursiveIteratorIterator::LEAVES_ONLY
+);
+$indexed = 0;
+foreach ($it as $file) {
+  if (!$file->isFile()) {
+    continue;
+  }
+  $ext = strtolower($file->getExtension());
+  if (!isset($exts[$ext])) {
+    continue;
+  }
+  $bn = strtolower($file->getFilename());
+  $index[$bn][] = $file->getPathname();
+  $indexed++;
+}
+fwrite(STDERR, "Indexed $indexed backup image files (" . count($index) . " distinct names).\n");
+
+// 2. Walk the audit CSV broken rows and match.
+$broken_verdicts = ['html' => 1, 'empty' => 1, 'truncated' => 1, 'missing' => 1];
+
+$in = fopen($audit, 'r');
+$header = fgetcsv($in);
+$col = array_flip($header);
+
+$out = fopen($manifest_path, 'w');
+fputcsv($out, ['target_uri', 'target_rel', 'source_path', 'matched_size', 'match_type', 'dimensions']);
+
+$stats = [
+  'matched_exact' => 0,
+  'matched_largest' => 0,
+  'miss_no_name' => 0,
+  'miss_too_small' => 0,
+  'skip_nonpublic' => 0,
+];
+
+/**
+ * Picks the largest valid image >= min dimension from candidate paths.
+ */
+$best_valid = function (array $paths) use ($min_dim) {
+  $best = NULL;
+  foreach ($paths as $p) {
+    $info = @getimagesize($p);
+    if ($info === FALSE) {
+      continue;
+    }
+    if ($info[0] < $min_dim || $info[1] < $min_dim) {
+      continue;
+    }
+    $area = $info[0] * $info[1];
+    if ($best === NULL || $area > $best['area']) {
+      $best = ['area' => $area, 'w' => $info[0], 'h' => $info[1], 'path' => $p];
+    }
+  }
+  return $best;
+};
+
+while (($r = fgetcsv($in)) !== FALSE) {
+  $verdict = $r[$col['verdict']] ?? '';
+  if (!isset($broken_verdicts[$verdict])) {
+    continue;
+  }
+  $uri = $r[$col['uri']];
+  $db_size = (int) ($r[$col['db_size']] ?? 0);
+
+  if (strpos($uri, 'public://') !== 0) {
+    $stats['skip_nonpublic']++;
+    continue;
+  }
+  $rel = substr($uri, strlen('public://'));
+  $bn = strtolower(basename($rel));
+
+  $candidates = $index[$bn] ?? [];
+  if (!$candidates) {
+    $stats['miss_no_name']++;
+    continue;
+  }
+
+  // Priority 1: exact recorded-size match (collision proof).
+  $chosen = NULL;
+  $match_type = '';
+  $dims = '';
+  if ($db_size > 0) {
+    foreach ($candidates as $p) {
+      if (filesize($p) === $db_size) {
+        $info = @getimagesize($p);
+        if ($info !== FALSE) {
+          $chosen = $p;
+          $match_type = 'exact_size';
+          $dims = $info[0] . 'x' . $info[1];
+          break;
+        }
+      }
+    }
+  }
+
+  // Priority 2: largest valid image >= min dimension.
+  if ($chosen === NULL) {
+    $best = $best_valid($candidates);
+    if ($best === NULL) {
+      $stats['miss_too_small']++;
+      continue;
+    }
+    $chosen = $best['path'];
+    $match_type = 'largest';
+    $dims = $best['w'] . 'x' . $best['h'];
+  }
+
+  // Stage the chosen original under its TARGET relative path.
+  $dest = $staging . '/' . $rel;
+  @mkdir(dirname($dest), 0775, TRUE);
+  if (@copy($chosen, $dest)) {
+    fputcsv($out, [$uri, $rel, $chosen, filesize($chosen), $match_type, $dims]);
+    $stats[$match_type === 'exact_size' ? 'matched_exact' : 'matched_largest']++;
+  }
+}
+
+fclose($in);
+fclose($out);
+
+$matched = $stats['matched_exact'] + $stats['matched_largest'];
+echo "\n=== Backup restore staging complete ===\n";
+echo "min dimension: $min_dim\n";
+foreach ($stats as $k => $v) {
+  echo sprintf("  %-18s %d\n", $k, $v);
+}
+echo "TOTAL staged for transport: $matched\n";
+echo "Staging dir: $staging\n";
+echo "Manifest: $manifest_path\n";
+echo "Next: rsync the staging dir to prod, then apply with the prod-side copy step.\n";


### PR DESCRIPTION
Recover the ~8,558 still-broken prod images (no on-disk twin) from the **Feb-2018 D7 files backup** (27 GB, 103k images). Wayback has no pre-2019 captures, so this backup is the only real source.

## Scripts
- `backup-restore-stage.php` (LOCAL, standalone PHP): matches the prod audit CSV broken set against the 2018 tree by basename, preferring an **exact `file_managed.filesize` match** (collision-proof - filesize kept the original size), else largest valid image >= min dim. Stages matched originals + manifest. Validated against the real backup (4/4 exact-size matches).
- `backup-restore-apply.php` (PROD, dry-run default): copies staged originals into place, validates, flushes derivatives, corrects file_managed; reversible per-file backup. Validated on local DDEV.

## Docs
3-stage SSH transport runbook (scp audit down -> stage local -> rsync up -> drush apply) + staged media-entity migration prep (restore first, then dedupe -> media create -> reference rewrite -> verify -> cutover).