### PR TITLE
fix(linkfix): portable work-dir + config-managed enable (v1.22.1)

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -110,6 +110,7 @@ module:
   saho_donate: 0
   saho_example_block: 0
   saho_featured_articles: 0
+  saho_linkfix: 0
   saho_media_migration: 0
   saho_performance: 0
   saho_publications: 0

--- a/webroot/modules/custom/saho_linkfix/README.md
+++ b/webroot/modules/custom/saho_linkfix/README.md
@@ -48,8 +48,10 @@ drush saho:linkfix-redirects-rollback   # delete redirects a run created
 drush saho:linkfix-rewrite-rollback     # restore bodies a run changed
 ```
 
-Work artifacts live in `sites/default/files/saho_linkfix_work/`. Every `--apply`
-run writes a rollback file.
+Work artifacts live in `public://saho_linkfix_work/` (resolved per-environment
+via Drupal's stream wrapper, so the commands work on local and prod without a
+path override). A deny-all `.htaccess` is written into that directory on
+creation. Every `--apply` run writes a rollback file there.
 
 ## Safety guarantees (asserted by tests)
 
@@ -63,9 +65,17 @@ run writes a rollback file.
 
 ## Deployment
 
+The module is in exported config (`core.extension.yml`), so `drush cim` keeps it
+enabled - it will not be silently disabled by a config import on deploy.
+
 1. Deploy code; the `.htaccess.custom` change re-scaffolds to `webroot/.htaccess`
-   via `composer drupal:scaffold` (the live file is gitignored).
-2. `drush cr`, then dry-run `saho:linkfix-scan`/`-redirects`/`-rewrite`.
+   via `composer drupal:scaffold` (the live file is gitignored). Run
+   `drush cim` (or `drush en saho_linkfix -y`) in the same step so the module is
+   enabled the moment the `.htaccess` search-block is removed - otherwise legacy
+   `.htm` URLs hard-404 in the gap between deploy and enable.
+2. `drush cr`, then dry-run `saho:linkfix-scan`/`-redirects`/`-rewrite` (default
+   paths now resolve via `public://`, no override needed).
 3. Apply redirects, verify, apply rewrites; archive the rollback files.
 4. Confirm a sample legacy URL 301s to the exact node and an unmapped one falls
    back to typed search. Cloudflare caches the 301s.
+   `BASE_URL=https://sahistory.org.za bash scripts/linkfix/verify-legacy-urls.sh`

--- a/webroot/modules/custom/saho_linkfix/src/Drush/Commands/SahoLinkfixCommands.php
+++ b/webroot/modules/custom/saho_linkfix/src/Drush/Commands/SahoLinkfixCommands.php
@@ -52,8 +52,8 @@ final class SahoLinkfixCommands extends DrushCommands {
   #[CLI\Option(name: 'gaps', description: 'Unmapped legacy links CSV output path.')]
   public function scan(
     array $options = [
-      'out' => '/var/www/html/webroot/sites/default/files/saho_linkfix_work/candidates.json',
-      'gaps' => '/var/www/html/webroot/sites/default/files/saho_linkfix_work/gaps.csv',
+      'out' => 'public://saho_linkfix_work/candidates.json',
+      'gaps' => 'public://saho_linkfix_work/gaps.csv',
     ],
   ): void {
     $this->ensureDir(dirname($options['out']));
@@ -131,9 +131,9 @@ final class SahoLinkfixCommands extends DrushCommands {
   #[CLI\Option(name: 'rollback-out', description: 'Where to write created redirect ids.')]
   public function redirects(
     array $options = [
-      'in' => '/var/www/html/webroot/sites/default/files/saho_linkfix_work/candidates.json',
+      'in' => 'public://saho_linkfix_work/candidates.json',
       'apply' => FALSE,
-      'rollback-out' => '/var/www/html/webroot/sites/default/files/saho_linkfix_work/redirects_rollback.json',
+      'rollback-out' => 'public://saho_linkfix_work/redirects_rollback.json',
     ],
   ): void {
     $candidates = $this->readJson($options['in']);
@@ -167,9 +167,9 @@ final class SahoLinkfixCommands extends DrushCommands {
   #[CLI\Option(name: 'rollback-out', description: 'Where to write the body snapshot rollback.')]
   public function rewrite(
     array $options = [
-      'in' => '/var/www/html/webroot/sites/default/files/saho_linkfix_work/candidates.json',
+      'in' => 'public://saho_linkfix_work/candidates.json',
       'apply' => FALSE,
-      'rollback-out' => '/var/www/html/webroot/sites/default/files/saho_linkfix_work/rewrite_rollback.json',
+      'rollback-out' => 'public://saho_linkfix_work/rewrite_rollback.json',
     ],
   ): void {
     $candidates = $this->readJson($options['in']);
@@ -205,7 +205,7 @@ final class SahoLinkfixCommands extends DrushCommands {
   #[CLI\Option(name: 'apply', description: 'Actually delete.')]
   public function redirectsRollback(
     array $options = [
-      'in' => '/var/www/html/webroot/sites/default/files/saho_linkfix_work/redirects_rollback.json',
+      'in' => 'public://saho_linkfix_work/redirects_rollback.json',
       'apply' => FALSE,
     ],
   ): void {
@@ -221,7 +221,7 @@ final class SahoLinkfixCommands extends DrushCommands {
   #[CLI\Option(name: 'apply', description: 'Actually restore bodies.')]
   public function rewriteRollback(
     array $options = [
-      'in' => '/var/www/html/webroot/sites/default/files/saho_linkfix_work/rewrite_rollback.json',
+      'in' => 'public://saho_linkfix_work/rewrite_rollback.json',
       'apply' => FALSE,
     ],
   ): void {


### PR DESCRIPTION
Closes #410. Hardens `saho_linkfix` for deploys after the v1.22.0 production rollout exposed two rough edges.

## Changes
- **Portable work dir** — Drush command defaults move from the hardcoded container path `/var/www/html/webroot/sites/default/files/saho_linkfix_work` to `public://saho_linkfix_work`, resolved per-environment via Drupal's stream wrapper. No more manual `--out/--in/--rollback-out` overrides on prod. Deny-all `.htaccess` still written into the dir. Verified: `drush saho:linkfix-scan` with default paths writes to the resolved files dir + creates the `.htaccess`.
- **Config-managed enable** — added `saho_linkfix` to `core.extension.yml` so `drush cim` keeps it enabled. Previously the module wasn't in exported config, so a config import could silently disable it (re-breaking every legacy link), and deploy-before-enable hard-404'd legacy `.htm`. README deploy notes updated to enable in the same step as the `.htaccess` scaffold.

## Testing
- 20 kernel tests pass; phpcs + drupal-check clean
- `public://` default verified to resolve + write correctly in a real Drush run
- `core.extension.yml` diff is exactly one line (`saho_linkfix: 0`); no other module drift included

No behaviour change for end users; production redirects/rewrites from v1.22.0 are untouched.