### PR TITLE
fix(csp): allow shop.sahistory.org.za in img-src

### DIFF
--- a/config/sync/seckit.settings.yml
+++ b/config/sync/seckit.settings.yml
@@ -11,7 +11,7 @@ seckit_xss:
     script-src: "'self' 'unsafe-inline' 'unsafe-eval' www.google-analytics.com www.googletagmanager.com *.googleapis.com static.cloudflareinsights.com unpkg.com translate.googleapis.com"
     object-src: "'self'"
     style-src: "'self' 'unsafe-inline' fonts.googleapis.com unpkg.com"
-    img-src: "'self' data: www.google-analytics.com www.googletagmanager.com v1.sahistory.org.za http://v1.sahistory.org.za http://www.v1.sahistory.org.za https://v1.sahistory.org.za *.tile.openstreetmap.org unpkg.com http://www.sahistory.org.za http://sahistory.org.za https://www.sahistory.org.za translate.google.com translate.googleapis.com fonts.gstatic.com"
+    img-src: "'self' data: www.google-analytics.com www.googletagmanager.com v1.sahistory.org.za http://v1.sahistory.org.za http://www.v1.sahistory.org.za https://v1.sahistory.org.za *.tile.openstreetmap.org unpkg.com http://www.sahistory.org.za http://sahistory.org.za https://www.sahistory.org.za translate.google.com translate.googleapis.com fonts.gstatic.com https://shop.sahistory.org.za"
     media-src: "'self'"
     frame-src: "'self' www.youtube.com youtube.com"
     frame-ancestors: "'self'"


### PR DESCRIPTION
Main-site pages (homepage publications section) embed book/publication covers hosted on shop.sahistory.org.za. The seckit CSP `img-src` allowlist omitted that host, so every cover load fired a **report-only** CSP violation that flooded the seckit watchdog log. (Report-only = images still displayed; this was log noise, not a broken display.) Adds `https://shop.sahistory.org.za` to img-src - stops the reports and keeps the policy correct for any future enforce-mode switch.