### PR TITLE
fix(csp): allow https: images/fonts + Google Maps/Translate frames

### DIFF
--- a/config/sync/seckit.settings.yml
+++ b/config/sync/seckit.settings.yml
@@ -11,12 +11,12 @@ seckit_xss:
     script-src: "'self' 'unsafe-inline' 'unsafe-eval' www.google-analytics.com www.googletagmanager.com *.googleapis.com static.cloudflareinsights.com unpkg.com translate.googleapis.com"
     object-src: "'self'"
     style-src: "'self' 'unsafe-inline' fonts.googleapis.com unpkg.com"
-    img-src: "'self' data: www.google-analytics.com www.googletagmanager.com v1.sahistory.org.za http://v1.sahistory.org.za http://www.v1.sahistory.org.za https://v1.sahistory.org.za *.tile.openstreetmap.org unpkg.com http://www.sahistory.org.za http://sahistory.org.za https://www.sahistory.org.za translate.google.com translate.googleapis.com fonts.gstatic.com https://shop.sahistory.org.za"
+    img-src: "'self' data: www.google-analytics.com www.googletagmanager.com v1.sahistory.org.za http://v1.sahistory.org.za http://www.v1.sahistory.org.za https://v1.sahistory.org.za *.tile.openstreetmap.org unpkg.com http://www.sahistory.org.za http://sahistory.org.za https://www.sahistory.org.za translate.google.com translate.googleapis.com fonts.gstatic.com https://shop.sahistory.org.za https:"
     media-src: "'self'"
-    frame-src: "'self' www.youtube.com youtube.com"
+    frame-src: "'self' www.youtube.com youtube.com https://www.google.com https://maps.google.com https://maps.google.co.za https://translate.google.com"
     frame-ancestors: "'self'"
     child-src: "'self'"
-    font-src: "'self' fonts.gstatic.com data:"
+    font-src: "'self' fonts.gstatic.com data: https:"
     connect-src: "'self' *.google-analytics.com www.google-analytics.com www.googletagmanager.com translate.googleapis.com"
     report-uri: /report-csp-violation
     upgrade-req: true


### PR DESCRIPTION
Follow-up to #415. The report-only CSP was flooding the seckit log with a long tail of legit third-party resources (ShareThis, scite.ai, Google Maps, editor-embedded external images). Allowlisting each domain is whack-a-mole, so tune by category: `img-src` and `font-src` allow `https:` (covers all external images/fonts/widgets), `frame-src` adds Google Maps/Translate. `script-src` stays strict - images/fonts are low-risk. Silences the noise and makes the policy enforce-ready.