### PR TITLE
fix(theme): empty page hero renders blank 420px gap (#390)

### DIFF
--- a/webroot/themes/custom/saho/templates/content/node--page.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--page.html.twig
@@ -17,7 +17,10 @@
 #}
 
 {# ─── Pre-flight checks ──────────────────────────────────────────────────── #}
-{% set has_hero    = node.field_image.entity is not empty %}
+{# Index the first delta directly: node.field_image.entity triggers an
+   appendItem() side-effect on an empty field, which makes the guard wrongly
+   truthy and renders an empty <img src=""> hero (huge gap). #}
+{% set has_hero    = node.field_image.0.entity is not empty %}
 {% set has_files   = node.field_file_upload is not empty %}
 {% set has_comments = content.comment_node_page is defined and content.comment_node_page|render|trim %}
 


### PR DESCRIPTION
Closes #390.

## Problem
`/funders` (node 96296, basic page) showed a huge empty gap above the "Current Funders" content. Cause: the page-hero guard in `node--page.html.twig` used `node.field_image.entity is not empty`. On a node with an **empty** `field_image`, Twig's `.entity` access triggers `FieldItemList::__get`'s `appendItem()` side-effect, so the guard evaluates truthy and the template emits `<img src="" alt="Funders">` — a 420px blank hero. This affected **every** basic page without its own image.

## Fix
Guard on the first delta — `node.field_image.0.entity is not empty` — which is null for an empty field (no `appendItem`) and also false for a present-but-broken file reference (relevant given the known legacy image corruption).

## Verification (Playwright, local DDEV)
- node 96296 (empty `field_image`): hero **gone**, "Current Funders" moves from y=850 → y=390 (gap closed)
- node 59088 (real `field_image`): hero **still renders** (no regression)
- Direct `renderPlain` of the node confirms `saho-page-hero` is absent for the empty case and present for the populated case

One-line template guard change; no module/CSS changes.