### PR TITLE
fix(theme): guard suggested-reading cards against null related entities

### DIFF
--- a/webroot/themes/custom/saho/templates/content/saho-suggested-reading.html.twig
+++ b/webroot/themes/custom/saho/templates/content/saho-suggested-reading.html.twig
@@ -23,6 +23,9 @@
         <div class="saho-cards-grid">
           {% for item in items %}
             {% set entity = item.entity %}
+            {# Skip references whose target entity is missing/deleted so we
+               never render a /node/null (or /<type>/null) link. #}
+            {% if entity %}
             {% set image_url = null %}
 
 {# Get image URL based on content type and available fields #}
@@ -113,6 +116,7 @@
                 </div>
               </a>
             </div>
+            {% endif %}
           {% endfor %}
         </div>
       </div>


### PR DESCRIPTION
Root cause of the **14,835-hit NULL-bug** (`/archive/null`, `/people/null`, `/dated-event/null`...). The Suggested Reading block renders each `field_*_related_tab` reference as a card linking to `path('entity.node.canonical', {node: entity.id()})`. When a related reference points at a deleted entity, `item.entity` is null → `entity.id()` null → `/node/null` (and `/<type>/null` via related-field formatters). Confirmed page-generated (not bots) via prod access log: real on-site Referer `/people/billy-nair`. Fix wraps the card in `{% if entity %}`. Verified biography page renders 200, no twig error.