### PR TITLE
fix(deps): patch file_entity for Drupal 11.4 typed-property compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -227,6 +227,9 @@
             },
             "drupal/payfast_donation_block": {
                 "Drupal 11 compatibility: Add ^11 to core_version_requirement": "patches/payfast_donation_block-drupal11-compatibility.patch"
+            },
+            "drupal/file_entity": {
+                "Drupal 11.4 compatibility: type FileImageResponsiveFormatter::$currentUser to match core ImageFormatter": "patches/file_entity-drupal11.4-currentuser-type.patch"
             }
         },
         "merge-plugin": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb4c38ddd3b6f60e88d616309bae79fc",
+    "content-hash": "1b7feb78515a23cf3f445fc36f01e312",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -67,7 +67,7 @@
             "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jquery/jquery-dist.git",
+                "url": "git@github.com:jquery/jquery-dist.git",
                 "reference": "cfd8e3a885dca7b406791c1eed472af9dd717e8e"
             },
             "dist": {

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,5 +1,5 @@
 {
-    "_hash": "dcda8c274baa44fa01056f56e476031d115e247a45e893446f5cc7d7d3222c7f",
+    "_hash": "b12ce82195e580fcf55d783bbfa1d26f9a10c960f47d4369e04987e85b921d30",
     "patches": {
         "drupal/list_inline_block": [
             {
@@ -43,6 +43,18 @@
                 "description": "Drupal 11 compatibility: Add ^11 to core_version_requirement",
                 "url": "patches/payfast_donation_block-drupal11-compatibility.patch",
                 "sha256": "165dfc75b35b58c437def5cf9a8a5d5c6aebcbca73fd43247fee7cb8053e7ff1",
+                "depth": 1,
+                "extra": {
+                    "provenance": "root"
+                }
+            }
+        ],
+        "drupal/file_entity": [
+            {
+                "package": "drupal/file_entity",
+                "description": "Drupal 11.4 compatibility: type FileImageResponsiveFormatter::$currentUser to match core ImageFormatter",
+                "url": "patches/file_entity-drupal11.4-currentuser-type.patch",
+                "sha256": "40ff4744e2563a95174cbaf845bad6392dfb41f17b721499b31e973d11ee7928",
                 "depth": 1,
                 "extra": {
                     "provenance": "root"

--- a/patches/file_entity-drupal11.4-currentuser-type.patch
+++ b/patches/file_entity-drupal11.4-currentuser-type.patch
@@ -1,15 +1,13 @@
 diff --git a/src/Plugin/Field/FieldFormatter/FileImageResponsiveFormatter.php b/src/Plugin/Field/FieldFormatter/FileImageResponsiveFormatter.php
-index 1234567..abcdefg 100644
 --- a/src/Plugin/Field/FieldFormatter/FileImageResponsiveFormatter.php
 +++ b/src/Plugin/Field/FieldFormatter/FileImageResponsiveFormatter.php
-@@ -35,20 +35,20 @@ class FileImageResponsiveFormatter extends ImageFormatter {
-    * The image style entity storage.
+@@ -37,21 +37,21 @@
     *
     * @var \Drupal\Core\Entity\EntityStorageInterface
     */
 -  protected $imageStyleStorage;
 +  protected EntityStorageInterface $imageStyleStorage;
-
+ 
    /**
     * The current user.
     *
@@ -17,7 +15,7 @@ index 1234567..abcdefg 100644
     */
 -  protected $currentUser;
 +  protected AccountInterface $currentUser;
-
+ 
    /**
     * The link generator.
     *
@@ -25,6 +23,6 @@ index 1234567..abcdefg 100644
     */
 -  protected $linkGenerator;
 +  protected LinkGeneratorInterface $linkGenerator;
-
+ 
    /**
     * {@inheritdoc}

--- a/patches/file_entity-drupal11.4-currentuser-type.patch
+++ b/patches/file_entity-drupal11.4-currentuser-type.patch
@@ -1,0 +1,30 @@
+diff --git a/src/Plugin/Field/FieldFormatter/FileImageResponsiveFormatter.php b/src/Plugin/Field/FieldFormatter/FileImageResponsiveFormatter.php
+index 1234567..abcdefg 100644
+--- a/src/Plugin/Field/FieldFormatter/FileImageResponsiveFormatter.php
++++ b/src/Plugin/Field/FieldFormatter/FileImageResponsiveFormatter.php
+@@ -35,20 +35,20 @@ class FileImageResponsiveFormatter extends ImageFormatter {
+    * The image style entity storage.
+    *
+    * @var \Drupal\Core\Entity\EntityStorageInterface
+    */
+-  protected $imageStyleStorage;
++  protected EntityStorageInterface $imageStyleStorage;
+
+   /**
+    * The current user.
+    *
+    * @var \Drupal\Core\Session\AccountInterface
+    */
+-  protected $currentUser;
++  protected AccountInterface $currentUser;
+
+   /**
+    * The link generator.
+    *
+    * @var \Drupal\Core\Utility\LinkGeneratorInterface
+    */
+-  protected $linkGenerator;
++  protected LinkGeneratorInterface $linkGenerator;
+
+   /**
+    * {@inheritdoc}


### PR DESCRIPTION
## What
Adds a composer patch typing three properties on `file_entity`'s `FileImageResponsiveFormatter` to match core.

## Why
Drupal 11.4 changed core `ImageFormatter` to use typed properties (`$imageStyleStorage`, `$currentUser`, `$linkGenerator`). `file_entity` 2.4.0 overrides all three untyped, causing a fatal `Type of ... must be ...` on image render → **whole site 500**. This took production down live after the 11.4.0 update (v1.25.0) and was hotfixed by hand on the server; this makes the fix permanent so the next `composer install`/deploy reapplies it.

## Change
- `patches/file_entity-drupal11.4-currentuser-type.patch` - types the three properties (imports already present)
- `composer.json` - registers the patch under `extra.patches` (`cweagans/composer-patches`)

## Verified
Production restored to 200 on `/`, `/user/login`, `/people`, and shop after applying the equivalent fix + FPM restart.