### PR TITLE
SAHO-486: harden timeline JSON-LD against script-block breakout

### DIFF
--- a/webroot/modules/custom/saho_timeline/src/Controller/TimelineController.php
+++ b/webroot/modules/custom/saho_timeline/src/Controller/TimelineController.php
@@ -232,13 +232,17 @@ class TimelineController extends ControllerBase {
       }
     }
 
+    // JSON_HEX_TAG: this string is printed raw inside a <script
+    // type="application/ld+json"> block, so a literal '</script>' in an
+    // event title must never survive encoding (script-block breakout =
+    // stored XSS from editor-authored titles).
     return json_encode([
       '@context' => 'https://schema.org',
       '@type' => 'ItemList',
       'name' => 'Timeline of South African History',
       'numberOfItems' => $position,
       'itemListElement' => $items,
-    ], JSON_UNESCAPED_SLASHES);
+    ], JSON_HEX_TAG | JSON_HEX_AMP);
   }
 
 }


### PR DESCRIPTION
Follow-up hardening to #487, found in post-merge self-review.

`TimelineController::buildJsonLd()` encoded with `JSON_UNESCAPED_SLASHES`, so an event title containing a literal `</script>` would have closed the raw-printed JSON-LD block and executed markup - a stored XSS gated on the ability to author event titles (editors). Low severity, defense-in-depth fix: encode with `JSON_HEX_TAG | JSON_HEX_AMP` so breakout sequences become `<\/script>`.

Verified on DDEV: the emitted block still parses as a valid schema.org ItemList (35 items), phpcs clean.