### PR TITLE
fix(tdih): /this-day-in-history emptied by the closed birthday disclosure

### DIFF
--- a/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
@@ -396,6 +396,15 @@ class TdihInteractiveBlock extends BlockBase implements ContainerFactoryPluginIn
     if ($this->configuration['show_today_history']) {
       $nodes = $this->nodeFetcher->loadPotentialEvents($target_date);
 
+      // Editorial curation first - but most days carry no
+      // field_home_page_feature event, and the old block showed the
+      // day's uncurated events rather than an empty panel. Fall back to
+      // the full day set so "No events found for today" only appears
+      // when the day genuinely has nothing.
+      if (empty($nodes)) {
+        $nodes = $this->nodeFetcher->loadAllBirthdayEvents($target_date);
+      }
+
       if (!empty($nodes)) {
         // Build node items for rendering and filter by exact date.
         foreach ($nodes as $node) {

--- a/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
+++ b/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
@@ -73,9 +73,12 @@
     </div>
 
     {# The birthday picker expands in place at the panel foot (R3 #478):
-       a quiet mono invitation, not a form block. #}
+       a quiet mono invitation, not a form block. On instances that do
+       NOT show the today-ledger (the /this-day-in-history page), the
+       form and its default today results ARE the page's content, so the
+       disclosure defaults open - a closed one left that page empty. #}
     {% if date_picker_form %}
-      <details class="tdih-birthday-disclosure">
+      <details class="tdih-birthday-disclosure"{% if not show_today_history %} open{% endif %}>
         <summary class="tdih-birthday-summary">{{ 'What happened on your birthday?'|t }} <span aria-hidden="true">&rarr;</span></summary>
         <div class="tdih-birthday-picker" role="search" aria-label="{{ 'Search historical events by date'|t }}">
           {{ date_picker_form }}


### PR DESCRIPTION
Two regressions on TDIH surfaces vs prod (v1.25.0), both shipped with the #452 Open Record merge and both surfacing on any ordinary day - reported from /this-day-in-history looking empty locally.

## 1. /this-day-in-history emptied by the closed birthday disclosure

The page's TDIH block instance has the today-ledger disabled (`.tdih-today-history-wrapper` ships `display:none` on prod too) - the page's entire visible content has always been the birthday form's default 'today' results. Round 3 (#478) wrapped the picker in a closed `<details>`: right for the front-page panel, but it swallowed this page whole.

**Fix:** the disclosure defaults `open` when the block instance does not show the today-ledger (the form IS the content). One-line template condition.

## 2. Front-page This Day panel: 'No events found for today' on uncurated days

`loadPotentialEvents()` only returns `field_home_page_feature=1` events, and most days have none (14 July: zero curated, seven real events). The old block showed the day's events; the redesigned panel went quiet.

**Fix:** curation still leads when present; empty days fall back to the existing `loadAllBirthdayEvents()` (uncurated day set), so the empty message only appears when a day genuinely has nothing.

## Verified via Playwright on DDEV

- /this-day-in-history: picker + all 7 events for 14 July with images (prod parity).
- Front page: 'THIS DAY · 14 JULY' with the Nakasa duotone lead figure + three ledger entries (prod shows Nakasa too).
- phpcs clean, tdih tests green.

Not related to the timeline rebuild (#487).