### PR TITLE
Prod transport prerequisites: Catalyst provenance fields (#494 phase 0) + JSON:API write guardrails (#393)

### DIFF
--- a/config/sync/core.entity_form_display.node.archive.default.yml
+++ b/config/sync/core.entity_form_display.node.archive.default.yml
@@ -33,6 +33,11 @@ dependencies:
     - field.field.node.archive.field_media_library_type
     - field.field.node.archive.field_navigation_links_placehold
     - field.field.node.archive.field_node_image_caption
+    - field.field.node.archive.field_original_created_date
+    - field.field.node.archive.field_original_creator
+    - field.field.node.archive.field_original_creator_role
+    - field.field.node.archive.field_original_source_url
+    - field.field.node.archive.field_provenance_note
     - field.field.node.archive.field_publication_date_archive
     - field.field.node.archive.field_publication_place
     - field.field.node.archive.field_publication_title
@@ -56,6 +61,7 @@ dependencies:
     - field_group
     - file
     - image
+    - link
     - path
     - text
 third_party_settings:
@@ -174,6 +180,26 @@ third_party_settings:
         id: ''
         open: true
         required_fields: false
+    group_provenance:
+      children:
+        - field_original_creator
+        - field_original_creator_role
+        - field_archive_publication_date
+        - field_original_created_date
+        - field_original_source_url
+        - field_provenance_note
+      label: 'Provenance & Attribution'
+      region: content
+      parent_name: ''
+      weight: 30
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: 'Credit for third-party material hosted by SAHO. Use these instead of the account Authored by field.'
+        required_fields: true
 id: node.archive.default
 targetEntityType: node
 bundle: archive
@@ -220,7 +246,7 @@ content:
     third_party_settings: {  }
   field_archive_publication_date:
     type: datetime_default
-    weight: 18
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -392,6 +418,42 @@ content:
     region: content
     settings:
       size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_original_created_date:
+    type: datetime_default
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_original_creator:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_original_creator_role:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_original_source_url:
+    type: link_default
+    weight: 5
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_provenance_note:
+    type: text_textarea
+    weight: 6
+    region: content
+    settings:
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
   field_publication_date_archive:

--- a/config/sync/core.entity_view_display.node.archive.another_teaser.yml
+++ b/config/sync/core.entity_view_display.node.archive.another_teaser.yml
@@ -34,6 +34,11 @@ dependencies:
     - field.field.node.archive.field_media_library_type
     - field.field.node.archive.field_navigation_links_placehold
     - field.field.node.archive.field_node_image_caption
+    - field.field.node.archive.field_original_created_date
+    - field.field.node.archive.field_original_creator
+    - field.field.node.archive.field_original_creator_role
+    - field.field.node.archive.field_original_source_url
+    - field.field.node.archive.field_provenance_note
     - field.field.node.archive.field_publication_date_archive
     - field.field.node.archive.field_publication_place
     - field.field.node.archive.field_publication_title
@@ -99,6 +104,11 @@ hidden:
   field_media_library_type: true
   field_navigation_links_placehold: true
   field_node_image_caption: true
+  field_original_created_date: true
+  field_original_creator: true
+  field_original_creator_role: true
+  field_original_source_url: true
+  field_provenance_note: true
   field_publication_date_archive: true
   field_publication_place: true
   field_publication_title: true

--- a/config/sync/core.entity_view_display.node.archive.another_teaser_frontpage.yml
+++ b/config/sync/core.entity_view_display.node.archive.another_teaser_frontpage.yml
@@ -34,6 +34,11 @@ dependencies:
     - field.field.node.archive.field_media_library_type
     - field.field.node.archive.field_navigation_links_placehold
     - field.field.node.archive.field_node_image_caption
+    - field.field.node.archive.field_original_created_date
+    - field.field.node.archive.field_original_creator
+    - field.field.node.archive.field_original_creator_role
+    - field.field.node.archive.field_original_source_url
+    - field.field.node.archive.field_provenance_note
     - field.field.node.archive.field_publication_date_archive
     - field.field.node.archive.field_publication_place
     - field.field.node.archive.field_publication_title
@@ -118,6 +123,11 @@ hidden:
   field_media_library_type: true
   field_navigation_links_placehold: true
   field_node_image_caption: true
+  field_original_created_date: true
+  field_original_creator: true
+  field_original_creator_role: true
+  field_original_source_url: true
+  field_provenance_note: true
   field_publication_date_archive: true
   field_publication_place: true
   field_publication_title: true

--- a/config/sync/core.entity_view_display.node.archive.custom_view_node.yml
+++ b/config/sync/core.entity_view_display.node.archive.custom_view_node.yml
@@ -34,6 +34,11 @@ dependencies:
     - field.field.node.archive.field_media_library_type
     - field.field.node.archive.field_navigation_links_placehold
     - field.field.node.archive.field_node_image_caption
+    - field.field.node.archive.field_original_created_date
+    - field.field.node.archive.field_original_creator
+    - field.field.node.archive.field_original_creator_role
+    - field.field.node.archive.field_original_source_url
+    - field.field.node.archive.field_provenance_note
     - field.field.node.archive.field_publication_date_archive
     - field.field.node.archive.field_publication_place
     - field.field.node.archive.field_publication_title
@@ -99,6 +104,11 @@ hidden:
   field_media_library_type: true
   field_navigation_links_placehold: true
   field_node_image_caption: true
+  field_original_created_date: true
+  field_original_creator: true
+  field_original_creator_role: true
+  field_original_source_url: true
+  field_provenance_note: true
   field_publication_date_archive: true
   field_publication_place: true
   field_publication_title: true

--- a/config/sync/core.entity_view_display.node.archive.default.yml
+++ b/config/sync/core.entity_view_display.node.archive.default.yml
@@ -33,6 +33,11 @@ dependencies:
     - field.field.node.archive.field_media_library_type
     - field.field.node.archive.field_navigation_links_placehold
     - field.field.node.archive.field_node_image_caption
+    - field.field.node.archive.field_original_created_date
+    - field.field.node.archive.field_original_creator
+    - field.field.node.archive.field_original_creator_role
+    - field.field.node.archive.field_original_source_url
+    - field.field.node.archive.field_provenance_note
     - field.field.node.archive.field_publication_date_archive
     - field.field.node.archive.field_publication_place
     - field.field.node.archive.field_publication_title
@@ -222,6 +227,11 @@ hidden:
   field_language: true
   field_media_library_type: true
   field_node_image_caption: true
+  field_original_created_date: true
+  field_original_creator: true
+  field_original_creator_role: true
+  field_original_source_url: true
+  field_provenance_note: true
   field_publication_date_archive: true
   field_publication_place: true
   field_publication_title: true

--- a/config/sync/core.entity_view_display.node.archive.full.yml
+++ b/config/sync/core.entity_view_display.node.archive.full.yml
@@ -34,6 +34,11 @@ dependencies:
     - field.field.node.archive.field_media_library_type
     - field.field.node.archive.field_navigation_links_placehold
     - field.field.node.archive.field_node_image_caption
+    - field.field.node.archive.field_original_created_date
+    - field.field.node.archive.field_original_creator
+    - field.field.node.archive.field_original_creator_role
+    - field.field.node.archive.field_original_source_url
+    - field.field.node.archive.field_provenance_note
     - field.field.node.archive.field_publication_date_archive
     - field.field.node.archive.field_publication_place
     - field.field.node.archive.field_publication_title
@@ -391,5 +396,10 @@ hidden:
   field_classroom_subject: true
   field_home_page_feature: true
   field_node_image_caption: true
+  field_original_created_date: true
+  field_original_creator: true
+  field_original_creator_role: true
+  field_original_source_url: true
+  field_provenance_note: true
   langcode: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.archive.search_result.yml
+++ b/config/sync/core.entity_view_display.node.archive.search_result.yml
@@ -34,6 +34,11 @@ dependencies:
     - field.field.node.archive.field_media_library_type
     - field.field.node.archive.field_navigation_links_placehold
     - field.field.node.archive.field_node_image_caption
+    - field.field.node.archive.field_original_created_date
+    - field.field.node.archive.field_original_creator
+    - field.field.node.archive.field_original_creator_role
+    - field.field.node.archive.field_original_source_url
+    - field.field.node.archive.field_provenance_note
     - field.field.node.archive.field_publication_date_archive
     - field.field.node.archive.field_publication_place
     - field.field.node.archive.field_publication_title
@@ -106,6 +111,11 @@ hidden:
   field_media_library_type: true
   field_navigation_links_placehold: true
   field_node_image_caption: true
+  field_original_created_date: true
+  field_original_creator: true
+  field_original_creator_role: true
+  field_original_source_url: true
+  field_provenance_note: true
   field_publication_date_archive: true
   field_publication_place: true
   field_publication_title: true

--- a/config/sync/core.entity_view_display.node.archive.teaser.yml
+++ b/config/sync/core.entity_view_display.node.archive.teaser.yml
@@ -34,6 +34,11 @@ dependencies:
     - field.field.node.archive.field_media_library_type
     - field.field.node.archive.field_navigation_links_placehold
     - field.field.node.archive.field_node_image_caption
+    - field.field.node.archive.field_original_created_date
+    - field.field.node.archive.field_original_creator
+    - field.field.node.archive.field_original_creator_role
+    - field.field.node.archive.field_original_source_url
+    - field.field.node.archive.field_provenance_note
     - field.field.node.archive.field_publication_date_archive
     - field.field.node.archive.field_publication_place
     - field.field.node.archive.field_publication_title
@@ -125,6 +130,11 @@ hidden:
   field_media_library_type: true
   field_navigation_links_placehold: true
   field_node_image_caption: true
+  field_original_created_date: true
+  field_original_creator: true
+  field_original_creator_role: true
+  field_original_source_url: true
+  field_provenance_note: true
   field_publication_date_archive: true
   field_publication_place: true
   field_publication_title: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -7,7 +7,6 @@ module:
   admin_toolbar_tools: 0
   advancedqueue: 0
   africa_regions: 0
-  antibot: 1
   asset_injector: 0
   basic_auth: 0
   better_exposed_filters: 0
@@ -24,7 +23,6 @@ module:
   config: 0
   config_ignore: 0
   contact: 0
-  content_translation: 10
   contextual: 0
   csv_serialization: 0
   ctools: 0
@@ -87,7 +85,6 @@ module:
   media: 0
   media_library: 0
   media_library_form_element: 0
-  menu_link_content: 1
   menu_ui: 0
   metatag: 0
   metatag_open_graph: 0
@@ -95,10 +92,8 @@ module:
   mysql: 0
   node: 0
   options: 0
-  page_cache: 1
   path: 0
   path_alias: 0
-  pathauto: 1
   payfast_donation_block: 0
   pdf_reader: 0
   phpass: 0
@@ -126,6 +121,7 @@ module:
   saho_statistics: 0
   saho_suggested_reading: 0
   saho_timeline: 0
+  saho_timeline_dates: 0
   saho_tools: 0
   saho_upcoming_events: 0
   saho_utils: 0
@@ -142,7 +138,6 @@ module:
   simple_sitemap: 0
   sophron: 0
   spammaster: 0
-  standard: 1000
   state_machine: 0
   system: 0
   tamper: 0
@@ -161,13 +156,19 @@ module:
   ultimate_cron: 0
   update: 0
   user: 0
-  views: 10
   views_bulk_operations: 0
   views_data_export: 0
   views_ui: 0
   webform: 0
   webform_attachment: 0
   webform_ui: 0
+  antibot: 1
+  menu_link_content: 1
+  page_cache: 1
+  pathauto: 1
+  content_translation: 10
+  views: 10
+  standard: 1000
 theme:
   stable9: 0
   claro: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -106,6 +106,7 @@ module:
   rest: 0
   robotstxt: 0
   sa_provinces: 0
+  saho_api_guard: 0
   saho_chrome: 0
   saho_classroom: 0
   saho_cleanup: 0

--- a/config/sync/field.field.node.archive.field_archive_publication_date.yml
+++ b/config/sync/field.field.node.archive.field_archive_publication_date.yml
@@ -12,7 +12,7 @@ field_name: field_archive_publication_date
 entity_type: node
 bundle: archive
 label: 'Archive Publication Date'
-description: "The Drupal date format of the archive item's publication"
+description: 'First publication of the work by its ORIGINAL creator (structured provenance slot; the free-text Publication date field holds legacy partial dates).'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.archive.field_original_created_date.yml
+++ b/config/sync/field.field.node.archive.field_original_created_date.yml
@@ -1,0 +1,21 @@
+uuid: c1177db3-2e0f-4dde-a2dd-73df673f18b0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_original_created_date
+    - node.type.archive
+  module:
+    - datetime
+id: node.archive.field_original_created_date
+field_name: field_original_created_date
+entity_type: node
+bundle: archive
+label: 'Recording/creation date'
+description: 'When the work itself was made, if it differs from first publication. First publication lives in Archive Publication Date.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/sync/field.field.node.archive.field_original_creator.yml
+++ b/config/sync/field.field.node.archive.field_original_creator.yml
@@ -1,0 +1,19 @@
+uuid: 6d1a7533-5925-43ab-a7c1-58981e21816a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_original_creator
+    - node.type.archive
+id: node.archive.field_original_creator
+field_name: field_original_creator
+entity_type: node
+bundle: archive
+label: 'Original creator'
+description: 'Person or organisation that created the original work (e.g. production company, photographer). Leave empty for SAHO-authored content.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.archive.field_original_creator_role.yml
+++ b/config/sync/field.field.node.archive.field_original_creator_role.yml
@@ -1,0 +1,21 @@
+uuid: 2cec8fc3-bed0-4894-bd71-8adce8f9a833
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_original_creator_role
+    - node.type.archive
+  module:
+    - options
+id: node.archive.field_original_creator_role
+field_name: field_original_creator_role
+entity_type: node
+bundle: archive
+label: 'Creator role'
+description: 'Role of the original creator(s), in the same order as the creators above.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.archive.field_original_source_url.yml
+++ b/config/sync/field.field.node.archive.field_original_source_url.yml
@@ -1,0 +1,23 @@
+uuid: 08f63d19-f22d-4240-ba0f-cae82415a88a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_original_source_url
+    - node.type.archive
+  module:
+    - link
+id: node.archive.field_original_source_url
+field_name: field_original_source_url
+entity_type: node
+bundle: archive
+label: 'Original source URL'
+description: 'Where the work was originally published or is canonically hosted.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 16
+field_type: link

--- a/config/sync/field.field.node.archive.field_provenance_note.yml
+++ b/config/sync/field.field.node.archive.field_provenance_note.yml
@@ -1,0 +1,22 @@
+uuid: c53e499c-6946-44c8-8301-d89511e312f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_provenance_note
+    - node.type.archive
+  module:
+    - text
+id: node.archive.field_provenance_note
+field_name: field_provenance_note
+entity_type: node
+bundle: archive
+label: 'Provenance note'
+description: 'Free-text acknowledgement of the original creator/custodian, rendered in the attribution block.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats: {  }
+field_type: text_long

--- a/config/sync/field.storage.node.field_original_created_date.yml
+++ b/config/sync/field.storage.node.field_original_created_date.yml
@@ -1,0 +1,20 @@
+uuid: 85159abc-eb28-44e9-9265-d60cfddb0232
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_original_created_date
+field_name: field_original_created_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_original_creator.yml
+++ b/config/sync/field.storage.node.field_original_creator.yml
@@ -1,0 +1,21 @@
+uuid: 59626a18-66d5-417b-a943-f07ab8b6c70d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_original_creator
+field_name: field_original_creator
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_original_creator_role.yml
+++ b/config/sync/field.storage.node.field_original_creator_role.yml
@@ -1,0 +1,51 @@
+uuid: 625c75d1-6df8-4536-bf06-c07fe0827791
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_original_creator_role
+field_name: field_original_creator_role
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: producer
+      label: Producer
+    -
+      value: filmmaker
+      label: Filmmaker
+    -
+      value: photographer
+      label: Photographer
+    -
+      value: author
+      label: Author
+    -
+      value: editor
+      label: Editor
+    -
+      value: publisher
+      label: Publisher
+    -
+      value: artist
+      label: Artist
+    -
+      value: composer
+      label: Composer
+    -
+      value: interviewer
+      label: Interviewer
+    -
+      value: institution
+      label: Institution
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_original_source_url.yml
+++ b/config/sync/field.storage.node.field_original_source_url.yml
@@ -1,0 +1,19 @@
+uuid: 8b9bbbd2-b534-4568-a27f-8284006cae6a
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_original_source_url
+field_name: field_original_source_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_provenance_note.yml
+++ b/config/sync/field.storage.node.field_provenance_note.yml
@@ -1,0 +1,19 @@
+uuid: 764fffd9-6969-4d4e-a089-ff8dbb1ff897
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_provenance_note
+field_name: field_provenance_note
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/jsonapi.settings.yml
+++ b/config/sync/jsonapi.settings.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: bbhVQEgCMWzCNQ9nBMR-PZeax3Tkujtue1HA7CE5574
-read_only: true
+read_only: false
 maintenance_header_retry_seconds:
   min: 5
   max: 10

--- a/config/sync/saho_api_guard.settings.yml
+++ b/config/sync/saho_api_guard.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: x5mVfhwG7gLLQJE1AsN6JcUCV93KKXR4q6Mflpi6JTU
+rate_limit_enabled: true
+writes_per_minute: 60
+writes_per_hour: 1000

--- a/config/sync/system.action.user_add_role_action.api_aiditor.yml
+++ b/config/sync/system.action.user_add_role_action.api_aiditor.yml
@@ -1,0 +1,14 @@
+uuid: c8d21c92-b494-438f-89aa-f9ba0a27caa8
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.api_aiditor
+  module:
+    - user
+id: user_add_role_action.api_aiditor
+label: 'Add the API AIditor (service) role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: api_aiditor

--- a/config/sync/system.action.user_add_role_action.api_harvester.yml
+++ b/config/sync/system.action.user_add_role_action.api_harvester.yml
@@ -1,0 +1,14 @@
+uuid: 53db4b75-cf7c-418d-8fd5-6ee0180ba4b7
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.api_harvester
+  module:
+    - user
+id: user_add_role_action.api_harvester
+label: 'Add the API Harvester (service) role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: api_harvester

--- a/config/sync/system.action.user_remove_role_action.api_aiditor.yml
+++ b/config/sync/system.action.user_remove_role_action.api_aiditor.yml
@@ -1,0 +1,14 @@
+uuid: 783b938c-8c5f-4679-a93c-b7712fe115f5
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.api_aiditor
+  module:
+    - user
+id: user_remove_role_action.api_aiditor
+label: 'Remove the API AIditor (service) role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: api_aiditor

--- a/config/sync/system.action.user_remove_role_action.api_harvester.yml
+++ b/config/sync/system.action.user_remove_role_action.api_harvester.yml
@@ -1,0 +1,14 @@
+uuid: 3b2de662-26b5-43ab-a289-b1b154cad0aa
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.api_harvester
+  module:
+    - user
+id: user_remove_role_action.api_harvester
+label: 'Remove the API Harvester (service) role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: api_harvester

--- a/config/sync/user.role.api_aiditor.yml
+++ b/config/sync/user.role.api_aiditor.yml
@@ -1,0 +1,32 @@
+uuid: c1ecd3cd-74d1-4abe-b40a-d7d90fac5621
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+    - node.type.archive
+    - node.type.article
+    - node.type.biography
+    - node.type.event
+    - node.type.gallery_image
+    - node.type.place
+  module:
+    - filter
+    - node
+    - saho_api_guard
+    - system
+id: api_aiditor
+label: 'API AIditor (service)'
+weight: 10
+is_admin: false
+permissions:
+  - 'access content'
+  - 'edit any archive content'
+  - 'edit any article content'
+  - 'edit any biography content'
+  - 'edit any event content'
+  - 'edit any gallery_image content'
+  - 'edit any place content'
+  - 'restricted to unpublished content (api guard)'
+  - 'use text format full_html'
+  - 'view any unpublished content (api guard)'

--- a/config/sync/user.role.api_harvester.yml
+++ b/config/sync/user.role.api_harvester.yml
@@ -1,0 +1,38 @@
+uuid: 5c768657-9baa-49dd-8591-a3e876d0a522
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+    - node.type.archive
+    - node.type.article
+    - node.type.biography
+    - node.type.event
+    - node.type.gallery_image
+    - node.type.place
+  module:
+    - filter
+    - node
+    - saho_api_guard
+    - system
+id: api_harvester
+label: 'API Harvester (service)'
+weight: 9
+is_admin: false
+permissions:
+  - 'access content'
+  - 'create archive content'
+  - 'create article content'
+  - 'create biography content'
+  - 'create event content'
+  - 'create gallery_image content'
+  - 'create place content'
+  - 'edit own archive content'
+  - 'edit own article content'
+  - 'edit own biography content'
+  - 'edit own event content'
+  - 'edit own gallery_image content'
+  - 'edit own place content'
+  - 'restricted to unpublished content (api guard)'
+  - 'use text format full_html'
+  - 'view own unpublished content'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - filter.format.filtered_html
-    - filter.format.full_html
     - filter.format.webform_default
     - media.type.audio
     - media.type.file
@@ -40,16 +39,6 @@ permissions:
   - 'create media'
   - 'create remote_video media'
   - 'create video media'
-  - 'delete any audio files'
-  - 'delete any audio media'
-  - 'delete any document files'
-  - 'delete any file media'
-  - 'delete any image files'
-  - 'delete any image media'
-  - 'delete any media'
-  - 'delete any remote_video media'
-  - 'delete any video files'
-  - 'delete any video media'
   - 'delete media'
   - 'delete own audio files'
   - 'delete own audio media'
@@ -69,15 +58,6 @@ permissions:
   - 'download own document files'
   - 'download own image files'
   - 'download own video files'
-  - 'edit any audio files'
-  - 'edit any audio media'
-  - 'edit any document files'
-  - 'edit any file media'
-  - 'edit any image files'
-  - 'edit any image media'
-  - 'edit any remote_video media'
-  - 'edit any video files'
-  - 'edit any video media'
   - 'edit own audio files'
   - 'edit own audio media'
   - 'edit own comments'
@@ -91,10 +71,8 @@ permissions:
   - 'opt-in or out of google analytics tracking'
   - 'post comments'
   - 'skip comment approval'
-  - 'update any media'
   - 'update media'
   - 'use text format filtered_html'
-  - 'use text format full_html'
   - 'use text format webform_default'
   - 'use timeline api'
   - 'view files'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -5,6 +5,11 @@ dependencies:
   config:
     - filter.format.filtered_html
     - filter.format.full_html
+    - media.type.audio
+    - media.type.file
+    - media.type.image
+    - media.type.remote_video
+    - media.type.video
     - node.type.archive
     - node.type.article
     - node.type.biography
@@ -20,8 +25,10 @@ dependencies:
     - comment
     - contextual
     - file
+    - file_entity
     - filter
     - help
+    - media
     - node
     - system
     - toolbar
@@ -54,6 +61,16 @@ permissions:
   - 'create place content'
   - 'create product content'
   - 'create upcomingevent content'
+  - 'delete any audio files'
+  - 'delete any audio media'
+  - 'delete any document files'
+  - 'delete any file media'
+  - 'delete any image files'
+  - 'delete any image media'
+  - 'delete any media'
+  - 'delete any remote_video media'
+  - 'delete any video files'
+  - 'delete any video media'
   - 'delete own archive content'
   - 'delete own article content'
   - 'delete own biography content'
@@ -68,15 +85,24 @@ permissions:
   - 'delete own upcomingevent content'
   - 'edit any archive content'
   - 'edit any article content'
+  - 'edit any audio files'
+  - 'edit any audio media'
   - 'edit any biography content'
   - 'edit any book content'
   - 'edit any button content'
+  - 'edit any document files'
   - 'edit any event content'
+  - 'edit any file media'
   - 'edit any image content'
+  - 'edit any image files'
+  - 'edit any image media'
   - 'edit any page content'
   - 'edit any place content'
   - 'edit any product content'
+  - 'edit any remote_video media'
   - 'edit any upcomingevent content'
+  - 'edit any video files'
+  - 'edit any video media'
   - 'edit any webform'
   - 'edit any webform submission'
   - 'edit own archive content'
@@ -93,6 +119,7 @@ permissions:
   - 'edit own upcomingevent content'
   - 'post comments'
   - 'skip comment approval'
+  - 'update any media'
   - 'use text format filtered_html'
   - 'use text format full_html'
   - 'view any webform submission'

--- a/config/sync/user.role.researcher.yml
+++ b/config/sync/user.role.researcher.yml
@@ -5,6 +5,11 @@ dependencies:
   config:
     - filter.format.filtered_html
     - filter.format.full_html
+    - media.type.audio
+    - media.type.file
+    - media.type.image
+    - media.type.remote_video
+    - media.type.video
     - node.type.archive
     - node.type.article
     - node.type.biography
@@ -19,8 +24,10 @@ dependencies:
   module:
     - comment
     - file
+    - file_entity
     - filter
     - help
+    - media
     - node
     - system
     - toolbar
@@ -53,6 +60,16 @@ permissions:
   - 'create place content'
   - 'create product content'
   - 'create upcomingevent content'
+  - 'delete any audio files'
+  - 'delete any audio media'
+  - 'delete any document files'
+  - 'delete any file media'
+  - 'delete any image files'
+  - 'delete any image media'
+  - 'delete any media'
+  - 'delete any remote_video media'
+  - 'delete any video files'
+  - 'delete any video media'
   - 'delete any webform submission'
   - 'delete own archive content'
   - 'delete own article content'
@@ -68,15 +85,24 @@ permissions:
   - 'delete own upcomingevent content'
   - 'edit any archive content'
   - 'edit any article content'
+  - 'edit any audio files'
+  - 'edit any audio media'
   - 'edit any biography content'
   - 'edit any book content'
   - 'edit any button content'
+  - 'edit any document files'
   - 'edit any event content'
+  - 'edit any file media'
   - 'edit any image content'
+  - 'edit any image files'
+  - 'edit any image media'
   - 'edit any page content'
   - 'edit any place content'
   - 'edit any product content'
+  - 'edit any remote_video media'
   - 'edit any upcomingevent content'
+  - 'edit any video files'
+  - 'edit any video media'
   - 'edit any webform'
   - 'edit any webform submission'
   - 'edit own archive content'
@@ -93,6 +119,7 @@ permissions:
   - 'edit own upcomingevent content'
   - 'post comments'
   - 'skip comment approval'
+  - 'update any media'
   - 'use text format filtered_html'
   - 'use text format full_html'
   - 'view any webform submission'

--- a/config/sync/user.role.researcher_advanced_.yml
+++ b/config/sync/user.role.researcher_advanced_.yml
@@ -3,6 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.full_html
+    - media.type.audio
+    - media.type.file
+    - media.type.image
+    - media.type.remote_video
+    - media.type.video
     - node.type.archive
     - node.type.article
     - node.type.biography
@@ -12,7 +18,10 @@ dependencies:
     - block
     - block_content
     - file
+    - file_entity
+    - filter
     - help
+    - media
     - node
     - system
     - taxonomy
@@ -32,12 +41,32 @@ permissions:
   - 'administer blocks'
   - 'administer nodes'
   - 'administer taxonomy'
-  - 'break content lock'
   - 'bypass node access'
   - 'create terms in field_galleries_tag'
   - 'delete any archive content'
   - 'delete any article content'
+  - 'delete any audio files'
+  - 'delete any audio media'
   - 'delete any biography content'
+  - 'delete any document files'
+  - 'delete any file media'
+  - 'delete any image files'
+  - 'delete any image media'
+  - 'delete any media'
   - 'delete any place content'
+  - 'delete any remote_video media'
+  - 'delete any video files'
+  - 'delete any video media'
   - 'delete own files'
+  - 'edit any audio files'
+  - 'edit any audio media'
+  - 'edit any document files'
+  - 'edit any file media'
+  - 'edit any image files'
+  - 'edit any image media'
+  - 'edit any remote_video media'
+  - 'edit any video files'
+  - 'edit any video media'
   - 'edit terms in field_galleries_tag'
+  - 'update any media'
+  - 'use text format full_html'

--- a/webroot/modules/custom/saho_api_guard/config/install/saho_api_guard.settings.yml
+++ b/webroot/modules/custom/saho_api_guard/config/install/saho_api_guard.settings.yml
@@ -1,0 +1,3 @@
+rate_limit_enabled: true
+writes_per_minute: 60
+writes_per_hour: 1000

--- a/webroot/modules/custom/saho_api_guard/config/schema/saho_api_guard.schema.yml
+++ b/webroot/modules/custom/saho_api_guard/config/schema/saho_api_guard.schema.yml
@@ -1,0 +1,13 @@
+saho_api_guard.settings:
+  type: config_object
+  label: 'SAHO API Guard settings'
+  mapping:
+    rate_limit_enabled:
+      type: boolean
+      label: 'Enable JSON:API write rate limiting'
+    writes_per_minute:
+      type: integer
+      label: 'Max JSON:API writes per account per minute'
+    writes_per_hour:
+      type: integer
+      label: 'Max JSON:API writes per account per hour'

--- a/webroot/modules/custom/saho_api_guard/saho_api_guard.info.yml
+++ b/webroot/modules/custom/saho_api_guard/saho_api_guard.info.yml
@@ -1,0 +1,8 @@
+name: SAHO API Guard
+type: module
+description: 'Least-privilege guardrails for service-account JSON:API writes: forced-unpublished saves, published-content edit lockout, and write rate limiting.'
+core_version_requirement: ^10 || ^11
+package: Custom
+dependencies:
+  - drupal:node
+  - drupal:jsonapi

--- a/webroot/modules/custom/saho_api_guard/saho_api_guard.module
+++ b/webroot/modules/custom/saho_api_guard/saho_api_guard.module
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @file
+ * Access guardrails for service-account (JSON:API) content writes.
+ */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_node_access().
+ *
+ * Two guardrails keyed on marker permissions rather than role IDs, so the
+ * rules are visible on the permissions page and reusable for future agents:
+ *
+ * - Accounts "restricted to unpublished content" can never update or delete
+ *   a published node, no matter what edit-any permissions they hold. A
+ *   forbidden result here always wins over the role-based allow (see the
+ *   access-combining docs on node_node_access()).
+ * - Accounts with the view marker may read unpublished nodes owned by other
+ *   accounts. Core only offers "view own unpublished content"; the AI editor
+ *   service account has to read harvester-owned drafts. Safe here because no
+ *   module in this codebase implements hook_node_grants(), so the grants
+ *   storage stays neutral for unpublished view and this allow takes effect.
+ */
+function saho_api_guard_node_access(NodeInterface $node, $operation, AccountInterface $account) {
+  if (in_array($operation, ['update', 'delete'], TRUE)
+    && $node->isPublished()
+    && $account->hasPermission('restricted to unpublished content (api guard)')) {
+    return AccessResult::forbidden('API guard: this account may not modify published content.')
+      ->cachePerPermissions()
+      ->addCacheableDependency($node);
+  }
+  if ($operation === 'view'
+    && !$node->isPublished()
+    && $account->hasPermission('view any unpublished content (api guard)')) {
+    return AccessResult::allowed()
+      ->cachePerPermissions()
+      ->addCacheableDependency($node);
+  }
+  return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave() for node.
+ *
+ * The node status base field defaults to published, and only some bundles
+ * override that default - so a JSON:API POST that simply omits status would
+ * create a PUBLISHED node. Field access alone cannot catch an omitted field;
+ * this presave is the structural never-publish guarantee for restricted
+ * accounts.
+ */
+function saho_api_guard_node_presave(NodeInterface $node) {
+  $account = \Drupal::currentUser();
+  if ($node->isPublished()
+    && $account->hasPermission('restricted to unpublished content (api guard)')
+    && !$account->hasPermission('administer nodes')) {
+    $node->setUnpublished();
+  }
+}

--- a/webroot/modules/custom/saho_api_guard/saho_api_guard.permissions.yml
+++ b/webroot/modules/custom/saho_api_guard/saho_api_guard.permissions.yml
@@ -1,0 +1,11 @@
+restricted to unpublished content (api guard):
+  title: 'API guard: restricted to unpublished content'
+  description: 'Marker permission for service accounts. Accounts with this permission can never publish, and cannot edit or delete published nodes - regardless of any other content permission they hold.'
+  restrict access: false
+view any unpublished content (api guard):
+  title: 'API guard: view any unpublished content'
+  description: 'Allows reading unpublished nodes owned by other accounts. Grant only to the AI editor service account.'
+  restrict access: true
+bypass api guard rate limits:
+  title: 'Bypass API guard JSON:API rate limits'
+  restrict access: true

--- a/webroot/modules/custom/saho_api_guard/saho_api_guard.services.yml
+++ b/webroot/modules/custom/saho_api_guard/saho_api_guard.services.yml
@@ -1,0 +1,6 @@
+services:
+  saho_api_guard.jsonapi_write_rate_limiter:
+    class: Drupal\saho_api_guard\EventSubscriber\JsonApiWriteRateLimiter
+    arguments: ['@flood', '@current_user', '@config.factory']
+    tags:
+      - { name: event_subscriber }

--- a/webroot/modules/custom/saho_api_guard/src/EventSubscriber/JsonApiWriteRateLimiter.php
+++ b/webroot/modules/custom/saho_api_guard/src/EventSubscriber/JsonApiWriteRateLimiter.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\saho_api_guard\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Flood\FloodInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Rate-limits JSON:API write requests per authenticated account.
+ *
+ * Runs as a request subscriber rather than http_middleware because the
+ * per-account flood key needs the authenticated user, which only exists
+ * after AuthenticationSubscriber (kernel.request priority 300). Priority 35
+ * keeps us ahead of routing (32) so flooded requests are rejected before
+ * any routing/controller cost.
+ *
+ * GET is deliberately unlimited: reads are access-checked and cheap, the
+ * harvester's dedupe lookups depend on them, and edge protection belongs to
+ * Cloudflare. Anonymous writers are skipped - entity access rejects them
+ * anyway, so there is no point burning flood rows on them.
+ */
+final class JsonApiWriteRateLimiter implements EventSubscriberInterface {
+
+  /**
+   * Flood event name for the per-minute window.
+   */
+  protected const EVENT_MINUTE = 'saho_api_guard.jsonapi_write_minute';
+
+  /**
+   * Flood event name for the per-hour window.
+   */
+  protected const EVENT_HOUR = 'saho_api_guard.jsonapi_write_hour';
+
+  /**
+   * HTTP methods that count as writes.
+   */
+  protected const WRITE_METHODS = ['POST', 'PATCH', 'DELETE'];
+
+  public function __construct(
+    protected FloodInterface $flood,
+    protected AccountProxyInterface $currentUser,
+    protected ConfigFactoryInterface $configFactory,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [KernelEvents::REQUEST => [['onRequest', 35]]];
+  }
+
+  /**
+   * Rejects JSON:API writes that exceed the configured flood windows.
+   */
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+    $request = $event->getRequest();
+    if (!in_array($request->getMethod(), self::WRITE_METHODS, TRUE)) {
+      return;
+    }
+    if (!str_starts_with($request->getPathInfo(), '/jsonapi/')) {
+      return;
+    }
+
+    $config = $this->configFactory->get('saho_api_guard.settings');
+    if (!$config->get('rate_limit_enabled')) {
+      return;
+    }
+    if ($this->currentUser->isAnonymous()) {
+      return;
+    }
+    if ($this->currentUser->hasPermission('bypass api guard rate limits')) {
+      return;
+    }
+
+    $identifier = 'uid:' . $this->currentUser->id();
+    $per_minute = max(1, (int) $config->get('writes_per_minute'));
+    $per_hour = max(1, (int) $config->get('writes_per_hour'));
+
+    if (!$this->flood->isAllowed(self::EVENT_MINUTE, $per_minute, 60, $identifier)) {
+      $event->setResponse($this->tooManyRequests(60));
+      return;
+    }
+    if (!$this->flood->isAllowed(self::EVENT_HOUR, $per_hour, 3600, $identifier)) {
+      $event->setResponse($this->tooManyRequests(3600));
+      return;
+    }
+    $this->flood->register(self::EVENT_MINUTE, 60, $identifier);
+    $this->flood->register(self::EVENT_HOUR, 3600, $identifier);
+  }
+
+  /**
+   * Builds a JSON:API-shaped 429 response.
+   */
+  protected function tooManyRequests(int $retry_after): JsonResponse {
+    return new JsonResponse(
+      [
+        'errors' => [
+          [
+            'status' => '429',
+            'title' => 'Too Many Requests',
+            'detail' => 'JSON:API write rate limit exceeded. Slow down and retry after the indicated interval.',
+          ],
+        ],
+      ],
+      429,
+      [
+        'Retry-After' => (string) $retry_after,
+        'Content-Type' => 'application/vnd.api+json',
+      ]
+    );
+  }
+
+}

--- a/webroot/modules/custom/saho_api_guard/tests/src/Kernel/GuardAccessTest.php
+++ b/webroot/modules/custom/saho_api_guard/tests/src/Kernel/GuardAccessTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_api_guard\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
+
+/**
+ * Tests the API guard access hooks and the forced-unpublish presave.
+ *
+ * @group saho_api_guard
+ */
+final class GuardAccessTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'node',
+    'saho_api_guard',
+  ];
+
+  /**
+   * The restricted service account (harvester-shaped permissions).
+   */
+  protected User $restricted;
+
+  /**
+   * An unrestricted editor with administer nodes.
+   */
+  protected User $editor;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['saho_api_guard']);
+
+    NodeType::create(['type' => 'archive', 'name' => 'Archive'])->save();
+
+    // User 1 is a superuser; burn it so test accounts get real access checks.
+    User::create(['name' => 'root'])->save();
+
+    $this->restricted = $this->createUserWithPermissions([
+      'access content',
+      'create archive content',
+      'edit own archive content',
+      'edit any archive content',
+      'restricted to unpublished content (api guard)',
+    ], 'svc_harvester');
+
+    $this->editor = $this->createUserWithPermissions([
+      'access content',
+      'create archive content',
+      'edit any archive content',
+      'administer nodes',
+    ], 'editor');
+  }
+
+  /**
+   * A node saved by a restricted account is always stored unpublished.
+   */
+  public function testPresaveForcesUnpublished(): void {
+    $this->setCurrentUser($this->restricted);
+    $node = Node::create([
+      'type' => 'archive',
+      'title' => 'Harvested item',
+      'uid' => $this->restricted->id(),
+      'status' => 1,
+    ]);
+    $node->save();
+    $this->assertFalse($node->isPublished(), 'Restricted save is forced unpublished even when status=1 was set.');
+  }
+
+  /**
+   * Accounts with administer nodes are not affected by the presave guard.
+   */
+  public function testPresaveLeavesEditorsAlone(): void {
+    $this->setCurrentUser($this->editor);
+    $node = Node::create([
+      'type' => 'archive',
+      'title' => 'Editorial item',
+      'uid' => $this->editor->id(),
+      'status' => 1,
+    ]);
+    $node->save();
+    $this->assertTrue($node->isPublished(), 'Editor saves keep their published status.');
+  }
+
+  /**
+   * Restricted accounts cannot update or delete published nodes.
+   */
+  public function testPublishedContentLockout(): void {
+    $published = Node::create([
+      'type' => 'archive',
+      'title' => 'Live record',
+      'uid' => $this->editor->id(),
+      'status' => 1,
+    ]);
+    $published->save();
+
+    $draft = Node::create([
+      'type' => 'archive',
+      'title' => 'Draft record',
+      'uid' => $this->editor->id(),
+      'status' => 0,
+    ]);
+    $draft->save();
+
+    $this->assertFalse($published->access('update', $this->restricted), 'Restricted account cannot update a published node despite edit any.');
+    $this->assertFalse($published->access('delete', $this->restricted), 'Restricted account cannot delete a published node.');
+    $this->assertTrue($draft->access('update', $this->restricted), 'Restricted account can update an unpublished node.');
+    $this->assertTrue($published->access('update', $this->editor), 'Editor retains update access to published nodes.');
+  }
+
+  /**
+   * The view marker grants read access to others' unpublished nodes.
+   */
+  public function testViewAnyUnpublished(): void {
+    $draft = Node::create([
+      'type' => 'archive',
+      'title' => 'Someone else’s draft',
+      'uid' => $this->editor->id(),
+      'status' => 0,
+    ]);
+    $draft->save();
+
+    $this->assertFalse($draft->access('view', $this->restricted), 'Without the marker, unpublished nodes of other accounts are not visible.');
+
+    $viewer = $this->createUserWithPermissions([
+      'access content',
+      'view any unpublished content (api guard)',
+    ], 'svc_aiditor');
+    $this->assertTrue($draft->access('view', $viewer), 'The view marker grants access to unpublished nodes owned by others.');
+  }
+
+  /**
+   * Locks in the core mechanism the roles depend on: status field access.
+   */
+  public function testStatusFieldEditAccess(): void {
+    $node = Node::create([
+      'type' => 'archive',
+      'title' => 'Field access probe',
+      'uid' => $this->restricted->id(),
+      'status' => 0,
+    ]);
+    $node->save();
+
+    $this->assertFalse(
+      $node->get('status')->access('edit', $this->restricted),
+      'Without administer node published status, the status field is not editable - JSON:API 403s payloads that include it.'
+    );
+    $this->assertTrue(
+      $node->get('status')->access('edit', $this->editor),
+      'administer nodes unlocks status field edits.'
+    );
+  }
+
+  /**
+   * Creates a user with a dedicated role holding the given permissions.
+   *
+   * @param string[] $permissions
+   *   Permissions for the role.
+   * @param string $name
+   *   Account name (doubles as role id).
+   *
+   * @return \Drupal\user\Entity\User
+   *   The saved user.
+   */
+  protected function createUserWithPermissions(array $permissions, string $name): User {
+    $role = Role::create(['id' => $name . '_role', 'label' => $name]);
+    foreach ($permissions as $permission) {
+      $role->grantPermission($permission);
+    }
+    $role->save();
+    $user = User::create(['name' => $name, 'roles' => [$role->id()]]);
+    $user->save();
+    return $user;
+  }
+
+  /**
+   * Sets the acting user for presave hooks.
+   */
+  protected function setCurrentUser(User $user): void {
+    $this->container->get('current_user')->setAccount($user);
+  }
+
+}

--- a/webroot/modules/custom/saho_api_guard/tests/src/Kernel/JsonApiWriteRateLimiterTest.php
+++ b/webroot/modules/custom/saho_api_guard/tests/src/Kernel/JsonApiWriteRateLimiterTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_api_guard\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Tests the flood-backed JSON:API write rate limiter.
+ *
+ * @group saho_api_guard
+ */
+final class JsonApiWriteRateLimiterTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'saho_api_guard',
+  ];
+
+  /**
+   * The authenticated account issuing requests.
+   */
+  protected User $account;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installSchema('user', ['users_data']);
+    $this->installConfig(['saho_api_guard']);
+
+    // Tight limits so tests exercise both windows cheaply.
+    $this->config('saho_api_guard.settings')
+      ->set('writes_per_minute', 3)
+      ->set('writes_per_hour', 5)
+      ->save();
+
+    User::create(['name' => 'root'])->save();
+    $this->account = User::create(['name' => 'svc_harvester']);
+    $this->account->save();
+    $this->container->get('current_user')->setAccount($this->account);
+  }
+
+  /**
+   * Dispatches a request through the subscriber, returns the set response.
+   */
+  protected function fire(string $method, string $path): ?int {
+    $subscriber = $this->container->get('saho_api_guard.jsonapi_write_rate_limiter');
+    $request = Request::create($path, $method);
+    $event = new RequestEvent(
+      $this->container->get('http_kernel'),
+      $request,
+      HttpKernelInterface::MAIN_REQUEST
+    );
+    $subscriber->onRequest($event);
+    return $event->getResponse()?->getStatusCode();
+  }
+
+  /**
+   * Writes within the window pass; the write over the limit 429s.
+   */
+  public function testMinuteWindow(): void {
+    foreach (range(1, 3) as $i) {
+      $this->assertNull($this->fire('POST', '/jsonapi/node/archive'), "Write $i within the window passes.");
+    }
+    $this->assertSame(429, $this->fire('POST', '/jsonapi/node/archive'), 'The 4th write in a minute is rejected.');
+  }
+
+  /**
+   * GET requests and non-jsonapi paths are never limited.
+   */
+  public function testOnlyJsonApiWritesAreLimited(): void {
+    foreach (range(1, 10) as $i) {
+      $this->assertNull($this->fire('GET', '/jsonapi/node/archive'), 'GET is unlimited.');
+      $this->assertNull($this->fire('POST', '/node/add/archive'), 'Non-jsonapi paths are unlimited.');
+    }
+  }
+
+  /**
+   * Anonymous requests are skipped (entity access rejects them anyway).
+   */
+  public function testAnonymousSkipped(): void {
+    $this->container->get('current_user')->setAccount(User::getAnonymousUser());
+    foreach (range(1, 10) as $i) {
+      $this->assertNull($this->fire('POST', '/jsonapi/node/archive'), 'Anonymous writes are not flood-tracked.');
+    }
+  }
+
+  /**
+   * The bypass permission disables limiting for trusted accounts.
+   */
+  public function testBypassPermission(): void {
+    $role = Role::create(['id' => 'bypass', 'label' => 'bypass']);
+    $role->grantPermission('bypass api guard rate limits');
+    $role->save();
+    $trusted = User::create(['name' => 'trusted', 'roles' => ['bypass']]);
+    $trusted->save();
+    $this->container->get('current_user')->setAccount($trusted);
+
+    foreach (range(1, 10) as $i) {
+      $this->assertNull($this->fire('POST', '/jsonapi/node/archive'), 'Bypass permission skips the limiter.');
+    }
+  }
+
+  /**
+   * The config kill switch disables the limiter entirely.
+   */
+  public function testKillSwitch(): void {
+    $this->config('saho_api_guard.settings')->set('rate_limit_enabled', FALSE)->save();
+    foreach (range(1, 10) as $i) {
+      $this->assertNull($this->fire('POST', '/jsonapi/node/archive'), 'Disabled limiter never responds.');
+    }
+  }
+
+  /**
+   * A 429 carries Retry-After and a JSON:API error body.
+   */
+  public function testResponseShape(): void {
+    foreach (range(1, 3) as $i) {
+      $this->fire('POST', '/jsonapi/node/archive');
+    }
+    $subscriber = $this->container->get('saho_api_guard.jsonapi_write_rate_limiter');
+    $request = Request::create('/jsonapi/node/archive', 'POST');
+    $event = new RequestEvent(
+      $this->container->get('http_kernel'),
+      $request,
+      HttpKernelInterface::MAIN_REQUEST
+    );
+    $subscriber->onRequest($event);
+    $response = $event->getResponse();
+    $this->assertNotNull($response);
+    $this->assertSame('60', $response->headers->get('Retry-After'));
+    $body = json_decode($response->getContent(), TRUE);
+    $this->assertSame('429', $body['errors'][0]['status']);
+  }
+
+}

--- a/webroot/themes/custom/saho/saho.theme
+++ b/webroot/themes/custom/saho/saho.theme
@@ -2461,6 +2461,8 @@ function saho_preprocess_node__image(array &$variables): void {
   $source = '';
   if ($node->hasField('field_source') && !$node->get('field_source')->isEmpty()) {
     $source = trim(strip_tags((string) $node->get('field_source')->value));
+    // Never surface the factory's machine marker.
+    $source = trim((string) preg_replace('/\[saho_import:[^\]]*\]/', '', $source));
   }
 
   $facts = [];
@@ -2538,10 +2540,44 @@ function saho_preprocess_node__archive(array &$variables): void {
     return implode(', ', $labels);
   };
   $language = $term_labels('field_language');
+
+  // Effective creator (#494): structured original-creator names, each with
+  // its role when the deltas pair up, falling back to the legacy free-text
+  // author string. Machine-name roles render Title Case.
+  $creator = '';
+  if ($node->hasField('field_original_creator') && !$node->get('field_original_creator')->isEmpty()) {
+    $names = array_column($node->get('field_original_creator')->getValue(), 'value');
+    $roles = $node->hasField('field_original_creator_role')
+      ? array_column($node->get('field_original_creator_role')->getValue(), 'value')
+      : [];
+    $parts = [];
+    foreach ($names as $i => $name) {
+      $role = trim((string) ($roles[$i] ?? ''));
+      $parts[] = $role !== '' ? $name . ' (' . ucfirst($role) . ')' : $name;
+    }
+    $creator = implode('; ', $parts);
+  }
+  if ($creator === '') {
+    $creator = $value('field_author');
+  }
+
+  // Recording/creation date - distinct from first publication.
+  $recorded = '';
+  if ($node->hasField('field_original_created_date') && !$node->get('field_original_created_date')->isEmpty()) {
+    $recorded_date = $node->get('field_original_created_date')->date;
+    $recorded = $recorded_date ? $recorded_date->format('j M Y') : '';
+  }
+
+  // The factory's [saho_import: ...] marker is machine housekeeping - it
+  // must never reach readers' eyes.
+  $source_text = trim(strip_tags((string) ($node->hasField('field_source') && !$node->get('field_source')->isEmpty() ? $node->get('field_source')->value : '')));
+  $source_text = trim((string) preg_replace('/\[saho_import:[^\]]*\]/', '', $source_text));
+
   $rows = [
     'Origin date' => $origin,
+    'Recorded' => $recorded,
     'Format' => $term_labels('field_media_library_type'),
-    'Creator' => $value('field_author'),
+    'Creator' => $creator,
     // Editors + Contributors complete the statement of responsibility.
     'Editors' => trim(strip_tags((string) $value('field_editors'))),
     'Contributors' => trim(strip_tags((string) $value('field_contributor'))),
@@ -2549,9 +2585,35 @@ function saho_preprocess_node__archive(array &$variables): void {
       'value' => $language,
       'lang' => _saho_record_lang_code($language),
     ] : '',
-    'Source' => trim(strip_tags((string) ($node->hasField('field_source') && !$node->get('field_source')->isEmpty() ? $node->get('field_source')->value : ''))),
+    'Source' => $source_text,
+    'Rights' => trim(strip_tags((string) $value('field_copyright'))),
     'Holding ref' => $refs->getRef($node),
   ];
+
+  // Original source URL(s) (#494): where the work canonically lives.
+  if ($node->hasField('field_original_source_url') && !$node->get('field_original_source_url')->isEmpty()) {
+    $first_link = $node->get('field_original_source_url')->first();
+    $link_uri = (string) $first_link->uri;
+    if ($link_uri !== '') {
+      $link_label = trim((string) $first_link->title);
+      if ($link_label === '' || $link_label === 'Original record') {
+        $link_label = (string) (parse_url($link_uri, PHP_URL_HOST) ?: $link_uri);
+        $link_label = preg_replace('/^www\./', '', $link_label);
+      }
+      $rows['Original source'] = [
+        'value' => $link_label,
+        'href' => Url::fromUri($link_uri)->toString(),
+      ];
+    }
+  }
+
+  // Provenance note (#494): the free-text acknowledgement, plain-rendered.
+  if ($node->hasField('field_provenance_note') && !$node->get('field_provenance_note')->isEmpty()) {
+    $prov_text = trim(strip_tags((string) $node->get('field_provenance_note')->value));
+    if ($prov_text !== '') {
+      $rows['Provenance'] = $prov_text;
+    }
+  }
 
   // Legacy source-link pair (field_link_url + field_link_title): a designed
   // row in Record details instead of an unstyled dump in the main column.

--- a/webroot/themes/custom/saho/saho.theme
+++ b/webroot/themes/custom/saho/saho.theme
@@ -2590,20 +2590,40 @@ function saho_preprocess_node__archive(array &$variables): void {
     'Holding ref' => $refs->getRef($node),
   ];
 
-  // Original source URL(s) (#494): where the work canonically lives.
+  // Original source URL(s) (#494): the resolved provider page first, then
+  // persistent identifiers (ARK/DOI) as their own rows - readers get the
+  // deep link, citations get the stable one.
   if ($node->hasField('field_original_source_url') && !$node->get('field_original_source_url')->isEmpty()) {
-    $first_link = $node->get('field_original_source_url')->first();
-    $link_uri = (string) $first_link->uri;
-    if ($link_uri !== '') {
-      $link_label = trim((string) $first_link->title);
-      if ($link_label === '' || $link_label === 'Original record') {
-        $link_label = (string) (parse_url($link_uri, PHP_URL_HOST) ?: $link_uri);
-        $link_label = preg_replace('/^www\./', '', $link_label);
+    foreach ($node->get('field_original_source_url')->getValue() as $delta => $link_item) {
+      $link_uri = (string) ($link_item['uri'] ?? '');
+      if ($link_uri === '') {
+        continue;
       }
-      $rows['Original source'] = [
-        'value' => $link_label,
-        'href' => Url::fromUri($link_uri)->toString(),
-      ];
+      $link_title = trim((string) ($link_item['title'] ?? ''));
+      // Persistent-ID detection is by HOST - provider pages (Calisphere)
+      // legitimately embed ark:/ in their item paths.
+      $link_host = strtolower((string) (parse_url($link_uri, PHP_URL_HOST) ?: ''));
+      $is_persistent = stripos($link_title, 'persistent') !== FALSE
+        || in_array($link_host, ['ark.cdlib.org', 'n2t.net', 'doi.org', 'dx.doi.org', 'hdl.handle.net', 'purl.org'], TRUE);
+      if ($delta === 0 && !$is_persistent) {
+        $link_label = $link_title;
+        if ($link_label === '' || $link_label === 'Original record') {
+          $link_label = (string) (parse_url($link_uri, PHP_URL_HOST) ?: $link_uri);
+          $link_label = preg_replace('/^www\./', '', $link_label);
+        }
+        $rows['Original source'] = [
+          'value' => $link_label,
+          'href' => Url::fromUri($link_uri)->toString(),
+        ];
+      }
+      else {
+        // Short display form: the identifier path beats a naked host.
+        $short = preg_replace('#^https?://[^/]+/#', '', $link_uri);
+        $rows['Persistent ID'] = [
+          'value' => $short !== '' ? $short : $link_uri,
+          'href' => Url::fromUri($link_uri)->toString(),
+        ];
+      }
     }
   }
 


### PR DESCRIPTION
Drupal-side prerequisites for the Archive Factory local-to-prod content transport (#495 Tier 4).

## Commit 1 - Catalyst provenance fields (#494, fields-only phase)
Field-reuse audit drove the model (details in commit message): 5 new fields on archive + `field_archive_publication_date` reused as the structured original-publication slot; grouped 'Provenance & Attribution' form section; view displays untouched. Citation-generator integration and the display block remain on #494.
Also rides: `saho_timeline_dates` added to core.extension (#495 Tier 0 gap).

## Commit 2 - saho_api_guard + service roles + JSON:API writes (#393)
- `jsonapi.settings read_only: false`
- `api_harvester` (create + edit-own, 6 bundles) / `api_aiditor` (edit-any, NO create) roles
- Structural never-publish: presave forces restricted accounts' saves unpublished (core status defaults to PUBLISHED when omitted - field access alone cannot cover this); node_access hook locks published nodes; flood-based write rate limiter (60/min, 1000/hr, kill switch)
- 11 kernel tests; live-verified on DDEV (403 pointer on status, 201-unpublished create, 429 + Retry-After burst)

## Commit 3 - REVIEW FLAG: authenticated-role trim
Moves `edit any`/`delete any` media+files perms and `full_html` from **authenticated** (every champion/shop customer had them) to editor/researcher roles verbatim. Needs editorial sign-off - see commit message.

## Prod runbook (after merge + deploy)
```
drush user:create svc_harvester --mail=svc-harvester@sahistory.org.za --password="$(openssl rand -base64 32)"
drush user:role:add api_harvester svc_harvester
# same for svc_aiditor / api_aiditor
```
Plus Cloudflare WAF skip rule (path /jsonapi AND agent-IP list), cache-bypass for /jsonapi*, mod_security test (CRS 920420 family), MultiPHP body-size limits. Kill switch: `drush cset jsonapi.settings read_only 1`.

Factory/AIditor counterparts: saho-archive-import `feat/jsonapi-ship-transport` (ship v2: files/terms/parent remap, approval gate) and saho-aiditor main (hardened client).

Refs #393 #494 #495