### PR TITLE
feat(dashboard): contributor dashboard with badges, achievements and task shortcuts

### DIFF
--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -28,8 +28,10 @@ dependencies:
     - file_entity
     - filter
     - help
+    - linkchecker
     - media
     - node
+    - redirect
     - system
     - toolbar
     - webform
@@ -39,6 +41,7 @@ weight: 3
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access broken links report'
   - 'access comments'
   - 'access content'
   - 'access content overview'
@@ -48,8 +51,10 @@ permissions:
   - 'access site in maintenance mode'
   - 'access toolbar'
   - 'access user profiles'
+  - 'administer comments'
   - 'administer filters'
   - 'administer nodes'
+  - 'administer redirects'
   - 'create archive content'
   - 'create article content'
   - 'create biography content'

--- a/config/sync/user.role.moderator.yml
+++ b/config/sync/user.role.moderator.yml
@@ -10,24 +10,31 @@ dependencies:
     - file
     - filter
     - help
+    - linkchecker
     - node
+    - redirect
     - system
+    - webform
 id: moderator
 label: moderator
 weight: 6
 is_admin: null
 permissions:
   - 'access administration pages'
+  - 'access broken links report'
   - 'access comments'
   - 'access content'
   - 'access help pages'
   - 'access site in maintenance mode'
   - 'access user profiles'
+  - 'administer comments'
+  - 'administer redirects'
   - 'delete own files'
   - 'edit own comments'
   - 'post comments'
   - 'skip comment approval'
   - 'use text format filtered_html'
   - 'use text format full_html'
+  - 'view any webform submission'
   - 'view own unpublished content'
   - 'view the administration theme'

--- a/webroot/modules/custom/saho_dashboard/css/dashboard.css
+++ b/webroot/modules/custom/saho_dashboard/css/dashboard.css
@@ -208,3 +208,225 @@ a.saho-task-tile:hover {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* Anniversary ribbon + on-this-day strip. */
+
+.saho-dash-ribbon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid #e7d9ae;
+  border-radius: 0.5rem;
+  background: linear-gradient(160deg, #fbf6e8, #f4e9cc);
+  color: var(--saho-color-primary, #990000);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.saho-dash-otd {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.6rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--saho-color-border, #e2ded6);
+  border-left: 3px solid var(--saho-color-accent, #b88a2e);
+  border-radius: 0.5rem;
+  background: var(--saho-color-surface, #fff);
+  font-size: 0.85rem;
+}
+
+.saho-dash-otd .saho-dash-icon {
+  color: var(--saho-color-accent, #b88a2e);
+  align-self: center;
+}
+
+.saho-dash-otd__kicker {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--saho-color-text-muted, #5d5e52);
+}
+
+.saho-dash-otd__year {
+  font-weight: 700;
+  color: var(--saho-color-accent, #b88a2e);
+}
+
+/* Impact tiles. */
+
+.saho-dash-impact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+
+.saho-impact-tile {
+  display: flex;
+  gap: 0.7rem;
+  padding: 0.85rem 0.9rem;
+  border: 1px solid var(--saho-color-border, #e2ded6);
+  border-left: 3px solid var(--saho-color-accent, #b88a2e);
+  border-radius: 0.5rem;
+  background: var(--saho-color-surface, #fff);
+}
+
+.saho-impact-tile__icon {
+  color: var(--saho-color-accent, #b88a2e);
+  margin-top: 0.15rem;
+}
+
+.saho-impact-tile__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.saho-impact-tile__count {
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--saho-color-primary, #990000);
+  font-variant-numeric: tabular-nums;
+}
+
+.saho-impact-tile__title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.saho-impact-tile__title a {
+  color: var(--saho-color-primary, #990000);
+}
+
+.saho-impact-tile__label {
+  font-size: 0.78rem;
+  color: var(--saho-color-text-muted, #5d5e52);
+  line-height: 1.35;
+}
+
+/* Mystery (secret, unrevealed) medallions. */
+
+.saho-medallion--mystery .saho-medallion__disc {
+  color: #6b6b66;
+  border-style: dashed;
+  border-color: #b4aea3;
+  background: #efede8;
+}
+
+.saho-medallion--mystery .saho-medallion__name {
+  letter-spacing: 0.15em;
+}
+
+/* Hover shine and lift (pointer devices only). */
+
+@media (hover: hover) {
+  .saho-medallion {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .saho-medallion:hover {
+    transform: translateY(-2px) rotate(-0.5deg);
+    box-shadow: var(--saho-color-shadow-sm, 0 2px 8px rgba(0, 0, 0, 0.12));
+  }
+
+  .saho-medallion__disc {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .saho-medallion__disc::after {
+    content: '';
+    position: absolute;
+    top: -60%;
+    left: -80%;
+    width: 60%;
+    height: 220%;
+    transform: rotate(25deg) translateX(0);
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
+    transition: transform 0.6s ease;
+    pointer-events: none;
+  }
+
+  .saho-medallion:hover .saho-medallion__disc::after {
+    transform: rotate(25deg) translateX(320%);
+  }
+}
+
+/* Progress bars animate when JS drives them into view. */
+
+.saho-medallion__bar {
+  transition: width 0.9s ease;
+}
+
+/* Vault card (Konami reveal). */
+
+.saho-dash-easter {
+  outline: none;
+  border-left: 3px solid var(--saho-color-accent, #b88a2e);
+}
+
+.saho-dash-easter .saho-dash-icon {
+  color: var(--saho-color-accent, #b88a2e);
+}
+
+.saho-dash-easter__label {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--saho-color-text-muted, #5d5e52);
+}
+
+/* Toast + confetti. */
+
+.saho-dash-toast {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1080;
+  max-width: 320px;
+  padding: 0.7rem 1rem;
+  border-radius: 0.5rem;
+  border-left: 3px solid var(--saho-color-accent, #b88a2e);
+  background: var(--saho-color-primary, #990000);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  transform: translateY(0.75rem);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.saho-dash-toast--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.saho-dash-confetti {
+  position: fixed;
+  inset: 0;
+  z-index: 1090;
+  pointer-events: none;
+}
+
+/* Reduced motion: no lifts, shines, fills or slides. */
+
+@media (prefers-reduced-motion: reduce) {
+  .saho-medallion,
+  .saho-medallion__disc::after,
+  .saho-medallion__bar,
+  .saho-dash-toast,
+  .saho-task-tile {
+    transition: none;
+  }
+
+  .saho-medallion:hover {
+    transform: none;
+  }
+}

--- a/webroot/modules/custom/saho_dashboard/css/dashboard.css
+++ b/webroot/modules/custom/saho_dashboard/css/dashboard.css
@@ -1,0 +1,210 @@
+/**
+ * Contributor dashboard - role pills, achievement medallions, task tiles.
+ *
+ * Built on the theme's design tokens (CSS custom properties from
+ * _design-tokens.scss). Light surface only - the theme has no dark mode.
+ */
+
+.saho-dash-header__roles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.saho-dash-role {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.saho-dash-role .saho-dash-icon {
+  flex-shrink: 0;
+}
+
+.saho-dash-header__stats {
+  font-size: var(--saho-font-size-sm, 0.875rem);
+}
+
+/* Achievements strip. */
+
+.saho-dash-achievements {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.saho-medallion {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 0.9rem 0.6rem 0.8rem;
+  border: 1px solid var(--saho-color-border, #e2ded6);
+  border-radius: 0.5rem;
+  background: var(--saho-color-surface, #fff);
+}
+
+.saho-medallion__disc {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  margin-bottom: 0.45rem;
+}
+
+.saho-medallion--gold .saho-medallion__disc {
+  color: #8a6414;
+  background: linear-gradient(160deg, #f4e3b8, #d9b45c);
+  border-color: #b88a2e;
+}
+
+.saho-medallion--silver .saho-medallion__disc {
+  color: #4c5259;
+  background: linear-gradient(160deg, #eceff2, #c3c9d0);
+  border-color: #9aa2ab;
+}
+
+.saho-medallion--bronze .saho-medallion__disc {
+  color: #6d3a17;
+  background: linear-gradient(160deg, #ecc9a8, #c98a52);
+  border-color: #a05a2c;
+}
+
+.saho-medallion--locked {
+  border-style: dashed;
+}
+
+.saho-medallion--locked .saho-medallion__disc {
+  color: #b4aea3;
+  border-color: #d6d3cd;
+  background: #f6f4f0;
+}
+
+.saho-medallion__name {
+  font-weight: 600;
+  font-size: 0.85rem;
+  line-height: 1.2;
+}
+
+.saho-medallion__status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6b6b66;
+}
+
+.saho-medallion__status--gold { color: #8a6414; }
+.saho-medallion__status--silver { color: #4c5259; }
+.saho-medallion__status--bronze { color: #6d3a17; }
+
+.saho-medallion__metric {
+  font-size: 0.72rem;
+  color: var(--saho-color-text-muted, #5d5e52);
+  line-height: 1.25;
+}
+
+.saho-medallion__track {
+  width: 100%;
+  height: 4px;
+  margin-top: 0.5rem;
+  border-radius: 2px;
+  background: #eceae4;
+  overflow: hidden;
+}
+
+.saho-medallion__bar {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  background: var(--saho-color-accent, #b88a2e);
+}
+
+/* Task tiles. */
+
+.saho-dash-section-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.saho-dash-tasks {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+
+.saho-task-tile {
+  display: flex;
+  gap: 0.7rem;
+  padding: 0.85rem 0.9rem;
+  border: 1px solid var(--saho-color-border, #e2ded6);
+  border-left: 3px solid var(--saho-color-primary, #990000);
+  border-radius: 0.5rem;
+  background: var(--saho-color-surface, #fff);
+  color: inherit;
+  text-decoration: none;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+a.saho-task-tile:hover {
+  box-shadow: var(--saho-color-shadow-sm, 0 2px 8px rgba(0, 0, 0, 0.12));
+  transform: translateY(-1px);
+  color: inherit;
+}
+
+.saho-task-tile--clear {
+  border-left-color: var(--saho-color-success, #22c55e);
+}
+
+.saho-task-tile__icon {
+  color: var(--saho-color-primary, #990000);
+  margin-top: 0.15rem;
+}
+
+.saho-task-tile--clear .saho-task-tile__icon {
+  color: var(--saho-color-success, #22c55e);
+}
+
+.saho-task-tile__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.saho-task-tile__count {
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.saho-task-tile__title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.saho-task-tile__blurb {
+  font-size: 0.78rem;
+  color: var(--saho-color-text-muted, #5d5e52);
+  line-height: 1.35;
+}
+
+.saho-task-tile__samples {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-top: 0.4rem;
+  font-size: 0.78rem;
+}
+
+.saho-task-tile__samples a {
+  color: var(--saho-color-primary, #990000);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/webroot/modules/custom/saho_dashboard/js/dashboard.js
+++ b/webroot/modules/custom/saho_dashboard/js/dashboard.js
@@ -1,0 +1,296 @@
+/**
+ * @file
+ * Interactivity for the contributor dashboard.
+ *
+ * Count-up numbers, progress-bar fills, tier-up celebrations (confetti +
+ * toast), role-badge tooltips and the Konami-code vault. Everything degrades
+ * gracefully: server-rendered markup is complete without JS, and animation
+ * honours prefers-reduced-motion.
+ */
+
+(function (Drupal, drupalSettings, once) {
+  'use strict';
+
+  var REDUCED = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  var CONFETTI_COLORS = ['#990000', '#b88a2e', '#e2ded6', '#4c5259'];
+
+  var TIER_RANK = { bronze: 1, silver: 2, gold: 3 };
+
+  var KONAMI = [
+    'ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
+    'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a',
+  ];
+
+  /**
+   * Safe localStorage JSON access (pattern borrowed from theme saho-utils).
+   */
+  var storage = {
+    get: function (key) {
+      try {
+        var raw = window.localStorage.getItem(key);
+        return raw === null ? null : JSON.parse(raw);
+      }
+      catch (e) {
+        return null;
+      }
+    },
+    set: function (key, value) {
+      try {
+        window.localStorage.setItem(key, JSON.stringify(value));
+        return true;
+      }
+      catch (e) {
+        return false;
+      }
+    },
+  };
+
+  /**
+   * Mirrors DashboardBuilder::compact() so animation frames match the
+   * server-rendered final text.
+   */
+  function formatCompact(n) {
+    if (n >= 1000000) {
+      var m = Math.round(n / 100000) / 10;
+      return (m % 1 === 0 ? String(m) : m.toFixed(1)) + 'M';
+    }
+    if (n >= 10000) {
+      return Math.round(n / 1000).toLocaleString('en-US') + 'k';
+    }
+    return n.toLocaleString('en-US');
+  }
+
+  /**
+   * Eases a number from 0 to target inside the element (rAF, ease-out cubic).
+   */
+  function animateCount(el, target, compact) {
+    var duration = 1200;
+    var start = null;
+    var format = compact ? formatCompact : function (n) {
+      return n.toLocaleString('en-US');
+    };
+    function frame(ts) {
+      if (start === null) {
+        start = ts;
+      }
+      var progress = Math.min((ts - start) / duration, 1);
+      var eased = 1 - Math.pow(1 - progress, 3);
+      el.textContent = format(Math.round(target * eased));
+      if (progress < 1) {
+        window.requestAnimationFrame(frame);
+      }
+    }
+    window.requestAnimationFrame(frame);
+  }
+
+  /**
+   * Animates count-ups and progress bars as they scroll into view.
+   */
+  function initReveals(root) {
+    var counters = root.querySelectorAll('[data-countup]');
+    var bars = root.querySelectorAll('.saho-medallion__bar[data-progress]');
+    if (REDUCED || !('IntersectionObserver' in window)) {
+      return;
+    }
+    // Prime the bars at zero so the CSS width transition has a run-up.
+    bars.forEach(function (bar) {
+      bar.style.width = '0%';
+    });
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) {
+          return;
+        }
+        var el = entry.target;
+        observer.unobserve(el);
+        if (el.hasAttribute('data-countup')) {
+          var target = Number.parseInt(el.getAttribute('data-countup'), 10);
+          if (!Number.isNaN(target)) {
+            animateCount(el, target, el.hasAttribute('data-countup-compact'));
+          }
+        }
+        else {
+          el.style.width = el.getAttribute('data-progress') + '%';
+        }
+      });
+    }, { threshold: 0.4 });
+    counters.forEach(function (el) {
+      observer.observe(el);
+    });
+    bars.forEach(function (el) {
+      observer.observe(el);
+    });
+  }
+
+  /**
+   * Initializes Bootstrap tooltips on role badges, if Tooltip is available.
+   *
+   * The theme's one-shot initializer runs at page load only, so re-init
+   * defensively for anything it may have missed.
+   */
+  function initTooltips(root) {
+    if (!window.bootstrap || !window.bootstrap.Tooltip) {
+      return;
+    }
+    root.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+      if (!window.bootstrap.Tooltip.getInstance(el)) {
+        new window.bootstrap.Tooltip(el);
+      }
+    });
+  }
+
+  /**
+   * Shows a small self-made toast (the theme bundle does not ship
+   * bootstrap's Toast component).
+   */
+  function showToast(message, delay) {
+    window.setTimeout(function () {
+      var toast = document.createElement('div');
+      toast.className = 'saho-dash-toast';
+      toast.setAttribute('role', 'status');
+      toast.textContent = message;
+      document.body.appendChild(toast);
+      window.requestAnimationFrame(function () {
+        toast.classList.add('saho-dash-toast--visible');
+      });
+      window.setTimeout(function () {
+        toast.classList.remove('saho-dash-toast--visible');
+        window.setTimeout(function () {
+          toast.remove();
+        }, 400);
+      }, 5000);
+    }, delay || 0);
+  }
+
+  /**
+   * Fires a short canvas confetti burst in the SAHO palette.
+   */
+  function confettiBurst(count) {
+    if (REDUCED) {
+      return;
+    }
+    var canvas = document.createElement('canvas');
+    canvas.className = 'saho-dash-confetti';
+    canvas.setAttribute('aria-hidden', 'true');
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    document.body.appendChild(canvas);
+    var ctx = canvas.getContext('2d');
+    var particles = [];
+    var total = count || 90;
+    for (var i = 0; i < total; i++) {
+      particles.push({
+        x: canvas.width * (0.3 + Math.random() * 0.4),
+        y: -20 - Math.random() * canvas.height * 0.2,
+        vx: (Math.random() - 0.5) * 4,
+        vy: 2 + Math.random() * 3,
+        size: 5 + Math.random() * 6,
+        color: CONFETTI_COLORS[i % CONFETTI_COLORS.length],
+        rotation: Math.random() * Math.PI,
+        spin: (Math.random() - 0.5) * 0.2,
+      });
+    }
+    var start = null;
+    function frame(ts) {
+      if (start === null) {
+        start = ts;
+      }
+      var elapsed = ts - start;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      particles.forEach(function (p) {
+        p.x += p.vx;
+        p.y += p.vy;
+        p.vy += 0.06;
+        p.rotation += p.spin;
+        ctx.save();
+        ctx.translate(p.x, p.y);
+        ctx.rotate(p.rotation);
+        ctx.fillStyle = p.color;
+        ctx.globalAlpha = Math.max(0, 1 - elapsed / 1800);
+        ctx.fillRect(-p.size / 2, -p.size / 4, p.size, p.size / 2);
+        ctx.restore();
+      });
+      if (elapsed < 1800) {
+        window.requestAnimationFrame(frame);
+      }
+      else {
+        canvas.remove();
+      }
+    }
+    window.requestAnimationFrame(frame);
+  }
+
+  /**
+   * Celebrates newly attained tiers since the visitor's last visit.
+   *
+   * Baseline lives in localStorage per uid. The very first visit seeds
+   * silently, so long-standing gold holders do not get a confetti storm
+   * the day this ships.
+   */
+  function initTierCelebration(settings) {
+    var key = 'saho-dashboard-tiers-' + settings.uid;
+    var current = settings.tiers || {};
+    var stored = storage.get(key);
+    if (stored === null || typeof stored !== 'object') {
+      storage.set(key, current);
+      return;
+    }
+    var gained = [];
+    Object.keys(current).forEach(function (id) {
+      var now = TIER_RANK[current[id]] || 0;
+      var before = TIER_RANK[stored[id]] || 0;
+      if (now > before && settings.names && settings.names[id]) {
+        gained.push({ name: settings.names[id], tier: current[id] });
+      }
+    });
+    storage.set(key, current);
+    if (!gained.length) {
+      return;
+    }
+    confettiBurst();
+    gained.forEach(function (g, index) {
+      var tier = g.tier.charAt(0).toUpperCase() + g.tier.slice(1);
+      showToast(g.name + ' - ' + tier + ' attained', index * 1200);
+    });
+  }
+
+  /**
+   * Wires the Konami code to the hidden vault card.
+   */
+  function initKonami(root) {
+    var vault = root.querySelector('[data-saho-easter]');
+    if (!vault) {
+      return;
+    }
+    var position = 0;
+    function onKeydown(event) {
+      var expected = KONAMI[position];
+      var key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+      position = key === expected ? position + 1 : (key === KONAMI[0] ? 1 : 0);
+      if (position === KONAMI.length) {
+        document.removeEventListener('keydown', onKeydown);
+        vault.removeAttribute('hidden');
+        vault.scrollIntoView({ behavior: REDUCED ? 'auto' : 'smooth', block: 'center' });
+        vault.focus({ preventScroll: true });
+        confettiBurst(40);
+      }
+    }
+    document.addEventListener('keydown', onKeydown);
+  }
+
+  Drupal.behaviors.sahoDashboard = {
+    attach: function (context) {
+      once('saho-dashboard', '.saho-dashboard', context).forEach(function (root) {
+        var settings = (drupalSettings && drupalSettings.sahoDashboard) || {};
+        initReveals(root);
+        initTooltips(root);
+        if (settings.owner === true) {
+          initTierCelebration(settings);
+          initKonami(root);
+        }
+      });
+    },
+  };
+
+})(Drupal, drupalSettings, once);

--- a/webroot/modules/custom/saho_dashboard/saho_dashboard.info.yml
+++ b/webroot/modules/custom/saho_dashboard/saho_dashboard.info.yml
@@ -1,0 +1,8 @@
+name: 'SAHO Dashboard'
+type: module
+description: 'Adds a lightweight contributor dashboard to the user profile page.'
+package: SAHO
+core_version_requirement: ^10 || ^11
+dependencies:
+  - drupal:node
+  - drupal:user

--- a/webroot/modules/custom/saho_dashboard/saho_dashboard.libraries.yml
+++ b/webroot/modules/custom/saho_dashboard/saho_dashboard.libraries.yml
@@ -1,0 +1,7 @@
+dashboard:
+  version: 1.x
+  css:
+    theme:
+      css/dashboard.css: {}
+  dependencies:
+    - saho/saho-badge

--- a/webroot/modules/custom/saho_dashboard/saho_dashboard.libraries.yml
+++ b/webroot/modules/custom/saho_dashboard/saho_dashboard.libraries.yml
@@ -1,7 +1,12 @@
 dashboard:
-  version: 1.x
+  version: 1.1.x
   css:
     theme:
       css/dashboard.css: {}
+  js:
+    js/dashboard.js: {}
   dependencies:
     - saho/saho-badge
+    - core/drupal
+    - core/once
+    - core/drupalSettings

--- a/webroot/modules/custom/saho_dashboard/saho_dashboard.module
+++ b/webroot/modules/custom/saho_dashboard/saho_dashboard.module
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ * Adds a lightweight contributor dashboard to the user profile page.
+ */
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Implements hook_theme().
+ */
+function saho_dashboard_theme($existing, $type, $theme, $path) {
+  return [
+    'saho_dashboard' => [
+      'variables' => [
+        'stats' => [],
+        'recent' => [],
+        'review' => [],
+      ],
+    ],
+  ];
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_view() for user entities.
+ */
+function saho_dashboard_user_view(array &$build, UserInterface $account, EntityViewDisplayInterface $display, $view_mode) {
+  if ($view_mode !== 'full') {
+    return;
+  }
+  // Own profile only: this is a personal worklist, not a public byline.
+  if ((int) $account->id() !== (int) \Drupal::currentUser()->id()) {
+    return;
+  }
+
+  $data = \Drupal::service('saho_dashboard.builder')->build($account);
+  if ($data === NULL) {
+    return;
+  }
+
+  $build['saho_dashboard'] = [
+    '#theme' => 'saho_dashboard',
+    '#stats' => $data['stats'],
+    '#recent' => $data['recent'],
+    '#review' => $data['review'],
+    '#weight' => -10,
+    '#cache' => [
+      'contexts' => ['user'],
+      'max-age' => 3600,
+    ],
+  ];
+}

--- a/webroot/modules/custom/saho_dashboard/saho_dashboard.module
+++ b/webroot/modules/custom/saho_dashboard/saho_dashboard.module
@@ -21,6 +21,10 @@ function saho_dashboard_theme($existing, $type, $theme, $path) {
         'tasks' => [],
         'recent' => [],
         'review' => [],
+        'impact' => NULL,
+        'on_this_day' => NULL,
+        'anniversary' => NULL,
+        'easter' => NULL,
         'owner' => TRUE,
       ],
     ],
@@ -47,6 +51,17 @@ function saho_dashboard_user_view(array &$build, UserInterface $account, EntityV
     return;
   }
 
+  // Achievement names go to JS only for revealed rows, so an unearned
+  // secret cannot be read out of drupalSettings.
+  $tiers = [];
+  $names = [];
+  foreach ($data['achievements'] as $achievement) {
+    $tiers[$achievement['id']] = $achievement['tier'];
+    if ($achievement['revealed']) {
+      $names[$achievement['id']] = $achievement['name'];
+    }
+  }
+
   $build['saho_dashboard'] = [
     '#theme' => 'saho_dashboard',
     '#stats' => $data['stats'],
@@ -55,11 +70,25 @@ function saho_dashboard_user_view(array &$build, UserInterface $account, EntityV
     '#tasks' => $data['tasks'],
     '#recent' => $data['recent'],
     '#review' => $data['review'],
+    '#impact' => $data['impact'],
+    '#on_this_day' => $data['on_this_day'],
+    '#anniversary' => $data['anniversary'],
+    '#easter' => $data['easter'],
     '#owner' => $owner,
     '#weight' => -10,
     '#attached' => [
       'library' => ['saho_dashboard/dashboard'],
+      'drupalSettings' => [
+        'sahoDashboard' => [
+          'uid' => (int) $account->id(),
+          'owner' => $owner,
+          'tiers' => $tiers,
+          'names' => $names,
+        ],
+      ],
     ],
+    // 15 minutes; the on-this-day strip and anniversary ribbon are at worst
+    // that stale across SAST midnight, which is fine for a profile page.
     '#cache' => [
       'contexts' => ['user'],
       'max-age' => 900,

--- a/webroot/modules/custom/saho_dashboard/saho_dashboard.module
+++ b/webroot/modules/custom/saho_dashboard/saho_dashboard.module
@@ -18,6 +18,7 @@ function saho_dashboard_theme($existing, $type, $theme, $path) {
         'stats' => [],
         'recent' => [],
         'review' => [],
+        'owner' => TRUE,
       ],
     ],
   ];
@@ -30,8 +31,10 @@ function saho_dashboard_user_view(array &$build, UserInterface $account, EntityV
   if ($view_mode !== 'full') {
     return;
   }
-  // Own profile only: this is a personal worklist, not a public byline.
-  if ((int) $account->id() !== (int) \Drupal::currentUser()->id()) {
+  // Own profile, or any profile for user admins: this is a worklist for
+  // the small editorial team, not a public byline.
+  $owner = (int) $account->id() === (int) \Drupal::currentUser()->id();
+  if (!$owner && !\Drupal::currentUser()->hasPermission('administer users')) {
     return;
   }
 
@@ -45,6 +48,7 @@ function saho_dashboard_user_view(array &$build, UserInterface $account, EntityV
     '#stats' => $data['stats'],
     '#recent' => $data['recent'],
     '#review' => $data['review'],
+    '#owner' => $owner,
     '#weight' => -10,
     '#cache' => [
       'contexts' => ['user'],

--- a/webroot/modules/custom/saho_dashboard/saho_dashboard.module
+++ b/webroot/modules/custom/saho_dashboard/saho_dashboard.module
@@ -16,6 +16,9 @@ function saho_dashboard_theme($existing, $type, $theme, $path) {
     'saho_dashboard' => [
       'variables' => [
         'stats' => [],
+        'roles' => [],
+        'achievements' => [],
+        'tasks' => [],
         'recent' => [],
         'review' => [],
         'owner' => TRUE,
@@ -33,12 +36,13 @@ function saho_dashboard_user_view(array &$build, UserInterface $account, EntityV
   }
   // Own profile, or any profile for user admins: this is a worklist for
   // the small editorial team, not a public byline.
-  $owner = (int) $account->id() === (int) \Drupal::currentUser()->id();
-  if (!$owner && !\Drupal::currentUser()->hasPermission('administer users')) {
+  $viewer = \Drupal::currentUser();
+  $owner = (int) $account->id() === (int) $viewer->id();
+  if (!$owner && !$viewer->hasPermission('administer users')) {
     return;
   }
 
-  $data = \Drupal::service('saho_dashboard.builder')->build($account);
+  $data = \Drupal::service('saho_dashboard.builder')->build($account, $viewer, $owner);
   if ($data === NULL) {
     return;
   }
@@ -46,13 +50,19 @@ function saho_dashboard_user_view(array &$build, UserInterface $account, EntityV
   $build['saho_dashboard'] = [
     '#theme' => 'saho_dashboard',
     '#stats' => $data['stats'],
+    '#roles' => $data['roles'],
+    '#achievements' => $data['achievements'],
+    '#tasks' => $data['tasks'],
     '#recent' => $data['recent'],
     '#review' => $data['review'],
     '#owner' => $owner,
     '#weight' => -10,
+    '#attached' => [
+      'library' => ['saho_dashboard/dashboard'],
+    ],
     '#cache' => [
       'contexts' => ['user'],
-      'max-age' => 3600,
+      'max-age' => 900,
     ],
   ];
 }

--- a/webroot/modules/custom/saho_dashboard/saho_dashboard.services.yml
+++ b/webroot/modules/custom/saho_dashboard/saho_dashboard.services.yml
@@ -6,3 +6,4 @@ services:
       - '@entity_type.manager'
       - '@date.formatter'
       - '@datetime.time'
+      - '@?tdih.node_fetcher'

--- a/webroot/modules/custom/saho_dashboard/saho_dashboard.services.yml
+++ b/webroot/modules/custom/saho_dashboard/saho_dashboard.services.yml
@@ -1,0 +1,8 @@
+services:
+  saho_dashboard.builder:
+    class: Drupal\saho_dashboard\Service\DashboardBuilder
+    arguments:
+      - '@database'
+      - '@entity_type.manager'
+      - '@date.formatter'
+      - '@datetime.time'

--- a/webroot/modules/custom/saho_dashboard/src/Service/DashboardBuilder.php
+++ b/webroot/modules/custom/saho_dashboard/src/Service/DashboardBuilder.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Drupal\saho_dashboard\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\user\UserInterface;
+
+/**
+ * Builds the contributor dashboard shown on a user's own profile page.
+ *
+ * Deliberately lightweight: three read-only sections (stats, recent work,
+ * review reminders) driven by two small queries. No moderation states, no
+ * task queues - just a gentle nudge towards content that has gone stale.
+ */
+class DashboardBuilder {
+
+  /**
+   * Content untouched for this long is suggested for review (3 years).
+   */
+  const REVIEW_AGE_SECONDS = 94608000;
+
+  /**
+   * Maximum items listed per section.
+   */
+  const ITEMS_PER_SECTION = 6;
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The date formatter.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
+   * Constructs a DashboardBuilder.
+   */
+  public function __construct(Connection $database, EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter, TimeInterface $time) {
+    $this->database = $database;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->dateFormatter = $date_formatter;
+    $this->time = $time;
+  }
+
+  /**
+   * Builds the dashboard render data for the given account.
+   *
+   * @param \Drupal\user\UserInterface $account
+   *   The user whose profile page is being viewed.
+   *
+   * @return array|null
+   *   Render-ready data, or NULL when the user has no content activity.
+   */
+  public function build(UserInterface $account) {
+    $uid = (int) $account->id();
+    $stats = $this->getStats($uid);
+    if ($stats['worked_on'] === 0) {
+      return NULL;
+    }
+
+    return [
+      'stats' => $stats,
+      'recent' => $this->getRecentItems($uid),
+      'review' => $this->getReviewItems($uid),
+    ];
+  }
+
+  /**
+   * Returns headline counts for the user.
+   */
+  protected function getStats(int $uid): array {
+    $authored = (int) $this->database->select('node_field_data', 'n')
+      ->condition('n.uid', $uid)
+      ->condition('n.default_langcode', 1)
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+
+    $worked_on = (int) $this->database->query(
+      'SELECT COUNT(DISTINCT r.nid) FROM {node_revision} r WHERE r.revision_uid = :uid',
+      [':uid' => $uid]
+    )->fetchField();
+
+    return [
+      'authored' => $authored,
+      'worked_on' => max($worked_on, $authored),
+    ];
+  }
+
+  /**
+   * Nodes the user last touched, by their own newest revision.
+   *
+   * Sorting by the user's own revision timestamp (not node.changed) keeps
+   * bulk re-saves by other people or scripts from drowning out the user's
+   * actual edits.
+   */
+  protected function getRecentItems(int $uid): array {
+    $rows = $this->database->queryRange(
+      'SELECT r.nid, MAX(r.revision_timestamp) AS own_ts
+       FROM {node_revision} r
+       INNER JOIN {node_field_data} n ON n.nid = r.nid AND n.default_langcode = 1
+       WHERE r.revision_uid = :uid
+       GROUP BY r.nid
+       ORDER BY own_ts DESC',
+      0, self::ITEMS_PER_SECTION,
+      [':uid' => $uid]
+    )->fetchAllKeyed();
+
+    return $this->loadItems(array_keys($rows), array_map('intval', $rows));
+  }
+
+  /**
+   * Published nodes the user authored that have gone stale, oldest first.
+   */
+  protected function getReviewItems(int $uid): array {
+    $cutoff = $this->time->getRequestTime() - self::REVIEW_AGE_SECONDS;
+    $nids = $this->database->select('node_field_data', 'n')
+      ->fields('n', ['nid'])
+      ->condition('n.uid', $uid)
+      ->condition('n.status', 1)
+      ->condition('n.default_langcode', 1)
+      ->condition('n.changed', $cutoff, '<')
+      ->orderBy('n.changed', 'ASC')
+      ->range(0, self::ITEMS_PER_SECTION)
+      ->execute()
+      ->fetchCol();
+
+    return $this->loadItems($nids);
+  }
+
+  /**
+   * Loads nodes and maps them to simple template-ready rows.
+   *
+   * @param array $nids
+   *   Node IDs in display order.
+   * @param array $timestamps
+   *   Optional nid-keyed timestamps overriding node.changed for display -
+   *   used to show the user's own last edit rather than the global one.
+   */
+  protected function loadItems(array $nids, array $timestamps = []): array {
+    if (!$nids) {
+      return [];
+    }
+    $items = [];
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+    foreach ($nids as $nid) {
+      if (!isset($nodes[$nid])) {
+        continue;
+      }
+      $node = $nodes[$nid];
+      if (!$node->access('view')) {
+        continue;
+      }
+      $type = $this->entityTypeManager->getStorage('node_type')->load($node->bundle());
+      $timestamp = $timestamps[$nid] ?? $node->getChangedTime();
+      $items[] = [
+        'title' => $node->label(),
+        'url' => $node->toUrl()->toString(),
+        'edit_url' => $node->access('update') ? $node->toUrl('edit-form')->toString() : NULL,
+        'type' => $type ? $type->label() : $node->bundle(),
+        'published' => $node->isPublished(),
+        'changed' => $this->dateFormatter->format($timestamp, 'custom', 'j F Y'),
+        'changed_ago' => $this->dateFormatter->formatTimeDiffSince($timestamp, ['granularity' => 1]),
+      ];
+    }
+    return $items;
+  }
+
+}

--- a/webroot/modules/custom/saho_dashboard/src/Service/DashboardBuilder.php
+++ b/webroot/modules/custom/saho_dashboard/src/Service/DashboardBuilder.php
@@ -6,14 +6,17 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use Drupal\user\UserInterface;
 
 /**
  * Builds the contributor dashboard shown on a user's own profile page.
  *
- * Deliberately lightweight: three read-only sections (stats, recent work,
- * review reminders) driven by two small queries. No moderation states, no
- * task queues - just a gentle nudge towards content that has gone stale.
+ * Deliberately lightweight: read-only sections (role badges, achievements,
+ * task shortcuts, recent work, review reminders) computed live from existing
+ * tables. No moderation states, no task queues, no new storage - just a
+ * gentle, playful nudge towards the work that keeps the record healthy.
  */
 class DashboardBuilder {
 
@@ -26,6 +29,54 @@ class DashboardBuilder {
    * Maximum items listed per section.
    */
   const ITEMS_PER_SECTION = 6;
+
+  /**
+   * Achievement catalog: thresholds are bronze / silver / gold.
+   */
+  const ACHIEVEMENTS = [
+    'quill' => [
+      'name' => 'The Quill',
+      'metric' => 'pieces worked on',
+      'blurb' => 'Every edit adds a line to the record.',
+      'tiers' => [10, 250, 1000],
+    ],
+    'compass' => [
+      'name' => 'The Compass',
+      'metric' => 'kinds of content touched',
+      'blurb' => 'Biographies, places, events - ranging widely.',
+      'tiers' => [3, 6, 10],
+    ],
+    'lantern' => [
+      'name' => 'The Lantern',
+      'metric' => 'stale pages revived',
+      'blurb' => 'Brought light to pages untouched for 3+ years.',
+      'tiers' => [5, 25, 100],
+    ],
+    'laurel' => [
+      'name' => 'The Laurel',
+      'metric' => 'years contributing',
+      'blurb' => 'Long service to South African history.',
+      'tiers' => [1, 5, 10],
+    ],
+    'ember' => [
+      'name' => 'The Ember',
+      'metric' => 'edits in the last 30 days',
+      'blurb' => 'Keeping the fire going right now.',
+      'tiers' => [5, 20, 50],
+    ],
+  ];
+
+  /**
+   * Role badge map: role id => [label, icon, badge variant].
+   */
+  const ROLE_BADGES = [
+    'superadmin' => ['Custodian of the Record', 'crown', 'heritage-red'],
+    'administrator' => ['Custodian of the Record', 'crown', 'heritage-red'],
+    'editor' => ['Editor', 'quill', 'slate-blue'],
+    'moderator' => ['Moderator', 'shield', 'slate-blue'],
+    'researcher' => ['Researcher', 'magnifier', 'muted-gold'],
+    'researcher_advanced_' => ['Advanced researcher', 'magnifier', 'muted-gold'],
+  ];
 
   /**
    * The database connection.
@@ -70,11 +121,15 @@ class DashboardBuilder {
    *
    * @param \Drupal\user\UserInterface $account
    *   The user whose profile page is being viewed.
+   * @param \Drupal\Core\Session\AccountInterface $viewer
+   *   The user looking at the page (task tiles gate on their permissions).
+   * @param bool $owner
+   *   TRUE when the viewer is looking at their own profile.
    *
    * @return array|null
    *   Render-ready data, or NULL when the user has no content activity.
    */
-  public function build(UserInterface $account) {
+  public function build(UserInterface $account, AccountInterface $viewer, bool $owner) {
     $uid = (int) $account->id();
     $stats = $this->getStats($uid);
     if ($stats['worked_on'] === 0) {
@@ -83,6 +138,9 @@ class DashboardBuilder {
 
     return [
       'stats' => $stats,
+      'roles' => $this->getRoleBadges($account),
+      'achievements' => $this->getAchievements($uid, $stats['worked_on']),
+      'tasks' => $this->getTasks($uid, $viewer, $owner),
       'recent' => $this->getRecentItems($uid),
       'review' => $this->getReviewItems($uid),
     ];
@@ -107,6 +165,185 @@ class DashboardBuilder {
     return [
       'authored' => $authored,
       'worked_on' => max($worked_on, $authored),
+    ];
+  }
+
+  /**
+   * Maps the account's roles to badge pills with icons.
+   */
+  protected function getRoleBadges(UserInterface $account): array {
+    $badges = [];
+    foreach ($account->getRoles(TRUE) as $role_id) {
+      if (isset(self::ROLE_BADGES[$role_id])) {
+        [$label, $icon, $variant] = self::ROLE_BADGES[$role_id];
+        // Administrator and superadmin share one Custodian badge.
+        $badges[$label] = ['label' => $label, 'icon' => $icon, 'variant' => $variant];
+      }
+    }
+    return array_values($badges);
+  }
+
+  /**
+   * Computes the achievement medallions from existing revision data.
+   */
+  protected function getAchievements(int $uid, int $worked_on): array {
+    $now = $this->time->getRequestTime();
+
+    $types = (int) $this->database->query(
+      'SELECT COUNT(DISTINCT n.type) FROM {node_revision} r
+       INNER JOIN {node_field_data} n ON n.nid = r.nid AND n.default_langcode = 1
+       WHERE r.revision_uid = :uid',
+      [':uid' => $uid]
+    )->fetchField();
+
+    // A "stale rescue" is an own revision whose predecessor on the same node
+    // is at least the review age older - the page had gone dark and this
+    // user relit it. LAG() needs every node's revision chain, so the window
+    // runs over the whole table; acceptable at this site's scale behind the
+    // render cache.
+    $lantern = (int) $this->database->query(
+      'SELECT COUNT(*) FROM (
+         SELECT revision_uid, revision_timestamp - LAG(revision_timestamp)
+           OVER (PARTITION BY nid ORDER BY vid) AS gap
+         FROM {node_revision}
+       ) t WHERE t.revision_uid = :uid AND t.gap > :age',
+      [':uid' => $uid, ':age' => self::REVIEW_AGE_SECONDS]
+    )->fetchField();
+
+    $first = (int) $this->database->query(
+      'SELECT MIN(revision_timestamp) FROM {node_revision} WHERE revision_uid = :uid',
+      [':uid' => $uid]
+    )->fetchField();
+    $years = $first ? (int) floor(($now - $first) / 31557600) : 0;
+
+    $ember = (int) $this->database->query(
+      'SELECT COUNT(*) FROM {node_revision} WHERE revision_uid = :uid AND revision_timestamp > :since',
+      [':uid' => $uid, ':since' => $now - 2592000]
+    )->fetchField();
+
+    $values = [
+      'quill' => $worked_on,
+      'compass' => $types,
+      'lantern' => $lantern,
+      'laurel' => $years,
+      'ember' => $ember,
+    ];
+
+    $achievements = [];
+    foreach (self::ACHIEVEMENTS as $id => $def) {
+      $value = $values[$id];
+      $tier = NULL;
+      $next = NULL;
+      foreach (array_combine(['bronze', 'silver', 'gold'], $def['tiers']) as $name => $threshold) {
+        if ($value >= $threshold) {
+          $tier = $name;
+        }
+        elseif ($next === NULL) {
+          $next = $threshold;
+        }
+      }
+      $achievements[] = [
+        'id' => $id,
+        'icon' => $id,
+        'name' => $def['name'],
+        'blurb' => $def['blurb'],
+        'metric' => $def['metric'],
+        'value' => number_format($value),
+        'tier' => $tier,
+        'next' => $next ? number_format($next) : NULL,
+        'progress' => $next ? min(100, (int) round($value / max($next, 1) * 100)) : 100,
+      ];
+    }
+    return $achievements;
+  }
+
+  /**
+   * Builds the permission-gated "keep the record healthy" task tiles.
+   */
+  protected function getTasks(int $uid, AccountInterface $viewer, bool $owner): array {
+    $tiles = [];
+    $schema = $this->database->schema();
+
+    if ($viewer->hasPermission('administer comments') && $schema->tableExists('comment_field_data')) {
+      $count = (int) $this->database->query(
+        'SELECT COUNT(*) FROM {comment_field_data} WHERE status = 0 AND default_langcode = 1'
+      )->fetchField();
+      $tiles[] = $this->tile('comments', 'comment', 'Comments to approve', $count,
+        '/admin/content/comment/approval',
+        'Readers wrote in - each one waits for a simple yes or no.');
+    }
+
+    if ($viewer->hasPermission('administer redirects') && $schema->tableExists('redirect_404')) {
+      $count = (int) $this->database->query(
+        'SELECT COUNT(*) FROM {redirect_404} WHERE resolved = 0'
+      )->fetchField();
+      $tiles[] = $this->tile('redirects', 'link-broken', '404s to tame', $count,
+        '/admin/config/search/redirect/404',
+        'Dead URLs visitors keep hitting - one redirect each fixes them for good.');
+    }
+
+    if ($viewer->hasPermission('access broken links report') && $schema->tableExists('linkchecker_link')) {
+      $count = (int) $this->database->query(
+        'SELECT COUNT(*) FROM {linkchecker_link} WHERE fail_count > 0 AND code >= 400'
+      )->fetchField();
+      $tiles[] = $this->tile('brokenlinks', 'link-broken', 'Broken links in content', $count,
+        '/admin/reports/linkchecker',
+        'Links in our pages that answer with hard errors.');
+    }
+
+    if ($viewer->hasPermission('view any webform submission') && $schema->tableExists('webform_submission')) {
+      $count = (int) $this->database->query(
+        "SELECT COUNT(*) FROM {webform_submission} WHERE webform_id = 'contribute'"
+      )->fetchField();
+      $tiles[] = $this->tile('contribute', 'draft', 'Public contributions', $count,
+        '/admin/structure/webform/manage/contribute/results/submissions',
+        'Stories and corrections sent in by readers, waiting for an editorial eye.');
+    }
+
+    if ($viewer->hasPermission('access content overview')) {
+      $count = (int) $this->database->query(
+        "SELECT COUNT(DISTINCT entity_id) FROM {node__body} WHERE body_value LIKE '%.htm%' AND deleted = 0"
+      )->fetchField();
+      $tile = $this->tile('legacy', 'lantern', 'Pages with legacy links', $count, NULL,
+        'Body text still pointing at the old site\'s .htm addresses - open one and repair it.');
+      $nids = $this->database->queryRange(
+        "SELECT DISTINCT entity_id FROM {node__body} WHERE body_value LIKE '%.htm%' AND deleted = 0",
+        0, 5
+      )->fetchCol();
+      $tile['samples'] = $this->loadItems($nids);
+      $tiles[] = $tile;
+    }
+
+    if ($owner) {
+      $count = (int) $this->database->select('node_field_data', 'n')
+        ->condition('n.uid', $uid)
+        ->condition('n.status', 0)
+        ->condition('n.default_langcode', 1)
+        ->countQuery()
+        ->execute()
+        ->fetchField();
+      if ($count > 0) {
+        $url = $viewer->hasPermission('access content overview') ? '/admin/content?status=2' : NULL;
+        $tiles[] = $this->tile('drafts', 'draft', 'Your unpublished drafts', $count, $url,
+          'Pieces of yours the public cannot see yet.');
+      }
+    }
+
+    return $tiles;
+  }
+
+  /**
+   * Assembles one task tile row.
+   */
+  protected function tile(string $id, string $icon, string $title, int $count, ?string $path, string $blurb): array {
+    return [
+      'id' => $id,
+      'icon' => $icon,
+      'title' => $title,
+      'count' => number_format($count),
+      'all_clear' => $count === 0,
+      'url' => $path ? Url::fromUserInput($path)->toString() : NULL,
+      'blurb' => $blurb,
     ];
   }
 

--- a/webroot/modules/custom/saho_dashboard/src/Service/DashboardBuilder.php
+++ b/webroot/modules/custom/saho_dashboard/src/Service/DashboardBuilder.php
@@ -8,6 +8,7 @@ use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\tdih\Service\NodeFetcher;
 use Drupal\user\UserInterface;
 
 /**
@@ -29,6 +30,11 @@ class DashboardBuilder {
    * Maximum items listed per section.
    */
   const ITEMS_PER_SECTION = 6;
+
+  /**
+   * South African Standard Time offset from UTC in seconds (fixed, no DST).
+   */
+  const SAST_OFFSET = 7200;
 
   /**
    * Achievement catalog: thresholds are bronze / silver / gold.
@@ -64,7 +70,44 @@ class DashboardBuilder {
       'blurb' => 'Keeping the fire going right now.',
       'tiers' => [5, 20, 50],
     ],
+    'night_watch' => [
+      'name' => 'The Night Watch',
+      'icon' => 'moon',
+      'metric' => 'edits after dark',
+      'blurb' => 'Revisions saved between 22:00 and 05:00 SAST.',
+      'tiers' => [5, 25, 100],
+      'secret' => TRUE,
+    ],
+    'timekeeper' => [
+      'name' => 'The Timekeeper',
+      'icon' => 'clock',
+      'metric' => 'events touched on their anniversary',
+      'blurb' => 'Edited an event on the very day history remembers it.',
+      'tiers' => [1, 5, 25],
+      'secret' => TRUE,
+    ],
+    'cartographer' => [
+      'name' => 'The Cartographer',
+      'icon' => 'map',
+      'metric' => 'places worked on',
+      'blurb' => 'Mapping South Africa one place page at a time.',
+      'tiers' => [5, 25, 100],
+      'secret' => TRUE,
+    ],
+    'biographer' => [
+      'name' => 'The Biographer',
+      'icon' => 'book',
+      'metric' => 'biographies worked on',
+      'blurb' => 'Keeping the people of the record alive.',
+      'tiers' => [10, 100, 500],
+      'secret' => TRUE,
+    ],
   ];
+
+  /**
+   * Teaser shown in place of an unrevealed secret achievement's details.
+   */
+  const SECRET_TEASER = 'A secret achievement - keep working the record.';
 
   /**
    * Role badge map: role id => [label, icon, badge variant].
@@ -107,13 +150,28 @@ class DashboardBuilder {
   protected $time;
 
   /**
+   * The TDIH event fetcher, when the tdih module is enabled.
+   *
+   * @var \Drupal\tdih\Service\NodeFetcher|null
+   */
+  protected $tdihFetcher;
+
+  /**
+   * Per-uid cache of the user's first revision timestamp.
+   *
+   * @var int[]
+   */
+  protected $firstRevision = [];
+
+  /**
    * Constructs a DashboardBuilder.
    */
-  public function __construct(Connection $database, EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter, TimeInterface $time) {
+  public function __construct(Connection $database, EntityTypeManagerInterface $entity_type_manager, DateFormatterInterface $date_formatter, TimeInterface $time, ?NodeFetcher $tdih_fetcher = NULL) {
     $this->database = $database;
     $this->entityTypeManager = $entity_type_manager;
     $this->dateFormatter = $date_formatter;
     $this->time = $time;
+    $this->tdihFetcher = $tdih_fetcher;
   }
 
   /**
@@ -143,6 +201,10 @@ class DashboardBuilder {
       'tasks' => $this->getTasks($uid, $viewer, $owner),
       'recent' => $this->getRecentItems($uid),
       'review' => $this->getReviewItems($uid),
+      'impact' => $this->getImpact($uid),
+      'on_this_day' => $this->getOnThisDay($uid),
+      'anniversary' => $this->getAnniversary($uid),
+      'easter' => $owner ? $this->getEasterEgg($uid) : NULL,
     ];
   }
 
@@ -210,10 +272,7 @@ class DashboardBuilder {
       [':uid' => $uid, ':age' => self::REVIEW_AGE_SECONDS]
     )->fetchField();
 
-    $first = (int) $this->database->query(
-      'SELECT MIN(revision_timestamp) FROM {node_revision} WHERE revision_uid = :uid',
-      [':uid' => $uid]
-    )->fetchField();
+    $first = $this->getFirstRevisionTimestamp($uid);
     $years = $first ? (int) floor(($now - $first) / 31557600) : 0;
 
     $ember = (int) $this->database->query(
@@ -221,12 +280,48 @@ class DashboardBuilder {
       [':uid' => $uid, ':since' => $now - 2592000]
     )->fetchField();
 
+    // Secret achievement: revisions saved in the small hours, SAST. The hour
+    // bucket is derived arithmetically from the epoch (UTC + fixed offset),
+    // which is exact because SAST has no daylight saving.
+    $night_watch = (int) $this->database->query(
+      'SELECT COUNT(*) FROM {node_revision}
+       WHERE revision_uid = :uid
+       AND MOD(FLOOR(revision_timestamp / 3600) + 2, 24) NOT BETWEEN 5 AND 21',
+      [':uid' => $uid]
+    )->fetchField();
+
+    // Secret achievement: event nodes edited on their own anniversary.
+    // DATE_FORMAT/FROM_UNIXTIME are MySQL/MariaDB-specific, matching the
+    // window-function SQL above in portability.
+    $timekeeper = (int) $this->database->query(
+      "SELECT COUNT(DISTINCT r.nid) FROM {node_revision} r
+       INNER JOIN {node__field_event_date} fed
+         ON fed.entity_id = r.nid AND fed.deleted = 0
+       WHERE r.revision_uid = :uid
+       AND DATE_FORMAT(FROM_UNIXTIME(r.revision_timestamp + :offset), '%m-%d')
+           = SUBSTRING(fed.field_event_date_value, 6, 5)",
+      [':uid' => $uid, ':offset' => self::SAST_OFFSET]
+    )->fetchField();
+
+    // Secret achievements: distinct place / biography nodes worked on.
+    $by_type = $this->database->query(
+      "SELECT n.type, COUNT(DISTINCT r.nid) AS c FROM {node_revision} r
+       INNER JOIN {node_field_data} n ON n.nid = r.nid AND n.default_langcode = 1
+       WHERE r.revision_uid = :uid AND n.type IN ('place', 'biography')
+       GROUP BY n.type",
+      [':uid' => $uid]
+    )->fetchAllKeyed();
+
     $values = [
       'quill' => $worked_on,
       'compass' => $types,
       'lantern' => $lantern,
       'laurel' => $years,
       'ember' => $ember,
+      'night_watch' => $night_watch,
+      'timekeeper' => $timekeeper,
+      'cartographer' => (int) ($by_type['place'] ?? 0),
+      'biographer' => (int) ($by_type['biography'] ?? 0),
     ];
 
     $achievements = [];
@@ -242,9 +337,11 @@ class DashboardBuilder {
           $next = $threshold;
         }
       }
-      $achievements[] = [
+      $secret = !empty($def['secret']);
+      $revealed = !$secret || $tier !== NULL;
+      $row = [
         'id' => $id,
-        'icon' => $id,
+        'icon' => $def['icon'] ?? $id,
         'name' => $def['name'],
         'blurb' => $def['blurb'],
         'metric' => $def['metric'],
@@ -252,9 +349,205 @@ class DashboardBuilder {
         'tier' => $tier,
         'next' => $next ? number_format($next) : NULL,
         'progress' => $next ? min(100, (int) round($value / max($next, 1) * 100)) : 100,
+        'secret' => $secret,
+        'revealed' => $revealed,
       ];
+      if (!$revealed) {
+        // Strip everything that could spoil the surprise - these values must
+        // never reach the markup, not merely be hidden by the template.
+        $row = [
+          'name' => '???',
+          'icon' => 'mystery',
+          'blurb' => self::SECRET_TEASER,
+          'metric' => self::SECRET_TEASER,
+          'value' => NULL,
+          'next' => NULL,
+          'progress' => NULL,
+        ] + $row;
+      }
+      $achievements[] = $row;
     }
     return $achievements;
+  }
+
+  /**
+   * Returns the timestamp of the user's first revision, memoized per uid.
+   */
+  protected function getFirstRevisionTimestamp(int $uid): int {
+    if (!isset($this->firstRevision[$uid])) {
+      $this->firstRevision[$uid] = (int) $this->database->query(
+        'SELECT MIN(revision_timestamp) FROM {node_revision} WHERE revision_uid = :uid',
+        [':uid' => $uid]
+      )->fetchField();
+    }
+    return $this->firstRevision[$uid];
+  }
+
+  /**
+   * Readership impact: total views of the user's pages, plus their top page.
+   *
+   * View counts come from the custom saho_statistics module; when it is not
+   * installed the whole section quietly disappears.
+   */
+  protected function getImpact(int $uid): ?array {
+    if (!$this->database->schema()->tableExists('saho_node_counter')) {
+      return NULL;
+    }
+
+    $total = (int) $this->database->query(
+      'SELECT COALESCE(SUM(c.totalcount), 0) FROM {saho_node_counter} c
+       INNER JOIN {node_field_data} n ON n.nid = c.nid AND n.default_langcode = 1
+       WHERE n.uid = :uid',
+      [':uid' => $uid]
+    )->fetchField();
+    if ($total === 0) {
+      return NULL;
+    }
+
+    $top = $this->database->queryRange(
+      'SELECT c.nid, c.totalcount FROM {saho_node_counter} c
+       INNER JOIN {node_field_data} n ON n.nid = c.nid AND n.default_langcode = 1 AND n.status = 1
+       WHERE n.uid = :uid ORDER BY c.totalcount DESC',
+      0, 1,
+      [':uid' => $uid]
+    )->fetchAssoc();
+
+    $most_read = NULL;
+    if ($top) {
+      $items = $this->loadItems([(int) $top['nid']]);
+      if ($items) {
+        $most_read = $items[0];
+        $most_read['views'] = (int) $top['totalcount'];
+        $most_read['views_formatted'] = $this->compact((int) $top['totalcount']);
+      }
+    }
+
+    return [
+      'readers_reached' => $total,
+      'readers_reached_formatted' => $this->compact($total),
+      'most_read' => $most_read,
+    ];
+  }
+
+  /**
+   * Picks today's "on this day in the record" event for this user.
+   *
+   * Each contributor gets their own deterministic pick from the day's
+   * featured events, so two colleagues comparing dashboards see different
+   * moments of the same day.
+   */
+  protected function getOnThisDay(int $uid): ?array {
+    if (!$this->tdihFetcher) {
+      return NULL;
+    }
+    try {
+      $tz = new \DateTimeZone('Africa/Johannesburg');
+      $today = (new \DateTime('@' . $this->time->getRequestTime()))->setTimezone($tz);
+      $month_day = $today->format('m-d');
+
+      // The fetcher's LIKE match is a prefilter; keep only events whose date
+      // really is today's month-day (mirrors TdihBlock's own re-filter).
+      $matches = [];
+      foreach ($this->tdihFetcher->loadPotentialEvents($month_day) as $node) {
+        $raw = (string) $node->get('field_event_date')->value;
+        if (preg_match('/^(\d{4})-(\d{2}-\d{2})/', $raw, $m) && $m[2] === $month_day) {
+          $matches[$node->id()] = ['node' => $node, 'year' => $m[1]];
+        }
+      }
+      if (!$matches) {
+        return NULL;
+      }
+      ksort($matches);
+      $matches = array_values($matches);
+      $pick = $matches[abs(crc32($uid . '-' . $month_day)) % count($matches)];
+
+      return [
+        'year' => $pick['year'],
+        'title' => $pick['node']->label(),
+        'url' => $pick['node']->toUrl()->toString(),
+        'date_label' => $today->format('j F'),
+      ];
+    }
+    catch (\Exception $e) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Detects the anniversary of the user's very first edit (SAST).
+   */
+  protected function getAnniversary(int $uid): ?array {
+    $first = $this->getFirstRevisionTimestamp($uid);
+    if (!$first) {
+      return NULL;
+    }
+    $tz = new \DateTimeZone('Africa/Johannesburg');
+    $first_date = (new \DateTime('@' . $first))->setTimezone($tz);
+    $today = (new \DateTime('@' . $this->time->getRequestTime()))->setTimezone($tz);
+    $years = (int) $today->format('Y') - (int) $first_date->format('Y');
+    if ($years >= 1 && $first_date->format('m-d') === $today->format('m-d')) {
+      return [
+        'years' => $years,
+        'since' => $first_date->format('j F Y'),
+      ];
+    }
+    return NULL;
+  }
+
+  /**
+   * Hidden vault data: the user's first edit and the record's oldest entry.
+   *
+   * Rendered server-side but hidden; the front end reveals it on the Konami
+   * code. Owner-only (gated in build()).
+   */
+  protected function getEasterEgg(int $uid): ?array {
+    $first = NULL;
+    $first_nid = $this->database->queryRange(
+      'SELECT nid FROM {node_revision} WHERE revision_uid = :uid ORDER BY revision_timestamp ASC',
+      0, 1,
+      [':uid' => $uid]
+    )->fetchField();
+    if ($first_nid) {
+      $items = $this->loadItems([(int) $first_nid]);
+      if ($items) {
+        $first = $items[0];
+        $first['date'] = $this->dateFormatter->format($this->getFirstRevisionTimestamp($uid), 'custom', 'j F Y');
+      }
+    }
+
+    $oldest = NULL;
+    $oldest_row = $this->database->queryRange(
+      'SELECT nid, created FROM {node_field_data} WHERE status = 1 AND default_langcode = 1 ORDER BY created ASC',
+      0, 1
+    )->fetchAssoc();
+    if ($oldest_row) {
+      $nid = (int) $oldest_row['nid'];
+      // Override the displayed date with the creation date - "first entry"
+      // should show when it entered the record, not its last edit.
+      $items = $this->loadItems([$nid], [$nid => (int) $oldest_row['created']]);
+      if ($items) {
+        $oldest = $items[0];
+      }
+    }
+
+    if (!$first && !$oldest) {
+      return NULL;
+    }
+    return ['first' => $first, 'oldest' => $oldest];
+  }
+
+  /**
+   * Formats a large count compactly: 1234 -> 1,234, 34567 -> 35k, 1.2M.
+   */
+  protected function compact(int $n): string {
+    if ($n >= 1000000) {
+      $m = round($n / 1000000, 1);
+      return rtrim(rtrim(number_format($m, 1), '0'), '.') . 'M';
+    }
+    if ($n >= 10000) {
+      return number_format(round($n / 1000)) . 'k';
+    }
+    return number_format($n);
   }
 
   /**

--- a/webroot/modules/custom/saho_dashboard/templates/saho-dashboard-icons.html.twig
+++ b/webroot/modules/custom/saho_dashboard/templates/saho-dashboard-icons.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Inline SVG icon macros for the contributor dashboard.
+ *
+ * Follows the theme convention: small stroke icons on currentColor,
+ * aria-hidden, no external icon fonts.
+ */
+#}
+{% macro icon(name, size = 16) %}
+  {%- set paths = {
+    'quill': '<path d="M20 4c-6 0-11 3-13 9l-3 8 1 1 3-3h3c5 0 8-4 9-8"/><path d="M20 4c-3 3-7 7-11 13"/>',
+    'crown': '<path d="M4 18l-1-9 5 4 4-8 4 8 5-4-1 9z"/><path d="M4 21h16"/>',
+    'shield': '<path d="M12 3l7 3v5c0 5-3.2 8.1-7 10-3.8-1.9-7-5-7-10V6l7-3z"/>',
+    'magnifier': '<circle cx="10.5" cy="10.5" r="6"/><path d="M15 15l6 6"/>',
+    'compass': '<circle cx="12" cy="12" r="9"/><path d="M15.5 8.5l-2 5-5 2 2-5 5-2z"/>',
+    'lantern': '<path d="M12 5c2.5 3 4.5 4.7 4.5 7.5a4.5 4.5 0 0 1-9 0C7.5 9.7 9.5 8 12 5z"/><path d="M12 2v2"/><path d="M8 21h8"/>',
+    'laurel': '<path d="M6 4c-2 5-2 10 2 14"/><path d="M18 4c2 5 2 10-2 14"/><path d="M8 18c1.5 1.5 4 2 4 2s2.5-.5 4-2"/><path d="M12 4v3"/>',
+    'ember': '<path d="M12 3c3.5 4 6 6.5 6 10.5a6 6 0 0 1-12 0C6 9.5 8.5 7 12 3z"/><path d="M12 21a3 3 0 0 0 3-3c0-2-1.5-3-3-5-1.5 2-3 3-3 5a3 3 0 0 0 3 3z"/>',
+    'comment': '<path d="M4 5h16v11H10l-6 4V5z"/>',
+    'link-broken': '<path d="M8 12H6a4 4 0 0 1 0-8h2"/><path d="M16 12h2a4 4 0 0 0 0-8h-2"/><path d="M4 20L20 4" stroke-dasharray="2 3"/>',
+    'draft': '<path d="M6 3h9l4 4v14H6V3z"/><path d="M15 3v4h4"/><path d="M9 12h6M9 16h6"/>',
+    'star': '<path d="M12 3l2.5 5.5 6 .7-4.5 4 1.3 5.8-5.3-3-5.3 3 1.3-5.8-4.5-4 6-.7L12 3z"/>',
+  } -%}
+  <svg class="saho-dash-icon saho-dash-icon--{{ name }}" width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">{{ paths[name]|default(paths['star'])|raw }}</svg>
+{%- endmacro %}

--- a/webroot/modules/custom/saho_dashboard/templates/saho-dashboard-icons.html.twig
+++ b/webroot/modules/custom/saho_dashboard/templates/saho-dashboard-icons.html.twig
@@ -21,6 +21,13 @@
     'link-broken': '<path d="M8 12H6a4 4 0 0 1 0-8h2"/><path d="M16 12h2a4 4 0 0 0 0-8h-2"/><path d="M4 20L20 4" stroke-dasharray="2 3"/>',
     'draft': '<path d="M6 3h9l4 4v14H6V3z"/><path d="M15 3v4h4"/><path d="M9 12h6M9 16h6"/>',
     'star': '<path d="M12 3l2.5 5.5 6 .7-4.5 4 1.3 5.8-5.3-3-5.3 3 1.3-5.8-4.5-4 6-.7L12 3z"/>',
+    'mystery': '<circle cx="12" cy="12" r="9"/><path d="M9.5 9a2.5 2.5 0 1 1 3.6 2.2c-.7.4-1.1.9-1.1 1.8"/><path d="M12 16.5v.01"/>',
+    'moon': '<path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a7 7 0 0 0 10.5 10.5z"/>',
+    'clock': '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3.5 2"/>',
+    'map': '<path d="M9 4L3 6v14l6-2 6 2 6-2V4l-6 2-6-2z"/><path d="M9 4v14"/><path d="M15 6v14"/>',
+    'book': '<path d="M4 5a2 2 0 0 1 2-2h14v16H6a2 2 0 0 0-2 2V5z"/><path d="M4 19a2 2 0 0 1 2-2h14"/><path d="M9 7h7"/>',
+    'calendar': '<rect x="4" y="5" width="16" height="16" rx="2"/><path d="M4 10h16"/><path d="M8 3v4"/><path d="M16 3v4"/>',
+    'eye': '<path d="M2 12s3.5-6.5 10-6.5S22 12 22 12s-3.5 6.5-10 6.5S2 12 2 12z"/><circle cx="12" cy="12" r="2.5"/>',
   } -%}
   <svg class="saho-dash-icon saho-dash-icon--{{ name }}" width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">{{ paths[name]|default(paths['star'])|raw }}</svg>
 {%- endmacro %}

--- a/webroot/modules/custom/saho_dashboard/templates/saho-dashboard.html.twig
+++ b/webroot/modules/custom/saho_dashboard/templates/saho-dashboard.html.twig
@@ -7,12 +7,20 @@
  * - stats: { authored: int, worked_on: int }.
  * - roles: Role badge pills (label, icon, variant).
  * - achievements: Medallions (id, icon, name, blurb, metric, value, tier,
- *   next, progress). tier is bronze|silver|gold|null (locked).
+ *   next, progress, secret, revealed). tier is bronze|silver|gold|null
+ *   (locked). Unrevealed secrets arrive pre-masked ("???", mystery icon,
+ *   null value/next/progress).
  * - tasks: Permission-gated task tiles (id, icon, title, count, all_clear,
  *   url, blurb, optional samples list).
  * - recent: List of items the user recently worked on.
  * - review: List of stale published items suggested for review.
  *   Each item: title, url, edit_url, type, published, changed, changed_ago.
+ * - impact: null or { readers_reached: int, readers_reached_formatted,
+ *   most_read: item + views/views_formatted or null }.
+ * - on_this_day: null or { year, title, url, date_label }.
+ * - anniversary: null or { years: int, since: formatted date }.
+ * - easter: null or { first: item + date, oldest: item } - rendered hidden,
+ *   revealed by the front end (owner only).
  * - owner: TRUE when the viewer is looking at their own profile.
  */
 #}
@@ -22,25 +30,73 @@
   <div class="saho-dash-header mb-4">
     <div class="saho-dash-header__roles">
       {% for role in roles %}
-        <span class="saho-badge saho-badge--{{ role.variant }} saho-badge--small saho-badge--rounded saho-dash-role">
+        <span class="saho-badge saho-badge--{{ role.variant }} saho-badge--small saho-badge--rounded saho-dash-role"
+              data-bs-toggle="tooltip" data-bs-title="{{ role.label }}">
           {{ icons.icon(role.icon, 14) }}
           <span class="saho-badge__text">{{ role.label }}</span>
         </span>
       {% endfor %}
     </div>
     <p class="saho-dash-header__stats text-muted mb-0">
-      {{ stats.worked_on|number_format }} {{ 'pieces worked on'|t }} &middot;
-      {{ stats.authored|number_format }} {{ owner ? 'authored by you'|t : 'authored'|t }}
+      <span data-countup="{{ stats.worked_on }}">{{ stats.worked_on|number_format }}</span> {{ 'pieces worked on'|t }} &middot;
+      <span data-countup="{{ stats.authored }}">{{ stats.authored|number_format }}</span> {{ owner ? 'authored by you'|t : 'authored'|t }}
     </p>
+    {% if anniversary %}
+      <div class="saho-dash-ribbon mt-3" role="status">
+        {{ icons.icon('laurel', 18) }}
+        <span>
+          {{ anniversary.years }} {{ anniversary.years == 1 ? 'year'|t : 'years'|t }}
+          {{ 'to the day since your first edit'|t }} - {{ anniversary.since }}. {{ 'Thank you.'|t }}
+        </span>
+      </div>
+    {% endif %}
+    {% if on_this_day %}
+      <div class="saho-dash-otd mt-3">
+        {{ icons.icon('calendar', 16) }}
+        <span class="saho-dash-otd__kicker">{{ 'On this day in the record'|t }} &middot; {{ on_this_day.date_label }}</span>
+        <span class="saho-dash-otd__event">
+          <span class="saho-dash-otd__year">{{ on_this_day.year }}</span>
+          <a href="{{ on_this_day.url }}">{{ on_this_day.title }}</a>
+        </span>
+      </div>
+    {% endif %}
   </div>
+
+  {% if impact %}
+    <div class="saho-dash-impact mb-4">
+      <div class="saho-impact-tile">
+        <span class="saho-impact-tile__icon">{{ icons.icon('eye', 20) }}</span>
+        <span class="saho-impact-tile__body">
+          <span class="saho-impact-tile__count" data-countup="{{ impact.readers_reached }}" data-countup-compact>{{ impact.readers_reached_formatted }}</span>
+          <span class="saho-impact-tile__label">{{ owner ? 'readers reached by your pages'|t : 'readers reached'|t }}</span>
+        </span>
+      </div>
+      {% if impact.most_read %}
+        <div class="saho-impact-tile">
+          <span class="saho-impact-tile__icon">{{ icons.icon('star', 20) }}</span>
+          <span class="saho-impact-tile__body">
+            <span class="saho-impact-tile__title"><a href="{{ impact.most_read.url }}">{{ impact.most_read.title }}</a></span>
+            <span class="saho-impact-tile__label">
+              {{ owner ? 'your most-read page'|t : 'most-read page'|t }} &middot;
+              {{ impact.most_read.views_formatted }} {{ 'views'|t }}
+            </span>
+          </span>
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
 
   <div class="saho-dash-achievements mb-4" role="list" aria-label="{{ 'Achievements'|t }}">
     {% for a in achievements %}
-      <div class="saho-medallion{{ a.tier ? ' saho-medallion--' ~ a.tier : ' saho-medallion--locked' }}" role="listitem"
-           title="{{ a.blurb }}">
+      {% set mystery = a.secret and not a.revealed %}
+      <div class="saho-medallion{{ a.tier ? ' saho-medallion--' ~ a.tier : ' saho-medallion--locked' }}{{ mystery ? ' saho-medallion--mystery' : '' }}" role="listitem"
+           title="{{ a.blurb }}" data-achievement="{{ a.id }}" data-tier="{{ a.tier ?: '' }}">
         <span class="saho-medallion__disc">{{ icons.icon(a.icon, 22) }}</span>
         <span class="saho-medallion__name">{{ a.name }}</span>
-        {% if a.tier %}
+        {% if mystery %}
+          <span class="saho-medallion__status">???</span>
+          <span class="saho-medallion__metric">{{ 'Secret'|t }}</span>
+        {% elseif a.tier %}
           <span class="saho-medallion__status saho-medallion__status--{{ a.tier }}">{{ a.tier|capitalize }}</span>
           <span class="saho-medallion__metric">{{ a.value }} {{ a.metric }}</span>
         {% else %}
@@ -49,7 +105,7 @@
         {% endif %}
         {% if a.next %}
           <span class="saho-medallion__track" aria-hidden="true">
-            <span class="saho-medallion__bar" style="width: {{ a.progress }}%"></span>
+            <span class="saho-medallion__bar" style="width: {{ a.progress }}%" data-progress="{{ a.progress }}"></span>
           </span>
         {% endif %}
       </div>
@@ -141,5 +197,30 @@
       </div>
     </div>
   </div>
+
+  {% if easter %}
+    <div class="saho-dash-easter card mt-4" hidden data-saho-easter tabindex="-1">
+      <div class="card-header bg-transparent fw-semibold">
+        {{ icons.icon('lantern', 16) }} {{ 'The vault'|t }}
+        <span class="text-muted small fw-normal">{{ 'you found the hidden shelf'|t }}</span>
+      </div>
+      <ul class="list-group list-group-flush">
+        {% if easter.first %}
+          <li class="list-group-item">
+            <span class="saho-dash-easter__label">{{ 'Your opening line in the record'|t }}</span>
+            <a href="{{ easter.first.url }}">{{ easter.first.title }}</a>
+            <span class="text-muted small">- {{ easter.first.date }}</span>
+          </li>
+        {% endif %}
+        {% if easter.oldest %}
+          <li class="list-group-item">
+            <span class="saho-dash-easter__label">{{ "The record's first entry"|t }}</span>
+            <a href="{{ easter.oldest.url }}">{{ easter.oldest.title }}</a>
+            <span class="text-muted small">- {{ easter.oldest.changed }}</span>
+          </li>
+        {% endif %}
+      </ul>
+    </div>
+  {% endif %}
 
 </div>

--- a/webroot/modules/custom/saho_dashboard/templates/saho-dashboard.html.twig
+++ b/webroot/modules/custom/saho_dashboard/templates/saho-dashboard.html.twig
@@ -8,6 +8,7 @@
  * - recent: List of items the user recently worked on.
  * - review: List of stale published items suggested for review.
  *   Each item: title, url, edit_url, type, published, changed, changed_ago.
+ * - owner: TRUE when the viewer is looking at their own profile.
  */
 #}
 <div class="saho-dashboard mb-4">
@@ -25,7 +26,7 @@
       <div class="card h-100 text-center">
         <div class="card-body py-3">
           <div class="fs-3 fw-bold">{{ stats.authored }}</div>
-          <div class="text-muted small">{{ 'Authored by you'|t }}</div>
+          <div class="text-muted small">{{ owner ? 'Authored by you'|t : 'Authored'|t }}</div>
         </div>
       </div>
     </div>
@@ -43,7 +44,7 @@
               <div>
                 <a href="{{ item.url }}">{{ item.title }}</a>
                 <div class="text-muted small">
-                  {{ item.type }} - {{ 'you edited'|t }} {{ item.changed }}
+                  {{ item.type }} - {{ owner ? 'you edited'|t : 'edited'|t }} {{ item.changed }}
                   {% if not item.published %}
                     <span class="badge text-bg-secondary ms-1">{{ 'Unpublished'|t }}</span>
                   {% endif %}

--- a/webroot/modules/custom/saho_dashboard/templates/saho-dashboard.html.twig
+++ b/webroot/modules/custom/saho_dashboard/templates/saho-dashboard.html.twig
@@ -1,0 +1,90 @@
+{#
+/**
+ * @file
+ * Contributor dashboard on the user's own profile page.
+ *
+ * Available variables:
+ * - stats: { authored: int, worked_on: int }.
+ * - recent: List of items the user recently worked on.
+ * - review: List of stale published items suggested for review.
+ *   Each item: title, url, edit_url, type, published, changed, changed_ago.
+ */
+#}
+<div class="saho-dashboard mb-4">
+
+  <div class="row g-3 mb-4">
+    <div class="col-6 col-md-3">
+      <div class="card h-100 text-center">
+        <div class="card-body py-3">
+          <div class="fs-3 fw-bold">{{ stats.worked_on }}</div>
+          <div class="text-muted small">{{ 'Pieces worked on'|t }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="card h-100 text-center">
+        <div class="card-body py-3">
+          <div class="fs-3 fw-bold">{{ stats.authored }}</div>
+          <div class="text-muted small">{{ 'Authored by you'|t }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-4">
+    <div class="col-lg-6">
+      <div class="card h-100">
+        <div class="card-header bg-transparent fw-semibold">
+          {{ 'Recently worked on'|t }}
+        </div>
+        <ul class="list-group list-group-flush">
+          {% for item in recent %}
+            <li class="list-group-item d-flex justify-content-between align-items-start gap-2">
+              <div>
+                <a href="{{ item.url }}">{{ item.title }}</a>
+                <div class="text-muted small">
+                  {{ item.type }} - {{ 'you edited'|t }} {{ item.changed }}
+                  {% if not item.published %}
+                    <span class="badge text-bg-secondary ms-1">{{ 'Unpublished'|t }}</span>
+                  {% endif %}
+                </div>
+              </div>
+              {% if item.edit_url %}
+                <a class="btn btn-sm btn-outline-secondary flex-shrink-0" href="{{ item.edit_url }}">{{ 'Edit'|t }}</a>
+              {% endif %}
+            </li>
+          {% else %}
+            <li class="list-group-item text-muted">{{ 'Nothing yet.'|t }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+
+    <div class="col-lg-6">
+      <div class="card h-100">
+        <div class="card-header bg-transparent fw-semibold">
+          {{ 'Worth a review'|t }}
+          <span class="text-muted small fw-normal">{{ 'not updated in over 3 years'|t }}</span>
+        </div>
+        <ul class="list-group list-group-flush">
+          {% for item in review %}
+            <li class="list-group-item d-flex justify-content-between align-items-start gap-2">
+              <div>
+                <a href="{{ item.url }}">{{ item.title }}</a>
+                <div class="text-muted small">
+                  {{ item.type }} - {{ 'last updated'|t }} {{ item.changed_ago }} {{ 'ago'|t }}
+                </div>
+              </div>
+              {% if item.edit_url %}
+                <a class="btn btn-sm btn-outline-secondary flex-shrink-0" href="{{ item.edit_url }}">{{ 'Edit'|t }}</a>
+              {% endif %}
+            </li>
+          {% else %}
+            <li class="list-group-item text-muted">{{ 'All caught up - nothing stale.'|t }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/webroot/modules/custom/saho_dashboard/templates/saho-dashboard.html.twig
+++ b/webroot/modules/custom/saho_dashboard/templates/saho-dashboard.html.twig
@@ -1,36 +1,90 @@
 {#
 /**
  * @file
- * Contributor dashboard on the user's own profile page.
+ * Contributor dashboard on the user profile page.
  *
  * Available variables:
  * - stats: { authored: int, worked_on: int }.
+ * - roles: Role badge pills (label, icon, variant).
+ * - achievements: Medallions (id, icon, name, blurb, metric, value, tier,
+ *   next, progress). tier is bronze|silver|gold|null (locked).
+ * - tasks: Permission-gated task tiles (id, icon, title, count, all_clear,
+ *   url, blurb, optional samples list).
  * - recent: List of items the user recently worked on.
  * - review: List of stale published items suggested for review.
  *   Each item: title, url, edit_url, type, published, changed, changed_ago.
  * - owner: TRUE when the viewer is looking at their own profile.
  */
 #}
+{% import '@saho_dashboard/saho-dashboard-icons.html.twig' as icons %}
 <div class="saho-dashboard mb-4">
 
-  <div class="row g-3 mb-4">
-    <div class="col-6 col-md-3">
-      <div class="card h-100 text-center">
-        <div class="card-body py-3">
-          <div class="fs-3 fw-bold">{{ stats.worked_on }}</div>
-          <div class="text-muted small">{{ 'Pieces worked on'|t }}</div>
-        </div>
-      </div>
+  <div class="saho-dash-header mb-4">
+    <div class="saho-dash-header__roles">
+      {% for role in roles %}
+        <span class="saho-badge saho-badge--{{ role.variant }} saho-badge--small saho-badge--rounded saho-dash-role">
+          {{ icons.icon(role.icon, 14) }}
+          <span class="saho-badge__text">{{ role.label }}</span>
+        </span>
+      {% endfor %}
     </div>
-    <div class="col-6 col-md-3">
-      <div class="card h-100 text-center">
-        <div class="card-body py-3">
-          <div class="fs-3 fw-bold">{{ stats.authored }}</div>
-          <div class="text-muted small">{{ owner ? 'Authored by you'|t : 'Authored'|t }}</div>
-        </div>
-      </div>
-    </div>
+    <p class="saho-dash-header__stats text-muted mb-0">
+      {{ stats.worked_on|number_format }} {{ 'pieces worked on'|t }} &middot;
+      {{ stats.authored|number_format }} {{ owner ? 'authored by you'|t : 'authored'|t }}
+    </p>
   </div>
+
+  <div class="saho-dash-achievements mb-4" role="list" aria-label="{{ 'Achievements'|t }}">
+    {% for a in achievements %}
+      <div class="saho-medallion{{ a.tier ? ' saho-medallion--' ~ a.tier : ' saho-medallion--locked' }}" role="listitem"
+           title="{{ a.blurb }}">
+        <span class="saho-medallion__disc">{{ icons.icon(a.icon, 22) }}</span>
+        <span class="saho-medallion__name">{{ a.name }}</span>
+        {% if a.tier %}
+          <span class="saho-medallion__status saho-medallion__status--{{ a.tier }}">{{ a.tier|capitalize }}</span>
+          <span class="saho-medallion__metric">{{ a.value }} {{ a.metric }}</span>
+        {% else %}
+          <span class="saho-medallion__status">{{ a.value }} / {{ a.next }}</span>
+          <span class="saho-medallion__metric">{{ a.metric }}</span>
+        {% endif %}
+        {% if a.next %}
+          <span class="saho-medallion__track" aria-hidden="true">
+            <span class="saho-medallion__bar" style="width: {{ a.progress }}%"></span>
+          </span>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+
+  {% if tasks %}
+    <h3 class="saho-dash-section-title">{{ 'Keep the record healthy'|t }}</h3>
+    <div class="saho-dash-tasks mb-4">
+      {% for task in tasks %}
+        {% set tile_classes = 'saho-task-tile' ~ (task.all_clear ? ' saho-task-tile--clear' : '') %}
+        {% if task.url %}
+          <a class="{{ tile_classes }}" href="{{ task.url }}">
+        {% else %}
+          <div class="{{ tile_classes }}">
+        {% endif %}
+          <span class="saho-task-tile__icon">{{ icons.icon(task.icon, 18) }}</span>
+          <span class="saho-task-tile__body">
+            <span class="saho-task-tile__count">{{ task.all_clear ? 'All clear'|t : task.count }}</span>
+            <span class="saho-task-tile__title">{{ task.title }}</span>
+            <span class="saho-task-tile__blurb">{{ task.blurb }}</span>
+            {% if task.samples %}
+              <span class="saho-task-tile__samples">
+                {% for item in task.samples %}
+                  {% if item.edit_url %}
+                    <a href="{{ item.edit_url }}">{{ item.title|length > 40 ? item.title|slice(0, 40) ~ '...' : item.title }}</a>
+                  {% endif %}
+                {% endfor %}
+              </span>
+            {% endif %}
+          </span>
+        {% if task.url %}</a>{% else %}</div>{% endif %}
+      {% endfor %}
+    </div>
+  {% endif %}
 
   <div class="row g-4">
     <div class="col-lg-6">


### PR DESCRIPTION
## What

Turns the authenticated user's profile page (`/user`) into a contributor dashboard with a light gamification layer - 'The Record Keepers'. Everything is computed live from existing tables: no new storage, no editorial workflow.

**Role badges** - pills with inline SVG icons (theme saho-badge styles): Editor (quill), Moderator (shield), Researcher (magnifier), Custodian of the Record (crown, admins).

**Achievements** - five medallions with bronze/silver/gold tiers and progress toward the next tier:
- The Quill - pieces worked on (10/250/1,000)
- The Compass - kinds of content touched (3/6/10)
- The Lantern - stale pages revived: own revisions whose predecessor was 3+ years older, via `LAG()` over revision history (5/25/100)
- The Laurel - years contributing (1/5/10)
- The Ember - edits in the last 30 days (5/20/50)

**'Keep the record healthy' tiles** - permission-gated per viewer, each with live count and a direct link to the queue:
- Comments to approve (13,770 today) -> `/admin/content/comment/approval`
- 404s to tame (9,759) -> `/admin/config/search/redirect/404`
- Broken links in content, hard 4xx/5xx only (394) -> `/admin/reports/linkchecker`
- Public contributions (7,980) -> contribute webform submissions
- Pages with legacy .htm links (1,414) with direct edit shortcuts
- Your unpublished drafts (own profile only)

**Sections from earlier commits**: recently-worked-on (ordered by the user's own revisions) and worth-a-review (own content stale 3+ years).

## Permissions (config)

Editor + moderator roles gain `administer comments`, `administer redirects`, `access broken links report` (moderator also `view any webform submission`) - previously only administrator/superadmin could reach those queues, making the tiles pointless for the team meant to work them. Takes effect on prod at deploy + config import.

## Testing

phpcs (CI flags) + drupal-check clean. Verified with Playwright in DDEV:
- kim (editor): role pills render, Quill/Lantern gold + Compass bronze with progress bars, all six tiles with correct counts and links.
- sahoboss viewing /users/kim: neutral wording, kim's achievements, tiles gated by the admin's own permissions, no drafts tile (not owner).
- Anonymous/other users: dashboard hidden as before.

Visuals ride the theme's design tokens (heritage red, muted gold) and the inline-SVG icon convention - no icon fonts, no external assets.