### PR TITLE
fix(payfast): donations admin listing fatal on missing accessCheck()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -227,7 +227,8 @@
                 "Drupal 11 compatibility: Add ^11 to core_version_requirement": "patches/commerce_payfast-drupal11-compatibility.patch"
             },
             "drupal/payfast_donation_block": {
-                "Drupal 11 compatibility: Add ^11 to core_version_requirement": "patches/payfast_donation_block-drupal11-compatibility.patch"
+                "Drupal 11 compatibility: Add ^11 to core_version_requirement": "patches/payfast_donation_block-drupal11-compatibility.patch",
+                "Donations admin listing fatal: entity count query needs explicit accessCheck()": "patches/payfast_donation_block-listbuilder-accesscheck.patch"
             },
             "drupal/file_entity": {
                 "Drupal 11.4 compatibility (still unfixed in 2.5.0): type FileImageResponsiveFormatter::$currentUser to match core ImageFormatter": "patches/file_entity-drupal11.4-currentuser-type.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "681c67e9cefb1de1532bee7d628b7a2a",
+    "content-hash": "87edce72f600d8a57a02a5afa4b09089",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,5 +1,5 @@
 {
-    "_hash": "46b7b86ba961e6bd57c6e45dfcdf04cb3a8ce95c2055350db27f197cd33b6511",
+    "_hash": "3186951a6f02696b68d0b77154d6cd11eab7cef59c6424aeee831a2e0351a834",
     "patches": {
         "drupal/list_inline_block": [
             {
@@ -43,6 +43,16 @@
                 "description": "Drupal 11 compatibility: Add ^11 to core_version_requirement",
                 "url": "patches/payfast_donation_block-drupal11-compatibility.patch",
                 "sha256": "165dfc75b35b58c437def5cf9a8a5d5c6aebcbca73fd43247fee7cb8053e7ff1",
+                "depth": 1,
+                "extra": {
+                    "provenance": "root"
+                }
+            },
+            {
+                "package": "drupal/payfast_donation_block",
+                "description": "Donations admin listing fatal: entity count query needs explicit accessCheck()",
+                "url": "patches/payfast_donation_block-listbuilder-accesscheck.patch",
+                "sha256": "64a27bc82a12bf115b0148f6e1cd4344f51110c99b614a97fa619645ac159aa3",
                 "depth": 1,
                 "extra": {
                     "provenance": "root"

--- a/patches/payfast_donation_block-listbuilder-accesscheck.patch
+++ b/patches/payfast_donation_block-listbuilder-accesscheck.patch
@@ -1,5 +1,3 @@
-diff --git a/src/PayfastDonationsListBuilder.php b/src/PayfastDonationsListBuilder.php
-index 1234567..abcdefg 100644
 --- a/src/PayfastDonationsListBuilder.php	2026-07-16 01:08:30.451170542 +0200
 +++ b/src/PayfastDonationsListBuilder.php	2026-07-16 01:08:30.463293154 +0200
 @@ -67,6 +67,7 @@

--- a/patches/payfast_donation_block-listbuilder-accesscheck.patch
+++ b/patches/payfast_donation_block-listbuilder-accesscheck.patch
@@ -1,0 +1,10 @@
+--- a/src/PayfastDonationsListBuilder.php	2026-07-16 01:08:30.451170542 +0200
++++ b/src/PayfastDonationsListBuilder.php	2026-07-16 01:08:30.463293154 +0200
+@@ -67,6 +67,7 @@
+ 
+     $total = $this->getStorage()
+       ->getQuery()
++      ->accessCheck(FALSE)
+       ->count()
+       ->execute();
+ 

--- a/patches/payfast_donation_block-listbuilder-accesscheck.patch
+++ b/patches/payfast_donation_block-listbuilder-accesscheck.patch
@@ -1,3 +1,5 @@
+diff --git a/src/PayfastDonationsListBuilder.php b/src/PayfastDonationsListBuilder.php
+index 1234567..abcdefg 100644
 --- a/src/PayfastDonationsListBuilder.php	2026-07-16 01:08:30.451170542 +0200
 +++ b/src/PayfastDonationsListBuilder.php	2026-07-16 01:08:30.463293154 +0200
 @@ -67,6 +67,7 @@


### PR DESCRIPTION
## What

`/admin/content/payfast-donations` threw a WSOD:

> Drupal\Core\Entity\Query\QueryException: Entity queries must explicitly set whether the query should be access checked or not.

The contrib `payfast_donation_block` list builder's total-count query never calls `accessCheck()`, which Drupal 11 makes fatal. Fixed as a composer patch adding `accessCheck(FALSE)` - the route is permission-gated and the count is a plain total. Only entity query in the module without it.

## patches.lock.json caveat

Only the new entry + `_hash` change. During `composer patches-relock`, drupal.org file downloads were being served a Cloudflare challenge page (both remote patches came back as identical HTML), so the relock silently pinned the error page's sha256 for the two drupal.org-hosted patches. Those two pins were restored to their original values by hand. **Beware running `patches-relock` while drupal.org is challenging your network - verify the remote pins in the diff.**

## Testing

Applied locally (module installed from source, so the same one-line change was made to the installed copy) and verified with Playwright as admin: the listing renders with header row and 'Total payfast donations: 0'. Worth filing upstream on drupal.org when convenient.