### PR TITLE
fix(config): enable saho_dashboard in core.extension (#497 follow-up)

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -110,6 +110,7 @@ module:
   saho_chrome: 0
   saho_classroom: 0
   saho_cleanup: 0
+  saho_dashboard: 0
   saho_donate: 0
   saho_featured_articles: 0
   saho_frontpage: 0


### PR DESCRIPTION
One-line follow-up to #497: the dashboard PR shipped the module files and the editor/moderator role grants, but not the `core.extension.yml` enablement line - so a prod deploy + config import would leave saho_dashboard disabled and the dashboard silently absent.

Hand-edited into the export (alphabetical position) rather than `drush cex` to avoid sweeping unrelated local config drift. Verified locally: with this line the only remaining `config:status` delta disappears.