### PR TITLE
fix(classroom): legacy grade-topic articles pair with their presentation deck (pre-release)

### DIFF
--- a/webroot/modules/custom/saho_classroom/saho_classroom.deploy.php
+++ b/webroot/modules/custom/saho_classroom/saho_classroom.deploy.php
@@ -52,3 +52,70 @@ function saho_classroom_deploy_redirect_retired_views(array &$sandbox): string {
   \Drupal::moduleHandler()->loadInclude('saho_classroom', 'php', 'saho_classroom.post_update');
   return saho_classroom_post_update_redirect_retired_views($sandbox);
 }
+
+/**
+ * Backfill field_caps_topic from same-topic siblings on legacy articles.
+ *
+ * The retag migration tagged most "History Grade N - Topic M ..." companion
+ * articles with their CAPS topic, but missed some (e.g. the Grade 11 Topic 4
+ * Contextual Overview) - and without the topic term the teacher CTA cannot
+ * pair the article with its presentation deck and falls back to the generic
+ * presentations browse page. Siblings share the "History Grade N - Topic M"
+ * title prefix, so an untagged article inherits the topic its tagged siblings
+ * agree on. Idempotent and additive-only: never overwrites an existing value,
+ * skips prefixes whose tagged siblings disagree.
+ */
+function saho_classroom_deploy_backfill_sibling_caps_topics(array &$sandbox): string {
+  $storage = \Drupal::entityTypeManager()->getStorage('node');
+  $nids = $storage->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('type', 'article')
+    ->condition('title', 'History Grade %', 'LIKE')
+    ->execute();
+  if (!$nids) {
+    return 'No legacy grade-topic articles found.';
+  }
+
+  // Group by the "History Grade N - Topic M" prefix and collect each group's
+  // agreed topic term from the already-tagged members.
+  $groups = [];
+  foreach ($storage->loadMultiple($nids) as $node) {
+    if (!preg_match('/^(History Grade \d+ - Topic \d+)\b/', (string) $node->label(), $m)) {
+      continue;
+    }
+    $groups[$m[1]][] = $node;
+  }
+
+  $filled = 0;
+  $conflicts = [];
+  foreach ($groups as $prefix => $nodes) {
+    $topics = [];
+    foreach ($nodes as $node) {
+      if ($node->hasField('field_caps_topic') && !$node->get('field_caps_topic')->isEmpty()) {
+        $topics[(int) $node->get('field_caps_topic')->target_id] = TRUE;
+      }
+    }
+    if (count($topics) !== 1) {
+      if (count($topics) > 1) {
+        $conflicts[] = $prefix;
+      }
+      continue;
+    }
+    $topic_id = array_key_first($topics);
+    foreach ($nodes as $node) {
+      if ($node->hasField('field_caps_topic') && $node->get('field_caps_topic')->isEmpty()) {
+        $node->set('field_caps_topic', $topic_id);
+        $node->setNewRevision(FALSE);
+        $node->setSyncing(TRUE);
+        $node->save();
+        $filled++;
+      }
+    }
+  }
+
+  $message = sprintf('Backfilled field_caps_topic on %d legacy grade-topic articles.', $filled);
+  if ($conflicts) {
+    $message .= ' Skipped conflicting prefixes: ' . implode('; ', $conflicts) . '.';
+  }
+  return $message;
+}

--- a/webroot/modules/custom/saho_classroom/saho_classroom.module
+++ b/webroot/modules/custom/saho_classroom/saho_classroom.module
@@ -206,7 +206,9 @@ function saho_classroom_node_view(array &$build, EntityInterface $node, $display
     return;
   }
   $is_classroom = FALSE;
-  foreach (['field_classroom_categories', 'field_classroom'] as $field) {
+  // The CAPS fields count as classroom membership too: parts of the retagged
+  // corpus carry a topic/grade but neither legacy classroom term.
+  foreach (['field_classroom_categories', 'field_classroom', 'field_caps_topic', 'field_classroom_grade'] as $field) {
     if ($node->hasField($field) && !$node->get($field)->isEmpty()) {
       $is_classroom = TRUE;
       break;
@@ -409,9 +411,34 @@ function _saho_classroom_match_deck(NodeInterface $article): ?NodeInterface {
 
   if (!array_key_exists($source_id, $resolved)) {
     $resolved[$source_id] = NULL;
-    $article_tokens = _saho_classroom_tokens((string) $article->getUntranslated()->label());
+    $storage = \Drupal::entityTypeManager()->getStorage('node');
+
+    // Structured match first: an article tagged with a CAPS topic pairs with
+    // the deck teaching that same topic (and grade, when tagged). Exact, and
+    // immune to the numbered "History Grade N - Topic M" legacy titles that
+    // token scoring cannot read - those used to fall back to the browse page.
+    $source = $article->getUntranslated();
+    if ($source->hasField('field_caps_topic') && !$source->get('field_caps_topic')->isEmpty()) {
+      $query = $storage->getQuery()
+        ->accessCheck(TRUE)
+        ->condition('type', 'presentation')
+        ->condition('status', 1)
+        ->condition('field_caps_topic', $source->get('field_caps_topic')->target_id)
+        ->sort('nid')
+        ->range(0, 1);
+      if ($source->hasField('field_classroom_grade') && !$source->get('field_classroom_grade')->isEmpty()) {
+        $query->condition('field_classroom_grade', $source->get('field_classroom_grade')->target_id);
+      }
+      $ids = $query->execute();
+      if ($ids) {
+        $resolved[$source_id] = (int) reset($ids);
+      }
+    }
+
+    $article_tokens = $resolved[$source_id] === NULL
+      ? _saho_classroom_tokens((string) $source->label())
+      : [];
     if ($article_tokens) {
-      $storage = \Drupal::entityTypeManager()->getStorage('node');
       $ids = $storage->getQuery()
         ->accessCheck(TRUE)
         ->condition('type', 'presentation')


### PR DESCRIPTION
Found by Mads ahead of the release: /article/history-grade-11-topic-4-contextual-overview (and its siblings) showed the teacher CTA but it led to the generic /classroom/presentations browse landing, not the topic's presentation.

**Root cause** - the deck matcher is title-token based (0.6 overlap required). Numbered legacy titles like 'History Grade 11 - Topic 4 Contextual Overview' share no tokens with deck topics like 'Nationalisms: South Africa, the Middle East and Africa', so every legacy grade-topic article fell back to the browse page. The structured CAPS fields both sides carry were never consulted. Two secondary gaps: the Topic 4 overview article was missed by the retag (no field_caps_topic), and some retagged articles (e.g. Grade 11 Topic 2 Essay Questions) carry caps fields but neither legacy classroom term, so the CTA gate skipped them entirely.

**Fix**
1. `_saho_classroom_match_deck()` matches by structure first: same `field_caps_topic` (+ grade when tagged) -> the published deck teaching that topic. Token scoring stays as fallback for untagged content.
2. CTA gate widened: caps-topic/grade tags count as classroom membership.
3. New deploy hook `saho_classroom_deploy_backfill_sibling_caps_topics` - untagged articles inherit the topic their 'History Grade N - Topic M' title-prefix siblings agree on. Idempotent, additive-only, conflict-skipping; runs automatically on `drush deploy` so prod backfills itself on release.

**Verified locally** (Playwright + anonymous curl): the reported page now links to /classroom/grade-11/nationalisms-south-africa-middle-east-and-africa; spot checks map Grade 10 Topic 3 -> French Revolution deck, Grade 11 Topic 1 -> Communism, Topic 2 -> Capitalism, Topic 3 -> Ideas of Race; full audit: **all 34 published legacy grade-topic articles resolve to a deck, 0 fallbacks** (backfill filled 14). phpcs clean; classroom kernel tests pass; drupal-check delta zero (3 pre-existing errors untouched).

Should merge before the release tag so the deploy hook rides the release.