### PR TITLE
feat(schema): modernize schema.org JSON-LD - provenance attribution, @id graph, canonical host + first test coverage

### DIFF
--- a/webroot/modules/custom/saho_tools/saho_tools.module
+++ b/webroot/modules/custom/saho_tools/saho_tools.module
@@ -7,6 +7,7 @@
 
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Entity\FieldableEntityInterface;
@@ -173,6 +174,12 @@ function saho_tools_preprocess_html(&$variables) {
     // Schema.org JSON-LD injection.
     $schema_service = \Drupal::service('saho_tools.schema_org_service');
 
+    // The injected JSON-LD varies by path (breadcrumb, node schema) and by
+    // site config; without these the page cache serves stale structured
+    // data after an edit until it expires on its own.
+    $variables['#cache']['contexts'][] = 'url.path';
+    $variables['#cache']['tags'][] = 'config:system.site';
+
     // Add meta tag for AI/LLM discovery.
     $variables['#attached']['html_head'][] = [
       [
@@ -231,6 +238,8 @@ function saho_tools_preprocess_html(&$variables) {
     // For nodes, use the canonical URL.
     $node = \Drupal::routeMatch()->getParameter('node');
     if ($node instanceof NodeInterface) {
+      // Invalidate the cached page (and its embedded JSON-LD) on node edit.
+      $variables['#cache']['tags'] = Cache::mergeTags($variables['#cache']['tags'] ?? [], $node->getCacheTags());
       $canonical_url = $node->toUrl('canonical')->setAbsolute()->toString();
 
       // Add canonical link to head.

--- a/webroot/modules/custom/saho_tools/src/Controller/LlmTxtController.php
+++ b/webroot/modules/custom/saho_tools/src/Controller/LlmTxtController.php
@@ -5,6 +5,7 @@ namespace Drupal\saho_tools\Controller;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Site\Settings;
 use Drupal\saho_tools\Service\Builder\WebSiteSchemaBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -76,8 +77,8 @@ class LlmTxtController extends ControllerBase {
 
     // Always advertise the canonical production host: this file is read by
     // crawlers and cached copies, so it must never carry a local or staging
-    // hostname.
-    $base_url = rtrim(WebSiteSchemaBuilder::CANONICAL_URL, '/');
+    // hostname. Same override knob as the schema builders.
+    $base_url = rtrim(Settings::get('saho_canonical_url', WebSiteSchemaBuilder::CANONICAL_URL), '/');
 
     // Build llm.txt content using Twig template.
     $build = [

--- a/webroot/modules/custom/saho_tools/src/Schema/ProvenanceIds.php
+++ b/webroot/modules/custom/saho_tools/src/Schema/ProvenanceIds.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\saho_tools\Schema;
+
+/**
+ * Classifies provenance source URLs as provider pages or persistent IDs.
+ *
+ * A persistent identifier (ARK, DOI, Handle, PURL) is recognised by its HOST
+ * only: provider pages such as Calisphere legitimately embed "ark:/" in their
+ * path, and those must stay classified as ordinary source links. The same
+ * host list drives both the archive Record details panel (saho.theme) and the
+ * schema.org identifier mapping, so it lives here once.
+ *
+ * Pure static and dependency-free so it is unit-testable and callable from
+ * theme code.
+ */
+final class ProvenanceIds {
+
+  /**
+   * Hosts that serve persistent identifiers.
+   */
+  public const PERSISTENT_HOSTS = [
+    'ark.cdlib.org',
+    'n2t.net',
+    'doi.org',
+    'dx.doi.org',
+    'hdl.handle.net',
+    'purl.org',
+  ];
+
+  /**
+   * Maps persistent hosts to their identifier scheme name.
+   */
+  private const SCHEME_BY_HOST = [
+    'ark.cdlib.org' => 'ark',
+    'n2t.net' => 'ark',
+    'doi.org' => 'doi',
+    'dx.doi.org' => 'doi',
+    'hdl.handle.net' => 'handle',
+    'purl.org' => 'purl',
+  ];
+
+  /**
+   * Decides whether a source URL is a persistent identifier.
+   *
+   * @param string $uri
+   *   The link URI.
+   * @param string $title
+   *   Optional link title; editors labelling a link "Persistent link" flag it
+   *   explicitly regardless of host.
+   *
+   * @return bool
+   *   TRUE for ARK/DOI/Handle/PURL links (or persistent-titled links).
+   */
+  public static function isPersistent(string $uri, string $title = ''): bool {
+    if ($title !== '' && stripos($title, 'persistent') !== FALSE) {
+      return TRUE;
+    }
+    return self::propertyId($uri) !== NULL;
+  }
+
+  /**
+   * Returns the identifier scheme for a persistent URL, or NULL.
+   *
+   * @param string $uri
+   *   The link URI.
+   *
+   * @return string|null
+   *   One of 'ark', 'doi', 'handle', 'purl' - or NULL for ordinary URLs.
+   */
+  public static function propertyId(string $uri): ?string {
+    $host = parse_url($uri, PHP_URL_HOST);
+    if (!is_string($host) || $host === '') {
+      return NULL;
+    }
+    $host = strtolower($host);
+    if (str_starts_with($host, 'www.')) {
+      $host = substr($host, 4);
+    }
+    return self::SCHEME_BY_HOST[$host] ?? NULL;
+  }
+
+}

--- a/webroot/modules/custom/saho_tools/src/Schema/SchemaDates.php
+++ b/webroot/modules/custom/saho_tools/src/Schema/SchemaDates.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\saho_tools\Schema;
+
+/**
+ * Normalises SAHO's legacy date shapes into schema.org-safe ISO-8601 dates.
+ *
+ * Machine counterpart of the theme's _saho_record_date() humaniser: the same
+ * input taxonomy (ISO datetimes, zero-padded partials, "19-September-1925"
+ * legacy strings, bare years) but emitting Y-m-d / Y-m / Y - or NULL, because
+ * prose ("circa 1918", "early 1960s") must be OMITTED from Date properties,
+ * never emitted verbatim.
+ *
+ * Pure static and dependency-free for unit testing.
+ */
+final class SchemaDates {
+
+  /**
+   * Month names to numbers for the legacy d-MonthName-Y shape.
+   */
+  private const MONTHS = [
+    'january' => 1, 'february' => 2, 'march' => 3, 'april' => 4,
+    'may' => 5, 'june' => 6, 'july' => 7, 'august' => 8,
+    'september' => 9, 'october' => 10, 'november' => 11, 'december' => 12,
+  ];
+
+  /**
+   * Normalises a raw date string to an ISO-8601 (partial) date.
+   *
+   * @param string $value
+   *   The raw stored value.
+   *
+   * @return string|null
+   *   'Y-m-d', 'Y-m' or 'Y' - or NULL when the value is junk or prose.
+   */
+  public static function normalize(string $value): ?string {
+    $value = trim($value);
+    if ($value === '') {
+      return NULL;
+    }
+
+    // ISO date, optionally with a time suffix ("2001-05-04T00:00:00" or
+    // "2001-05-04 00:00:00"). Zeroed month/day segments encode partial dates.
+    if (preg_match('/^(\d{4})-(\d{2})-(\d{2})([T ].*)?$/', $value, $m)) {
+      $y = (int) $m[1];
+      $mo = (int) $m[2];
+      $d = (int) $m[3];
+      if ($y < 1000 || $y > 2099) {
+        return NULL;
+      }
+      if ($mo === 0) {
+        return (string) $y;
+      }
+      if ($mo < 1 || $mo > 12) {
+        return NULL;
+      }
+      if ($d === 0) {
+        return sprintf('%04d-%02d', $y, $mo);
+      }
+      return checkdate($mo, $d, $y) ? sprintf('%04d-%02d-%02d', $y, $mo, $d) : NULL;
+    }
+
+    // Year-month partial ("1993-12").
+    if (preg_match('/^(\d{4})-(\d{2})$/', $value, $m)) {
+      $y = (int) $m[1];
+      $mo = (int) $m[2];
+      if ($y >= 1000 && $y <= 2099 && $mo >= 1 && $mo <= 12) {
+        return sprintf('%04d-%02d', $y, $mo);
+      }
+      return NULL;
+    }
+
+    // Legacy "19-September-1925" (also accepts "9 September 1925").
+    if (preg_match('/^(\d{1,2})[- ]([a-zA-Z]+)[- ](\d{4})$/', $value, $m)) {
+      $d = (int) $m[1];
+      $mo = self::MONTHS[strtolower($m[2])] ?? NULL;
+      $y = (int) $m[3];
+      if ($mo !== NULL && $y >= 1000 && $y <= 2099 && checkdate($mo, $d, $y)) {
+        return sprintf('%04d-%02d-%02d', $y, $mo, $d);
+      }
+      return NULL;
+    }
+
+    // Bare year.
+    if (preg_match('/^(\d{4})$/', $value, $m)) {
+      $y = (int) $m[1];
+      return ($y >= 1000 && $y <= 2099) ? (string) $y : NULL;
+    }
+
+    // Anything else is prose - omit rather than pollute a Date property.
+    return NULL;
+  }
+
+}

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/ArchiveSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/ArchiveSchemaBuilder.php
@@ -2,11 +2,10 @@
 
 namespace Drupal\saho_tools\Service\Builder;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
+use Drupal\saho_tools\Schema\ProvenanceIds;
+use Drupal\saho_tools\Schema\SchemaDates;
 
 /**
  * Builds Schema.org structured data for Archive nodes.
@@ -16,13 +15,18 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * as additionalType to preserve archival semantics. Bare ArchiveComponent
  * has no Google rich-result template, which is why ~30k archive nodes
  * have been invisible to GSC.
+ *
+ * Carries the Catalyst provenance fields (#494): original creators with
+ * their roles, creation date, provider source pages (sameAs), persistent
+ * identifiers (ARK/DOI/Handle as PropertyValue identifiers) and the
+ * provenance note as creditText.
  */
-class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
+class ArchiveSchemaBuilder extends SchemaBuilderBase {
 
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+  /**
+   * Creator roles that describe an organisation rather than a person.
+   */
+  private const ORG_ROLES = ['institution' => TRUE, 'publisher' => TRUE];
 
   /**
    * {@inheritdoc}
@@ -39,7 +43,6 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
-    $url = $node->toUrl()->setAbsolute()->toString();
     $has_isbn = $node->hasField('field_isbn') && !$node->get('field_isbn')->isEmpty();
 
     $schema = [
@@ -47,56 +50,117 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       '@type' => $has_isbn ? 'Book' : 'CreativeWork',
       'additionalType' => 'https://schema.org/ArchiveComponent',
       'name' => $node->getTitle(),
-      'url' => $url,
-      'mainEntityOfPage' => [
-        '@type' => 'WebPage',
-        '@id' => $url,
-      ],
       'dateModified' => date('c', $node->getChangedTime()),
-    ];
+    ] + $this->identityProperties($node);
 
     // Prefer the publication title when set.
     if ($node->hasField('field_publication_title') && !$node->get('field_publication_title')->isEmpty()) {
       $schema['name'] = $node->get('field_publication_title')->value;
     }
 
-    // Authors (also surfaced as creator for GSC-friendly CreativeWork).
-    $authors = [];
-    if ($node->hasField('field_author') && !$node->get('field_author')->isEmpty()) {
-      foreach ($node->get('field_author') as $author) {
-        if (!empty($author->value)) {
-          $authors[] = [
-            '@type' => 'Person',
-            'name' => $author->value,
+    // Statement of responsibility: original creators (with roles) beat the
+    // legacy author string, which beats the institutional fallback.
+    $creators = $this->buildCreators($node);
+    if ($creators) {
+      $schema['creator'] = count($creators) === 1 ? $creators[0] : $creators;
+      // Only flat Person/Organization entries make sense as "author";
+      // Role wrappers stay on creator.
+      $schema['author'] = $schema['creator'];
+    }
+    else {
+      $authors = [];
+      if ($node->hasField('field_author') && !$node->get('field_author')->isEmpty()) {
+        foreach ($node->get('field_author') as $author) {
+          if (!empty($author->value)) {
+            $authors[] = [
+              '@type' => 'Person',
+              'name' => $author->value,
+            ];
+          }
+        }
+      }
+      if (!empty($authors)) {
+        $schema['author'] = count($authors) === 1 ? $authors[0] : $authors;
+        $schema['creator'] = $schema['author'];
+      }
+      else {
+        // Fall back to SAHO as institutional creator so the field is never
+        // empty (Google flags missing creator on CreativeWork-like items).
+        $schema['creator'] = $this->organizationRef();
+      }
+    }
+
+    // When the work itself predates its publication (a 1976 photograph
+    // published by an archive in 2019), say so.
+    if ($node->hasField('field_original_created_date') && !$node->get('field_original_created_date')->isEmpty()) {
+      $created = SchemaDates::normalize((string) $node->get('field_original_created_date')->value);
+      if ($created !== NULL) {
+        $schema['dateCreated'] = $created;
+      }
+    }
+
+    // Publication date: the structured datetime slot wins; the 21k free-text
+    // legacy values only pass through when they normalise to a real ISO
+    // (partial) date - prose like "circa 1918" is omitted, not emitted.
+    $published = NULL;
+    if ($node->hasField('field_archive_publication_date') && !$node->get('field_archive_publication_date')->isEmpty()) {
+      $published = SchemaDates::normalize((string) $node->get('field_archive_publication_date')->value);
+    }
+    if ($published === NULL && $node->hasField('field_publication_date_archive') && !$node->get('field_publication_date_archive')->isEmpty()) {
+      $published = SchemaDates::normalize((string) $node->get('field_publication_date_archive')->value);
+    }
+    if ($published !== NULL) {
+      $schema['datePublished'] = $published;
+    }
+
+    // Original source links: provider pages become sameAs, persistent IDs
+    // (ARK/DOI/Handle/PURL) become typed identifiers alongside the SAHO ref.
+    $same_as = [];
+    $persistent = [];
+    if ($node->hasField('field_original_source_url') && !$node->get('field_original_source_url')->isEmpty()) {
+      foreach ($node->get('field_original_source_url') as $link) {
+        // @phpstan-ignore-next-line
+        $uri = (string) $link->uri;
+        if ($uri === '') {
+          continue;
+        }
+        // @phpstan-ignore-next-line
+        $title = (string) ($link->title ?? '');
+        if (ProvenanceIds::isPersistent($uri, $title)) {
+          $persistent[] = [
+            '@type' => 'PropertyValue',
+            'propertyID' => ProvenanceIds::propertyId($uri) ?? 'persistent',
+            'value' => $uri,
           ];
+        }
+        else {
+          $same_as[] = $uri;
         }
       }
     }
-    if (!empty($authors)) {
-      $schema['author'] = count($authors) === 1 ? $authors[0] : $authors;
-      $schema['creator'] = $schema['author'];
+    if ($same_as) {
+      $schema['sameAs'] = count($same_as) === 1 ? $same_as[0] : $same_as;
     }
-    else {
-      // Fall back to SAHO as institutional creator so the field is never
-      // empty (Google flags missing creator on CreativeWork-like items).
-      $schema['creator'] = [
-        '@type' => 'Organization',
-        'name' => 'South African History Online',
-        'url' => \Drupal::request()->getSchemeAndHttpHost(),
-      ];
+    if ($persistent) {
+      $identifiers = isset($schema['identifier']) ? [$schema['identifier']] : [];
+      $identifiers = array_merge($identifiers, $persistent);
+      $schema['identifier'] = count($identifiers) === 1 ? $identifiers[0] : $identifiers;
     }
 
-    // Publication date.
-    if ($node->hasField('field_archive_publication_date') && !$node->get('field_archive_publication_date')->isEmpty()) {
-      $pub_date = $node->get('field_archive_publication_date')->value;
-      if (!empty($pub_date)) {
-        $schema['datePublished'] = $pub_date;
+    // Provenance note: the human acknowledgement of where the work came from.
+    if ($node->hasField('field_provenance_note') && !$node->get('field_provenance_note')->isEmpty()) {
+      $note = trim(strip_tags((string) $node->get('field_provenance_note')->value));
+      $note = trim(preg_replace('/\[saho_import:[^\]]*\]/', '', $note) ?? $note);
+      if ($note !== '') {
+        $schema['creditText'] = $note;
       }
     }
-    elseif ($node->hasField('field_publication_date_archive') && !$node->get('field_publication_date_archive')->isEmpty()) {
-      $pub_date = $node->get('field_publication_date_archive')->value;
-      if (!empty($pub_date)) {
-        $schema['datePublished'] = $pub_date;
+
+    // Rights statement.
+    if ($node->hasField('field_copyright') && !$node->get('field_copyright')->isEmpty()) {
+      $rights = trim(strip_tags((string) $node->get('field_copyright')->value));
+      if ($rights !== '') {
+        $schema['copyrightNotice'] = $rights;
       }
     }
 
@@ -162,7 +226,7 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       $schema['contributor'] = count($contributors) === 1 ? $contributors[0] : $contributors;
     }
 
-    // Keywords from tags.
+    // Keywords from tags; format taxonomy carries genre.
     if ($node->hasField('field_tags') && !$node->get('field_tags')->isEmpty()) {
       $keywords = [];
       foreach ($node->get('field_tags') as $tag) {
@@ -174,6 +238,19 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       }
       if (!empty($keywords)) {
         $schema['keywords'] = implode(', ', $keywords);
+      }
+    }
+    if ($node->hasField('field_media_library_type') && !$node->get('field_media_library_type')->isEmpty()) {
+      $genres = [];
+      foreach ($node->get('field_media_library_type') as $format) {
+        // @phpstan-ignore-next-line
+        $term = $format->entity;
+        if ($term) {
+          $genres[] = $term->getName();
+        }
+      }
+      if (!empty($genres)) {
+        $schema['genre'] = count($genres) === 1 ? $genres[0] : $genres;
       }
     }
 
@@ -232,14 +309,9 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       }
     }
 
-    // Holdings, publisher, license.
-    $base_url = \Drupal::request()->getSchemeAndHttpHost();
-    $org = [
-      '@type' => 'ArchiveOrganization',
-      'name' => 'South African History Online',
-      'url' => $base_url,
-    ];
-    $schema['holdingArchive'] = $org;
+    // Holdings, publisher, license - all SAHO references collapse onto the
+    // single sitewide organization entity via @id.
+    $schema['holdingArchive'] = $this->organizationRef('ArchiveOrganization');
 
     // Real publisher (e.g. "Sanchar Publishing House") when the record carries
     // one - what a Book rich result wants; SAHO remains the holding archive and
@@ -250,11 +322,7 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
     }
     if ($publisher_name !== '') {
       $schema['publisher'] = ['@type' => 'Organization', 'name' => $publisher_name];
-      $schema['provider'] = [
-        '@type' => 'Organization',
-        'name' => 'South African History Online',
-        'url' => $base_url,
-      ];
+      $schema['provider'] = $this->organizationRef();
       if ($node->hasField('field_publication_place') && !$node->get('field_publication_place')->isEmpty()) {
         $place = trim(strip_tags((string) $node->get('field_publication_place')->value));
         if ($place !== '') {
@@ -263,26 +331,58 @@ class ArchiveSchemaBuilder implements SchemaOrgBuilderInterface {
       }
     }
     else {
-      $schema['publisher'] = [
-        '@type' => 'Organization',
-        'name' => 'South African History Online',
-        'url' => $base_url,
-        'logo' => [
-          '@type' => 'ImageObject',
-          'url' => $base_url . '/themes/custom/saho/logo.png',
-          'width' => 600,
-          'height' => 60,
-        ],
-      ];
+      $schema['publisher'] = $this->organizationRef();
     }
-    $schema['copyrightHolder'] = [
-      '@type' => 'Organization',
-      'name' => 'South African History Online',
-    ];
+    $schema['copyrightHolder'] = $this->organizationRef();
     $schema['license'] = 'https://creativecommons.org/licenses/by-nc-sa/4.0/';
     $schema['isAccessibleForFree'] = TRUE;
 
     return $schema;
+  }
+
+  /**
+   * Builds creator entries from the Catalyst provenance fields.
+   *
+   * Creators pair with roles by delta; a role wraps the entry in the
+   * schema.org Role pattern, and organisational roles type the inner
+   * entity as Organization.
+   *
+   * @return array
+   *   Creator entries, empty when the provenance fields are unpopulated.
+   */
+  protected function buildCreators(NodeInterface $node): array {
+    if (!$node->hasField('field_original_creator') || $node->get('field_original_creator')->isEmpty()) {
+      return [];
+    }
+    $roles = [];
+    if ($node->hasField('field_original_creator_role')) {
+      foreach ($node->get('field_original_creator_role') as $delta => $item) {
+        // @phpstan-ignore-next-line
+        $roles[$delta] = (string) $item->value;
+      }
+    }
+    $creators = [];
+    foreach ($node->get('field_original_creator') as $delta => $item) {
+      // @phpstan-ignore-next-line
+      $name = trim((string) $item->value);
+      if ($name === '') {
+        continue;
+      }
+      $role = $roles[$delta] ?? '';
+      $entity_type = isset(self::ORG_ROLES[$role]) ? 'Organization' : 'Person';
+      $entity = ['@type' => $entity_type, 'name' => $name];
+      if ($role !== '') {
+        $creators[] = [
+          '@type' => 'Role',
+          'roleName' => $role,
+          'creator' => $entity,
+        ];
+      }
+      else {
+        $creators[] = $entity;
+      }
+    }
+    return $creators;
   }
 
 }

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/ArticleSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/ArticleSchemaBuilder.php
@@ -3,11 +3,8 @@
 namespace Drupal\saho_tools\Service\Builder;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org Article structured data for Article nodes.
@@ -17,12 +14,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * as additionalType to preserve semantics without sacrificing GSC
  * visibility).
  */
-class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
-
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class ArticleSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -39,21 +31,14 @@ class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
-    $url = $node->toUrl()->setAbsolute()->toString();
-
     $schema = [
       '@context' => 'https://schema.org',
       '@type' => 'Article',
       'additionalType' => 'https://schema.org/ScholarlyArticle',
       'headline' => $node->getTitle(),
-      'url' => $url,
-      'mainEntityOfPage' => [
-        '@type' => 'WebPage',
-        '@id' => $url,
-      ],
       'datePublished' => date('c', $node->getCreatedTime()),
       'dateModified' => date('c', $node->getChangedTime()),
-    ];
+    ] + $this->identityProperties($node);
 
     // Synopsis -> abstract; body -> articleBody + description + wordCount.
     if ($node->hasField('field_synopsis') && !$node->get('field_synopsis')->isEmpty()) {
@@ -227,21 +212,10 @@ class ArticleSchemaBuilder implements SchemaOrgBuilderInterface {
   }
 
   /**
-   * Publisher with logo dimensions (Google AMP/Article rich-result spec).
+   * Returns the @id-linked sitewide organization stub as publisher.
    */
   protected function getPublisherSchema(): array {
-    $base_url = \Drupal::request()->getSchemeAndHttpHost();
-    return [
-      '@type' => 'Organization',
-      'name' => 'South African History Online',
-      'url' => $base_url,
-      'logo' => [
-        '@type' => 'ImageObject',
-        'url' => $base_url . '/themes/custom/saho/logo.png',
-        'width' => 600,
-        'height' => 60,
-      ],
-    ];
+    return $this->organizationRef();
   }
 
 }

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/BiographySchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/BiographySchemaBuilder.php
@@ -2,11 +2,9 @@
 
 namespace Drupal\saho_tools\Service\Builder;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
+use Drupal\saho_tools\Schema\SchemaDates;
 
 /**
  * Builds Schema.org ProfilePage structured data for Biography nodes.
@@ -15,12 +13,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * person pages) with the Person nested under mainEntity. ProfilePage IS
  * reported in GSC's enhancement reports; bare Person is not.
  */
-class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
-
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class BiographySchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -37,10 +30,12 @@ class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
-    $url = $node->toUrl()->setAbsolute()->toString();
+    $url = $this->canonicalNodeUrl($node);
+    $ref_url = $this->refUrl($node);
 
     $person = [
       '@type' => 'Person',
+      '@id' => ($ref_url ?? $url) . '#person',
       'name' => $node->getTitle(),
       'url' => $url,
       'mainEntityOfPage' => [
@@ -67,18 +62,17 @@ class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
       $person['name'] = implode(' ', $name_parts);
     }
 
-    // Dates.
-    if ($node->hasField('field_drupal_birth_date') && !$node->get('field_drupal_birth_date')->isEmpty()) {
-      $birth_date = $node->get('field_drupal_birth_date')->value;
-      if (!empty($birth_date)) {
-        $person['birthDate'] = $birth_date;
-      }
+    // Dates: the structured datetime pair covers ~900 records; the legacy
+    // free-text field_dob/field_dod pair covers ~2,200/2,600 more in shapes
+    // SchemaDates can normalise ("19-September-1925", "1918"). Prose stays
+    // out of Date properties.
+    $birth = $this->firstDate($node, ['field_drupal_birth_date', 'field_dob']);
+    if ($birth !== NULL) {
+      $person['birthDate'] = $birth;
     }
-    if ($node->hasField('field_drupal_death_date') && !$node->get('field_drupal_death_date')->isEmpty()) {
-      $death_date = $node->get('field_drupal_death_date')->value;
-      if (!empty($death_date)) {
-        $person['deathDate'] = $death_date;
-      }
+    $death = $this->firstDate($node, ['field_drupal_death_date', 'field_dod']);
+    if ($death !== NULL) {
+      $person['deathDate'] = $death;
     }
 
     // Birth/death places.
@@ -172,19 +166,22 @@ class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
       }
     }
 
-    // knowsAbout from tags.
-    if ($node->hasField('field_tags') && !$node->get('field_tags')->isEmpty()) {
-      $topics = [];
-      foreach ($node->get('field_tags') as $tag) {
-        // @phpstan-ignore-next-line
-        $term = $tag->entity;
-        if ($term) {
-          $topics[] = $term->getName();
+    // knowsAbout from tags plus people categories (the far better-populated
+    // vocabulary: 11k+ records carry field_people_category, only ~80 tags).
+    $topics = [];
+    foreach (['field_tags', 'field_people_category'] as $topic_field) {
+      if ($node->hasField($topic_field) && !$node->get($topic_field)->isEmpty()) {
+        foreach ($node->get($topic_field) as $tag) {
+          // @phpstan-ignore-next-line
+          $term = $tag->entity;
+          if ($term) {
+            $topics[] = $term->getName();
+          }
         }
       }
-      if (!empty($topics)) {
-        $person['knowsAbout'] = $topics;
-      }
+    }
+    if (!empty($topics)) {
+      $person['knowsAbout'] = array_values(array_unique($topics));
     }
 
     // Description (up to 300 chars; Google accommodates the longer cap).
@@ -222,15 +219,37 @@ class BiographySchemaBuilder implements SchemaOrgBuilderInterface {
     $schema = [
       '@context' => 'https://schema.org',
       '@type' => 'ProfilePage',
-      'url' => $url,
       'dateCreated' => date('c', $node->getCreatedTime()),
       'dateModified' => date('c', $node->getChangedTime()),
       'mainEntity' => $person,
-    ];
+    ] + $this->identityProperties($node);
     if (!empty($citations)) {
       $schema['citation'] = $citations;
     }
     return $schema;
+  }
+
+  /**
+   * Returns the first schema-safe date found across the given fields.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The biography node.
+   * @param string[] $fields
+   *   Field names in order of preference.
+   *
+   * @return string|null
+   *   A normalised ISO (partial) date, or NULL when none normalises.
+   */
+  protected function firstDate(NodeInterface $node, array $fields): ?string {
+    foreach ($fields as $field) {
+      if ($node->hasField($field) && !$node->get($field)->isEmpty()) {
+        $date = SchemaDates::normalize((string) $node->get($field)->value);
+        if ($date !== NULL) {
+          return $date;
+        }
+      }
+    }
+    return NULL;
   }
 
 }

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/BreadcrumbSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/BreadcrumbSchemaBuilder.php
@@ -2,10 +2,7 @@
 
 namespace Drupal\saho_tools\Service\Builder;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org BreadcrumbList structured data.
@@ -13,20 +10,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * Generates breadcrumb navigation schema for improved search engine
  * understanding of site hierarchy and navigation.
  */
-class BreadcrumbSchemaBuilder implements SchemaOrgBuilderInterface {
-
-  /**
-   * Constructs a BreadcrumbSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class BreadcrumbSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -40,8 +24,7 @@ class BreadcrumbSchemaBuilder implements SchemaOrgBuilderInterface {
    * {@inheritdoc}
    */
   public function build(?NodeInterface $node = NULL): array {
-    $request = \Drupal::request();
-    $base_url = $request->getSchemeAndHttpHost();
+    $base_url = $this->canonicalBaseUrl();
     $route_match = \Drupal::routeMatch();
 
     // Start with home.
@@ -96,7 +79,7 @@ class BreadcrumbSchemaBuilder implements SchemaOrgBuilderInterface {
         '@type' => 'ListItem',
         'position' => $position,
         'name' => $node->getTitle(),
-        'item' => $node->toUrl()->setAbsolute()->toString(),
+        'item' => $this->canonicalNodeUrl($node),
       ];
     }
 

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/DragAndDropPageSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/DragAndDropPageSchemaBuilder.php
@@ -2,10 +2,7 @@
 
 namespace Drupal\saho_tools\Service\Builder;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org WebPage structured data for Drag and Drop Page nodes.
@@ -13,20 +10,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * Maps SAHO landing pages and homepage to Schema.org WebPage vocabulary
  * for optimal discovery by search engines and AI systems.
  */
-class DragAndDropPageSchemaBuilder implements SchemaOrgBuilderInterface {
-
-  /**
-   * Constructs a DragAndDropPageSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class DragAndDropPageSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -47,10 +31,9 @@ class DragAndDropPageSchemaBuilder implements SchemaOrgBuilderInterface {
       '@context' => 'https://schema.org',
       '@type' => 'WebPage',
       'name' => $node->getTitle(),
-      'url' => $node->toUrl()->setAbsolute()->toString(),
       'datePublished' => date('c', $node->getCreatedTime()),
       'dateModified' => date('c', $node->getChangedTime()),
-    ];
+    ] + $this->identityProperties($node);
 
     // Add description from body field.
     if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
@@ -81,13 +64,13 @@ class DragAndDropPageSchemaBuilder implements SchemaOrgBuilderInterface {
             '@type' => 'ListItem',
             'position' => 1,
             'name' => 'Home',
-            'item' => \Drupal::request()->getSchemeAndHttpHost(),
+            'item' => $this->canonicalBaseUrl(),
           ],
           [
             '@type' => 'ListItem',
             'position' => 2,
             'name' => $node->getTitle(),
-            'item' => $node->toUrl()->setAbsolute()->toString(),
+            'item' => $this->canonicalNodeUrl($node),
           ],
         ],
       ];
@@ -104,24 +87,13 @@ class DragAndDropPageSchemaBuilder implements SchemaOrgBuilderInterface {
   }
 
   /**
-   * Get SAHO publisher schema.
+   * Returns the @id-linked sitewide organization stub as publisher.
    *
    * @return array
-   *   Publisher organization schema.
+   *   Publisher organization stub.
    */
   protected function getPublisherSchema(): array {
-    $request = \Drupal::request();
-    $base_url = $request->getSchemeAndHttpHost();
-
-    return [
-      '@type' => 'Organization',
-      'name' => 'South African History Online',
-      'url' => $base_url,
-      'logo' => [
-        '@type' => 'ImageObject',
-        'url' => $base_url . '/themes/custom/saho/logo.png',
-      ],
-    ];
+    return $this->organizationRef();
   }
 
 }

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/EventSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/EventSchemaBuilder.php
@@ -3,11 +3,8 @@
 namespace Drupal\saho_tools\Service\Builder;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org Article structured data for historical Event nodes.
@@ -17,12 +14,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * (a GSC-eligible type) with the historical event nested under `about` as
  * a Schema.org Event with additionalType=HistoricalEvent.
  */
-class EventSchemaBuilder implements SchemaOrgBuilderInterface {
-
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class EventSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -39,21 +31,14 @@ class EventSchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
-    $url = $node->toUrl()->setAbsolute()->toString();
-
     $schema = [
       '@context' => 'https://schema.org',
       '@type' => 'Article',
       'additionalType' => 'https://schema.org/ScholarlyArticle',
       'headline' => $node->getTitle(),
-      'url' => $url,
-      'mainEntityOfPage' => [
-        '@type' => 'WebPage',
-        '@id' => $url,
-      ],
       'datePublished' => date('c', $node->getCreatedTime()),
       'dateModified' => date('c', $node->getChangedTime()),
-    ];
+    ] + $this->identityProperties($node);
 
     // Event date drives the historical event's startDate.
     $event_date = NULL;
@@ -236,21 +221,10 @@ class EventSchemaBuilder implements SchemaOrgBuilderInterface {
   }
 
   /**
-   * Get SAHO publisher schema with logo dimensions (Google AMP spec).
+   * Returns the @id-linked sitewide organization stub as publisher.
    */
   protected function getPublisherSchema(): array {
-    $base_url = \Drupal::request()->getSchemeAndHttpHost();
-    return [
-      '@type' => 'Organization',
-      'name' => 'South African History Online',
-      'url' => $base_url,
-      'logo' => [
-        '@type' => 'ImageObject',
-        'url' => $base_url . '/themes/custom/saho/logo.png',
-        'width' => 600,
-        'height' => 60,
-      ],
-    ];
+    return $this->organizationRef();
   }
 
 }

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/ImageSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/ImageSchemaBuilder.php
@@ -2,11 +2,8 @@
 
 namespace Drupal\saho_tools\Service\Builder;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org ImageObject structured data for Image nodes.
@@ -14,20 +11,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * Maps SAHO image/gallery content to Schema.org ImageObject
  * vocabulary for optimal image discovery and attribution.
  */
-class ImageSchemaBuilder implements SchemaOrgBuilderInterface {
-
-  /**
-   * Constructs an ImageSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class ImageSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -48,8 +32,7 @@ class ImageSchemaBuilder implements SchemaOrgBuilderInterface {
       '@context' => 'https://schema.org',
       '@type' => 'ImageObject',
       'name' => $node->getTitle(),
-      'url' => $node->toUrl()->setAbsolute()->toString(),
-    ];
+    ] + $this->identityProperties($node);
 
     // Get the image field based on node type.
     $image_field = $node->getType() === 'gallery_image' ? 'field_gallery_image' : 'field_image';
@@ -110,28 +93,18 @@ class ImageSchemaBuilder implements SchemaOrgBuilderInterface {
       ];
     }
     else {
-      $schema['creator'] = [
-        '@type' => 'Organization',
-        'name' => 'South African History Online',
-        'url' => \Drupal::request()->getSchemeAndHttpHost(),
-      ];
+      $schema['creator'] = $this->organizationRef();
     }
 
     // Add copyright holder.
-    $schema['copyrightHolder'] = [
-      '@type' => 'Organization',
-      'name' => 'South African History Online',
-    ];
+    $schema['copyrightHolder'] = $this->organizationRef();
 
     // Add license.
     $schema['license'] = 'https://creativecommons.org/licenses/by-nc-sa/4.0/';
     $schema['isAccessibleForFree'] = TRUE;
 
     // Add IPTC Photo Metadata properties (schema.org 2020 update).
-    $request = \Drupal::request();
-    $base_url = $request->getSchemeAndHttpHost();
-
-    $schema['acquireLicensePage'] = $base_url . '/about/copyright-licensing';
+    $schema['acquireLicensePage'] = $this->canonicalBaseUrl() . '/about/copyright-licensing';
 
     $schema['copyrightNotice'] = '© ' . date('Y') . ' South African History Online. Licensed under CC BY-NC-SA 4.0.';
 

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/OrganizationSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/OrganizationSchemaBuilder.php
@@ -2,31 +2,17 @@
 
 namespace Drupal\saho_tools\Service\Builder;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org Organization structured data for SAHO site-wide.
  *
  * Provides comprehensive organization information for search engines
- * and AI systems to understand SAHO's identity and mission.
+ * and AI systems to understand SAHO's identity and mission. This is the
+ * ONE sitewide organization entity - every builder that references SAHO
+ * (publisher, provider, holdingArchive) points at its @id.
  */
-class OrganizationSchemaBuilder implements SchemaOrgBuilderInterface {
-
-  /**
-   * Constructs an OrganizationSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class OrganizationSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -40,12 +26,12 @@ class OrganizationSchemaBuilder implements SchemaOrgBuilderInterface {
    * {@inheritdoc}
    */
   public function build(?NodeInterface $node = NULL): array {
-    $request = \Drupal::request();
-    $base_url = $request->getSchemeAndHttpHost();
+    $base_url = $this->canonicalBaseUrl();
 
     $schema = [
       '@context' => 'https://schema.org',
       '@type' => ['Organization', 'EducationalOrganization'],
+      '@id' => $this->organizationId(),
       'name' => 'South African History Online',
       'alternateName' => 'SAHO',
       'legalName' => 'South African History Online',

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/PageSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/PageSchemaBuilder.php
@@ -3,11 +3,8 @@
 namespace Drupal\saho_tools\Service\Builder;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org WebPage structured data for Page nodes.
@@ -15,20 +12,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * Maps SAHO standard pages to Schema.org WebPage vocabulary
  * for optimal discovery by search engines and AI systems.
  */
-class PageSchemaBuilder implements SchemaOrgBuilderInterface {
-
-  /**
-   * Constructs a PageSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class PageSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -49,10 +33,9 @@ class PageSchemaBuilder implements SchemaOrgBuilderInterface {
       '@context' => 'https://schema.org',
       '@type' => 'WebPage',
       'name' => $node->getTitle(),
-      'url' => $node->toUrl()->setAbsolute()->toString(),
       'datePublished' => date('c', $node->getCreatedTime()),
       'dateModified' => date('c', $node->getChangedTime()),
-    ];
+    ] + $this->identityProperties($node);
 
     // Add description from body field.
     if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
@@ -87,13 +70,13 @@ class PageSchemaBuilder implements SchemaOrgBuilderInterface {
           '@type' => 'ListItem',
           'position' => 1,
           'name' => 'Home',
-          'item' => \Drupal::request()->getSchemeAndHttpHost(),
+          'item' => $this->canonicalBaseUrl(),
         ],
         [
           '@type' => 'ListItem',
           'position' => 2,
           'name' => $node->getTitle(),
-          'item' => $node->toUrl()->setAbsolute()->toString(),
+          'item' => $this->canonicalNodeUrl($node),
         ],
       ],
     ];
@@ -143,24 +126,13 @@ class PageSchemaBuilder implements SchemaOrgBuilderInterface {
   }
 
   /**
-   * Get SAHO publisher schema.
+   * Returns the @id-linked sitewide organization stub as publisher.
    *
    * @return array
-   *   Publisher organization schema.
+   *   Publisher organization stub.
    */
   protected function getPublisherSchema(): array {
-    $request = \Drupal::request();
-    $base_url = $request->getSchemeAndHttpHost();
-
-    return [
-      '@type' => 'Organization',
-      'name' => 'South African History Online',
-      'url' => $base_url,
-      'logo' => [
-        '@type' => 'ImageObject',
-        'url' => $base_url . '/themes/custom/saho/logo.png',
-      ],
-    ];
+    return $this->organizationRef();
   }
 
 }

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/PlaceSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/PlaceSchemaBuilder.php
@@ -2,11 +2,8 @@
 
 namespace Drupal\saho_tools\Service\Builder;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org structured data for Place nodes.
@@ -31,7 +28,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  *   the top-level @type because Google requires phone/hours/address
  *   for those - they survive as additionalType instead.
  */
-class PlaceSchemaBuilder implements SchemaOrgBuilderInterface {
+class PlaceSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * Maps SAHO field_place_type term names to Schema.org @type values.
@@ -213,19 +210,6 @@ class PlaceSchemaBuilder implements SchemaOrgBuilderInterface {
   ];
 
   /**
-   * Constructs a PlaceSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
-
-  /**
    * {@inheritdoc}
    */
   public function supports(string $node_type): bool {
@@ -240,20 +224,14 @@ class PlaceSchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
-    $url = $node->toUrl()->setAbsolute()->toString();
     [$type, $additional_type] = $this->resolvePlaceType($node);
 
     $schema = [
       '@context' => 'https://schema.org',
       '@type' => $type,
       'name' => $node->getTitle(),
-      'url' => $url,
-      'mainEntityOfPage' => [
-        '@type' => 'WebPage',
-        '@id' => $url,
-      ],
       'dateModified' => date('c', $node->getChangedTime()),
-    ];
+    ] + $this->identityProperties($node);
 
     if ($additional_type !== NULL) {
       $schema['additionalType'] = 'https://schema.org/' . $additional_type;

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/ProductSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/ProductSchemaBuilder.php
@@ -2,11 +2,8 @@
 
 namespace Drupal\saho_tools\Service\Builder;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org Book/Product structured data for Product nodes.
@@ -14,20 +11,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * Maps SAHO product content (books, publications) to Schema.org
  * Book/Product vocabulary for e-commerce and catalog discovery.
  */
-class ProductSchemaBuilder implements SchemaOrgBuilderInterface {
-
-  /**
-   * Constructs a ProductSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class ProductSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -44,12 +28,15 @@ class ProductSchemaBuilder implements SchemaOrgBuilderInterface {
       return [];
     }
 
+    // Only claim Book when an ISBN backs it up; otherwise fall back to
+    // the generic Product type.
+    $has_isbn = $node->hasField('field_isbn') && !$node->get('field_isbn')->isEmpty();
+
     $schema = [
       '@context' => 'https://schema.org',
-      '@type' => 'Book',
+      '@type' => $has_isbn ? 'Book' : 'Product',
       'name' => $node->getTitle(),
-      'url' => $node->toUrl()->setAbsolute()->toString(),
-    ];
+    ] + $this->identityProperties($node);
 
     // Add description.
     if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
@@ -75,7 +62,7 @@ class ProductSchemaBuilder implements SchemaOrgBuilderInterface {
     }
 
     // Add ISBN if available.
-    if ($node->hasField('field_isbn') && !$node->get('field_isbn')->isEmpty()) {
+    if ($has_isbn) {
       $schema['isbn'] = $node->get('field_isbn')->value;
     }
 

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/SchemaBuilderBase.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/SchemaBuilderBase.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\saho_tools\Service\Builder;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\node\NodeInterface;
+use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
+
+/**
+ * Shared identity plumbing for all SAHO schema.org builders.
+ *
+ * Centralises three things every builder needs:
+ * - the canonical base URL (apex host; www 301s to it in production), so
+ *   local/staging hosts never leak into structured data;
+ * - the stable identity block: @id on the permanent /ref/ URL from saho_refs,
+ *   url on the canonical alias, and a SAHO-ref PropertyValue identifier;
+ * - @id-linked stubs for the single sitewide Organization/WebSite entities,
+ *   so publisher/holdingArchive/provider references dedupe to one entity
+ *   instead of re-inlining SAHO on every block.
+ */
+abstract class SchemaBuilderBase implements SchemaOrgBuilderInterface {
+
+  /**
+   * Default canonical base URL (apex - www redirects here).
+   */
+  protected const CANONICAL_BASE = 'https://sahistory.org.za';
+
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected FileUrlGeneratorInterface $fileUrlGenerator,
+  ) {}
+
+  /**
+   * Returns the canonical base URL, without a trailing slash.
+   *
+   * Overridable per environment via $settings['saho_canonical_url'].
+   */
+  protected function canonicalBaseUrl(): string {
+    return rtrim(Settings::get('saho_canonical_url', static::CANONICAL_BASE), '/');
+  }
+
+  /**
+   * Returns the node's canonical URL on the canonical host.
+   */
+  protected function canonicalNodeUrl(NodeInterface $node): string {
+    return $this->canonicalBaseUrl() . $node->toUrl()->toString();
+  }
+
+  /**
+   * Returns the node's SAHO display ref (e.g. "R-0123456"), if available.
+   */
+  protected function refCode(NodeInterface $node): ?string {
+    if (!\Drupal::hasService('saho_refs.display_ref')) {
+      return NULL;
+    }
+    $ref = \Drupal::service('saho_refs.display_ref')->getRef($node);
+    return is_string($ref) && $ref !== '' ? $ref : NULL;
+  }
+
+  /**
+   * Returns the permanent /ref/ URL for the node, if refs are available.
+   */
+  protected function refUrl(NodeInterface $node): ?string {
+    $code = $this->refCode($node);
+    return $code === NULL ? NULL : $this->canonicalBaseUrl() . '/ref/' . $code;
+  }
+
+  /**
+   * Builds the shared identity properties for a node schema.
+   *
+   * @id is the permanent /ref/ URL (an opaque IRI - never fetched, so the
+   * 301 it serves is irrelevant); url stays the canonical alias that matches
+   * rel=canonical and the sitemap. Do not invert them.
+   *
+   * @return array
+   *   Keys: @id, url, mainEntityOfPage, and identifier when a ref exists.
+   */
+  protected function identityProperties(NodeInterface $node): array {
+    $url = $this->canonicalNodeUrl($node);
+    $properties = [
+      '@id' => $this->refUrl($node) ?? $url,
+      'url' => $url,
+      'mainEntityOfPage' => [
+        '@type' => 'WebPage',
+        '@id' => $url,
+      ],
+    ];
+    $code = $this->refCode($node);
+    if ($code !== NULL) {
+      $properties['identifier'] = [
+        '@type' => 'PropertyValue',
+        'propertyID' => 'SAHO',
+        'value' => $code,
+      ];
+    }
+    return $properties;
+  }
+
+  /**
+   * Returns the @id of the sitewide SAHO Organization entity.
+   */
+  protected function organizationId(): string {
+    return $this->canonicalBaseUrl() . '/#organization';
+  }
+
+  /**
+   * Returns an @id-linked stub for the SAHO organization.
+   *
+   * Keeps @type and name inline so literal-minded validators stay green
+   * while consumers dedupe on the shared @id.
+   *
+   * @param string $type
+   *   The schema.org type to present the stub as.
+   *
+   * @return array
+   *   The stub reference.
+   */
+  protected function organizationRef(string $type = 'Organization'): array {
+    return [
+      '@id' => $this->organizationId(),
+      '@type' => $type,
+      'name' => 'South African History Online',
+    ];
+  }
+
+  /**
+   * Returns the @id of the sitewide WebSite entity.
+   */
+  protected function websiteId(): string {
+    return $this->canonicalBaseUrl() . '/#website';
+  }
+
+}

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/UpcomingEventSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/UpcomingEventSchemaBuilder.php
@@ -3,11 +3,8 @@
 namespace Drupal\saho_tools\Service\Builder;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\Entity\File;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org Event structured data for Upcoming Event nodes.
@@ -15,20 +12,7 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * Maps SAHO upcoming events (exhibitions, conferences, museum openings)
  * to Schema.org Event vocabulary for optimal discovery by search engines.
  */
-class UpcomingEventSchemaBuilder implements SchemaOrgBuilderInterface {
-
-  /**
-   * Constructs an UpcomingEventSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+class UpcomingEventSchemaBuilder extends SchemaBuilderBase {
 
   /**
    * {@inheritdoc}
@@ -49,8 +33,7 @@ class UpcomingEventSchemaBuilder implements SchemaOrgBuilderInterface {
       '@context' => 'https://schema.org',
       '@type' => 'Event',
       'name' => $node->getTitle(),
-      'url' => $node->toUrl()->setAbsolute()->toString(),
-    ];
+    ] + $this->identityProperties($node);
 
     // Add start date.
     $start_date = NULL;
@@ -144,7 +127,7 @@ class UpcomingEventSchemaBuilder implements SchemaOrgBuilderInterface {
       'price' => '0',
       'priceCurrency' => 'ZAR',
       'availability' => 'https://schema.org/InStock',
-      'url' => $node->toUrl()->setAbsolute()->toString(),
+      'url' => $this->canonicalNodeUrl($node),
     ];
 
     // Add event status and attendance mode.
@@ -198,20 +181,13 @@ class UpcomingEventSchemaBuilder implements SchemaOrgBuilderInterface {
   }
 
   /**
-   * Get SAHO organization schema.
+   * Returns the @id-linked sitewide organization stub.
    *
    * @return array
-   *   Organization schema for organizer.
+   *   Organization stub for organizer/performer.
    */
   protected function getOrganizationSchema(): array {
-    $request = \Drupal::request();
-    $base_url = $request->getSchemeAndHttpHost();
-
-    return [
-      '@type' => 'Organization',
-      'name' => 'South African History Online',
-      'url' => $base_url,
-    ];
+    return $this->organizationRef();
   }
 
 }

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/WebSiteSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/WebSiteSchemaBuilder.php
@@ -2,10 +2,7 @@
 
 namespace Drupal\saho_tools\Service\Builder;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\node\NodeInterface;
-use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
 
 /**
  * Builds Schema.org WebSite structured data for SAHO site-wide.
@@ -15,29 +12,18 @@ use Drupal\saho_tools\Service\SchemaOrgBuilderInterface;
  * target points at the canonical Search API view (/search) and its exposed
  * fulltext filter parameter (search_api_fulltext).
  */
-class WebSiteSchemaBuilder implements SchemaOrgBuilderInterface {
+class WebSiteSchemaBuilder extends SchemaBuilderBase {
 
   /**
-   * The canonical production host for SAHO.
+   * The canonical production base URL for SAHO.
    *
-   * This matches the host advertised in robots.txt (Sitemap) and the
-   * canonical apex that www.sahistory.org.za redirects to. Using the apex
-   * here avoids the 301 redirect in the SearchAction target.
+   * The apex host: www.sahistory.org.za 301s to it (verified live), and it
+   * matches the Sitemap host advertised in robots.txt. Kept as a public
+   * const because LlmTxtController also reads it; the schema output itself
+   * goes through canonicalBaseUrl() so $settings['saho_canonical_url'] can
+   * override per environment.
    */
-  const CANONICAL_URL = 'https://www.sahistory.org.za/';
-
-  /**
-   * Constructs a WebSiteSchemaBuilder.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
-   *   The file URL generator service.
-   */
-  public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
-    protected FileUrlGeneratorInterface $fileUrlGenerator,
-  ) {}
+  const CANONICAL_URL = 'https://sahistory.org.za/';
 
   /**
    * {@inheritdoc}
@@ -51,17 +37,20 @@ class WebSiteSchemaBuilder implements SchemaOrgBuilderInterface {
    * {@inheritdoc}
    */
   public function build(?NodeInterface $node = NULL): array {
+    $base_url = $this->canonicalBaseUrl();
     return [
       '@context' => 'https://schema.org',
       '@type' => 'WebSite',
-      'url' => self::CANONICAL_URL,
+      '@id' => $this->websiteId(),
+      'url' => $base_url . '/',
       'name' => 'South African History Online',
       'alternateName' => 'SAHO',
+      'publisher' => $this->organizationRef(),
       'potentialAction' => [
         '@type' => 'SearchAction',
         'target' => [
           '@type' => 'EntryPoint',
-          'urlTemplate' => self::CANONICAL_URL . 'search?search_api_fulltext={search_term_string}',
+          'urlTemplate' => $base_url . '/search?search_api_fulltext={search_term_string}',
         ],
         'query-input' => 'required name=search_term_string',
       ],

--- a/webroot/modules/custom/saho_tools/src/Service/SchemaOrgService.php
+++ b/webroot/modules/custom/saho_tools/src/Service/SchemaOrgService.php
@@ -6,6 +6,7 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Site\Settings;
 use Drupal\node\NodeInterface;
 
 /**
@@ -140,13 +141,12 @@ class SchemaOrgService {
    *   Basic organization schema.
    */
   protected function buildBasicOrganizationSchema(): array {
-    $config = \Drupal::config('system.site');
-    $request = \Drupal::request();
-    $base_url = $request->getSchemeAndHttpHost();
+    $base_url = rtrim(Settings::get('saho_canonical_url', 'https://sahistory.org.za'), '/');
 
     return [
       '@context' => 'https://schema.org',
       '@type' => ['Organization', 'EducationalOrganization'],
+      '@id' => $base_url . '/#organization',
       'name' => 'South African History Online',
       'alternateName' => 'SAHO',
       'url' => $base_url,

--- a/webroot/modules/custom/saho_tools/tests/src/Kernel/ArchiveSchemaBuilderTest.php
+++ b/webroot/modules/custom/saho_tools/tests/src/Kernel/ArchiveSchemaBuilderTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_tools\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Archive schema: Catalyst provenance mapping and stable identity.
+ *
+ * @group saho_tools
+ */
+final class ArchiveSchemaBuilderTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'node',
+    'link',
+    'datetime',
+    'options',
+    'saho_refs',
+    'saho_tools',
+  ];
+
+  /**
+   * The builder under test.
+   *
+   * @var \Drupal\saho_tools\Service\Builder\ArchiveSchemaBuilder
+   */
+  protected $builder;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['field', 'filter', 'node']);
+    $this->setSetting('saho_canonical_url', 'https://schema.test');
+
+    NodeType::create(['type' => 'archive', 'name' => 'Archive'])->save();
+
+    $fields = [
+      ['field_original_creator', 'string', -1, []],
+      ['field_original_creator_role', 'list_string', -1,
+        [
+          'allowed_values' => [
+            'photographer' => 'Photographer',
+            'institution' => 'Institution',
+            'producer' => 'Producer',
+          ],
+        ],
+      ],
+      ['field_original_source_url', 'link', -1, []],
+      ['field_original_created_date', 'datetime', 1, ['datetime_type' => 'date']],
+      ['field_provenance_note', 'text_long', 1, []],
+      ['field_archive_publication_date', 'datetime', 1, ['datetime_type' => 'date']],
+      ['field_publication_date_archive', 'string', 1, []],
+      ['field_author', 'string', -1, []],
+      ['field_copyright', 'string', 1, []],
+    ];
+    foreach ($fields as [$name, $type, $cardinality, $settings]) {
+      FieldStorageConfig::create([
+        'field_name' => $name,
+        'entity_type' => 'node',
+        'type' => $type,
+        'cardinality' => $cardinality,
+        'settings' => $settings,
+      ])->save();
+      FieldConfig::create([
+        'field_name' => $name,
+        'entity_type' => 'node',
+        'bundle' => 'archive',
+      ])->save();
+    }
+
+    $this->builder = $this->container->get('saho_tools.schema_builder.archive');
+  }
+
+  /**
+   * Creates an archive node with the given field values.
+   */
+  protected function archiveNode(array $values): Node {
+    $node = Node::create(['type' => 'archive', 'title' => 'Test record'] + $values);
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * Creators pair with roles by delta; institutions become organizations.
+   */
+  public function testCreatorRolePairing(): void {
+    $node = $this->archiveNode([
+      'field_original_creator' => [['value' => 'Everett, Michael'], ['value' => 'LAPL']],
+      'field_original_creator_role' => [['value' => 'photographer'], ['value' => 'institution']],
+    ]);
+    $schema = $this->builder->build($node);
+
+    $this->assertSame([
+      [
+        '@type' => 'Role',
+        'roleName' => 'photographer',
+        'creator' => ['@type' => 'Person', 'name' => 'Everett, Michael'],
+      ],
+      [
+        '@type' => 'Role',
+        'roleName' => 'institution',
+        'creator' => ['@type' => 'Organization', 'name' => 'LAPL'],
+      ],
+    ], $schema['creator']);
+  }
+
+  /**
+   * Creators without roles are bare Persons; author is the next fallback.
+   */
+  public function testCreatorFallbackChain(): void {
+    $bare = $this->builder->build($this->archiveNode([
+      'field_original_creator' => [['value' => 'Horn, Pat']],
+    ]));
+    $this->assertSame(['@type' => 'Person', 'name' => 'Horn, Pat'], $bare['creator']);
+
+    $author = $this->builder->build($this->archiveNode([
+      'field_author' => [['value' => 'Dirk Kohnert']],
+    ]));
+    $this->assertSame(['@type' => 'Person', 'name' => 'Dirk Kohnert'], $author['creator']);
+
+    $none = $this->builder->build($this->archiveNode([]));
+    $this->assertSame('https://schema.test/#organization', $none['creator']['@id']);
+    $this->assertSame('South African History Online', $none['creator']['name']);
+  }
+
+  /**
+   * Provider pages become sameAs; persistent IDs become typed identifiers.
+   */
+  public function testSourceUrlSplit(): void {
+    $node = $this->archiveNode([
+      'field_original_source_url' => [
+        ['uri' => 'https://archive.org/details/item1', 'title' => 'Original record'],
+        ['uri' => 'https://doi.org/10.2307/2637233', 'title' => ''],
+      ],
+    ]);
+    $schema = $this->builder->build($node);
+
+    $this->assertSame('https://archive.org/details/item1', $schema['sameAs']);
+    $identifiers = $schema['identifier'];
+    $this->assertCount(2, $identifiers);
+    $this->assertSame('SAHO', $identifiers[0]['propertyID']);
+    $this->assertMatchesRegularExpression('/^R-\d{7}$/', $identifiers[0]['value']);
+    $this->assertSame('doi', $identifiers[1]['propertyID']);
+    $this->assertSame('https://doi.org/10.2307/2637233', $identifiers[1]['value']);
+  }
+
+  /**
+   * Publication date: structured slot wins, free text normalises, prose out.
+   */
+  public function testDatePublishedChain(): void {
+    $structured = $this->builder->build($this->archiveNode([
+      'field_archive_publication_date' => [['value' => '1976-06-16']],
+      'field_publication_date_archive' => [['value' => 'circa 1918']],
+    ]));
+    $this->assertSame('1976-06-16', $structured['datePublished']);
+
+    $partial = $this->builder->build($this->archiveNode([
+      'field_publication_date_archive' => [['value' => '1993-12-00']],
+    ]));
+    $this->assertSame('1993-12', $partial['datePublished']);
+
+    $prose = $this->builder->build($this->archiveNode([
+      'field_publication_date_archive' => [['value' => 'circa 1918']],
+    ]));
+    $this->assertArrayNotHasKey('datePublished', $prose);
+  }
+
+  /**
+   * The provenance note becomes creditText with markup and markers stripped.
+   */
+  public function testCreditText(): void {
+    $node = $this->archiveNode([
+      'field_original_created_date' => [['value' => '1976-06-16']],
+      'field_provenance_note' => [
+        [
+          'value' => '<p>Original material from DPLA.</p> [saho_import:dpla-2026] ',
+          'format' => 'plain_text',
+        ],
+      ],
+      'field_copyright' => [['value' => 'Rights reserved by LAPL']],
+    ]);
+    $schema = $this->builder->build($node);
+
+    $this->assertSame('Original material from DPLA.', $schema['creditText']);
+    $this->assertSame('Rights reserved by LAPL', $schema['copyrightNotice']);
+    $this->assertSame('1976-06-16', $schema['dateCreated']);
+  }
+
+  /**
+   * Identity: @id on the /ref/ URL, url on the canonical alias, org stubs.
+   */
+  public function testStableIdentity(): void {
+    $node = $this->archiveNode([]);
+    $schema = $this->builder->build($node);
+
+    $expected_ref = sprintf('https://schema.test/ref/R-%07d', $node->id());
+    $this->assertSame($expected_ref, $schema['@id']);
+    $this->assertStringStartsWith('https://schema.test/', $schema['url']);
+    $this->assertNotSame($schema['@id'], $schema['url']);
+    $this->assertSame('https://schema.test/#organization', $schema['publisher']['@id']);
+    $this->assertSame('ArchiveOrganization', $schema['holdingArchive']['@type']);
+    $this->assertSame('https://schema.test/#organization', $schema['holdingArchive']['@id']);
+    $this->assertStringNotContainsString('ddev.site', json_encode($schema));
+  }
+
+}

--- a/webroot/modules/custom/saho_tools/tests/src/Kernel/BiographySchemaBuilderTest.php
+++ b/webroot/modules/custom/saho_tools/tests/src/Kernel/BiographySchemaBuilderTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_tools\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+
+/**
+ * Biography schema: date fallback chain, topics and stable identity.
+ *
+ * @group saho_tools
+ */
+final class BiographySchemaBuilderTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'node',
+    'datetime',
+    'taxonomy',
+    'saho_refs',
+    'saho_tools',
+  ];
+
+  /**
+   * The builder under test.
+   *
+   * @var \Drupal\saho_tools\Service\Builder\BiographySchemaBuilder
+   */
+  protected $builder;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['field', 'filter', 'node']);
+    $this->setSetting('saho_canonical_url', 'https://schema.test');
+
+    NodeType::create(['type' => 'biography', 'name' => 'Biography'])->save();
+    Vocabulary::create(['vid' => 'people_category', 'name' => 'People category'])->save();
+
+    $fields = [
+      ['field_drupal_birth_date', 'datetime', ['datetime_type' => 'date'], []],
+      ['field_drupal_death_date', 'datetime', ['datetime_type' => 'date'], []],
+      ['field_dob', 'string', [], []],
+      ['field_dod', 'string', [], []],
+      ['field_people_category', 'entity_reference', ['target_type' => 'taxonomy_term'], []],
+    ];
+    foreach ($fields as [$name, $type, $storage_settings, $field_settings]) {
+      FieldStorageConfig::create([
+        'field_name' => $name,
+        'entity_type' => 'node',
+        'type' => $type,
+        'cardinality' => $type === 'entity_reference' ? -1 : 1,
+        'settings' => $storage_settings,
+      ])->save();
+      FieldConfig::create([
+        'field_name' => $name,
+        'entity_type' => 'node',
+        'bundle' => 'biography',
+        'settings' => $field_settings,
+      ])->save();
+    }
+
+    $this->builder = $this->container->get('saho_tools.schema_builder.biography');
+  }
+
+  /**
+   * Creates a biography node with the given field values.
+   */
+  protected function bio(array $values): Node {
+    $node = Node::create(['type' => 'biography', 'title' => 'Test Person'] + $values);
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * The structured datetime field wins over the legacy string field.
+   */
+  public function testStructuredDateWins(): void {
+    $schema = $this->builder->build($this->bio([
+      'field_drupal_birth_date' => [['value' => '1925-09-19']],
+      'field_dob' => [['value' => '1-January-1900']],
+    ]));
+    $this->assertSame('1925-09-19', $schema['mainEntity']['birthDate']);
+  }
+
+  /**
+   * Legacy field_dob/field_dod shapes normalise when no structured date.
+   */
+  public function testLegacyDateFallback(): void {
+    $schema = $this->builder->build($this->bio([
+      'field_dob' => [['value' => '19-September-1925']],
+      'field_dod' => [['value' => '1977']],
+    ]));
+    $this->assertSame('1925-09-19', $schema['mainEntity']['birthDate']);
+    $this->assertSame('1977', $schema['mainEntity']['deathDate']);
+  }
+
+  /**
+   * Prose dates are omitted, never emitted verbatim.
+   */
+  public function testProseDatesOmitted(): void {
+    $schema = $this->builder->build($this->bio([
+      'field_dob' => [['value' => 'circa 1918']],
+    ]));
+    $this->assertArrayNotHasKey('birthDate', $schema['mainEntity']);
+  }
+
+  /**
+   * People categories feed knowsAbout, deduplicated.
+   */
+  public function testPeopleCategoryTopics(): void {
+    $term_a = Term::create(['vid' => 'people_category', 'name' => 'Activist']);
+    $term_a->save();
+    $term_b = Term::create(['vid' => 'people_category', 'name' => 'Author']);
+    $term_b->save();
+    $schema = $this->builder->build($this->bio([
+      'field_people_category' => [
+        ['target_id' => $term_a->id()],
+        ['target_id' => $term_b->id()],
+        ['target_id' => $term_a->id()],
+      ],
+    ]));
+    $this->assertSame(['Activist', 'Author'], $schema['mainEntity']['knowsAbout']);
+  }
+
+  /**
+   * ProfilePage @id sits on the /ref/ URL; the Person gets its own anchor.
+   */
+  public function testStableIdentity(): void {
+    $node = $this->bio([]);
+    $schema = $this->builder->build($node);
+
+    $ref = sprintf('https://schema.test/ref/B-%07d', $node->id());
+    $this->assertSame('ProfilePage', $schema['@type']);
+    $this->assertSame($ref, $schema['@id']);
+    $this->assertSame($ref . '#person', $schema['mainEntity']['@id']);
+    $this->assertSame('SAHO', $schema['identifier']['propertyID']);
+    $this->assertStringNotContainsString('ddev.site', json_encode($schema));
+  }
+
+}

--- a/webroot/modules/custom/saho_tools/tests/src/Kernel/SchemaIdentityTest.php
+++ b/webroot/modules/custom/saho_tools/tests/src/Kernel/SchemaIdentityTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_tools\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Sitewide entities: one organization, @id-linked, on the canonical host.
+ *
+ * @group saho_tools
+ */
+final class SchemaIdentityTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'node',
+    'saho_tools',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->setSetting('saho_canonical_url', 'https://schema.test');
+  }
+
+  /**
+   * The organization entity carries the shared @id on the canonical host.
+   */
+  public function testOrganizationIdentity(): void {
+    $schema = $this->container->get('saho_tools.schema_builder.organization')->build();
+
+    $this->assertSame('https://schema.test/#organization', $schema['@id']);
+    $this->assertSame('https://schema.test', $schema['url']);
+    $this->assertStringStartsWith('https://schema.test/', $schema['logo']['url']);
+    $this->assertStringNotContainsString('ddev.site', json_encode($schema));
+  }
+
+  /**
+   * The website entity links its publisher to the organization @id.
+   */
+  public function testWebsiteIdentity(): void {
+    $schema = $this->container->get('saho_tools.schema_builder.website')->build();
+
+    $this->assertSame('https://schema.test/#website', $schema['@id']);
+    $this->assertSame('https://schema.test/', $schema['url']);
+    $this->assertSame('https://schema.test/#organization', $schema['publisher']['@id']);
+    $this->assertSame(
+      'https://schema.test/search?search_api_fulltext={search_term_string}',
+      $schema['potentialAction']['target']['urlTemplate']
+    );
+  }
+
+  /**
+   * Without the settings override, the default is the production apex host.
+   */
+  public function testDefaultCanonicalHost(): void {
+    $this->setSetting('saho_canonical_url', NULL);
+    $schema = $this->container->get('saho_tools.schema_builder.website')->build();
+    $this->assertSame('https://sahistory.org.za/', $schema['url']);
+  }
+
+}

--- a/webroot/modules/custom/saho_tools/tests/src/Unit/Schema/ProvenanceIdsTest.php
+++ b/webroot/modules/custom/saho_tools/tests/src/Unit/Schema/ProvenanceIdsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_tools\Unit\Schema;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\saho_tools\Schema\ProvenanceIds;
+
+/**
+ * Persistent-identifier detection for provenance source URLs.
+ *
+ * @group saho_tools
+ * @coversDefaultClass \Drupal\saho_tools\Schema\ProvenanceIds
+ */
+final class ProvenanceIdsTest extends UnitTestCase {
+
+  /**
+   * @covers ::isPersistent
+   * @covers ::propertyId
+   * @dataProvider provideUrls
+   */
+  public function testDetection(string $uri, string $title, bool $persistent, ?string $scheme): void {
+    $this->assertSame($persistent, ProvenanceIds::isPersistent($uri, $title));
+    $this->assertSame($scheme, ProvenanceIds::propertyId($uri));
+  }
+
+  /**
+   * URL shapes from the Catalyst provenance imports.
+   */
+  public static function provideUrls(): array {
+    return [
+      'n2t ark' => ['https://n2t.net/ark:/13030/hb0f59n7bx', '', TRUE, 'ark'],
+      'cdlib ark' => ['https://ark.cdlib.org/ark:/13030/tf0z09n5jk', '', TRUE, 'ark'],
+      'doi' => ['https://doi.org/10.2307/2637233', '', TRUE, 'doi'],
+      'dx doi' => ['https://dx.doi.org/10.2307/2637233', '', TRUE, 'doi'],
+      'handle' => ['https://hdl.handle.net/10855/12345', '', TRUE, 'handle'],
+      'purl' => ['https://purl.org/dc/terms/', '', TRUE, 'purl'],
+      'www prefix stripped' => ['https://www.doi.org/10.1000/x', '', TRUE, 'doi'],
+      'uppercase host' => ['https://N2T.net/ark:/99999/x', '', TRUE, 'ark'],
+      'ark in provider path stays provider' => [
+        'https://calisphere.org/item/ark:/13030/hb0f59n7bx/',
+        '',
+        FALSE,
+        NULL,
+      ],
+      'ordinary provider page' => ['https://archive.org/details/something', '', FALSE, NULL],
+      'title hint forces persistent' => [
+        'https://tessa.lapl.org/some/item',
+        'Persistent link',
+        TRUE,
+        NULL,
+      ],
+      'title hint case-insensitive' => ['https://example.org/x', 'PERSISTENT URL', TRUE, NULL],
+      'no host' => ['not-a-url', '', FALSE, NULL],
+    ];
+  }
+
+}

--- a/webroot/modules/custom/saho_tools/tests/src/Unit/Schema/SchemaDatesTest.php
+++ b/webroot/modules/custom/saho_tools/tests/src/Unit/Schema/SchemaDatesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_tools\Unit\Schema;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\saho_tools\Schema\SchemaDates;
+
+/**
+ * Normalisation of SAHO's legacy date shapes into schema-safe ISO dates.
+ *
+ * @group saho_tools
+ * @coversDefaultClass \Drupal\saho_tools\Schema\SchemaDates
+ */
+final class SchemaDatesTest extends UnitTestCase {
+
+  /**
+   * @covers ::normalize
+   * @dataProvider provideDates
+   */
+  public function testNormalize(string $input, ?string $expected): void {
+    $this->assertSame($expected, SchemaDates::normalize($input));
+  }
+
+  /**
+   * Date shapes seen in field_dob/field_dod/field_publication_date_archive.
+   */
+  public static function provideDates(): array {
+    return [
+      'full iso' => ['1925-09-19', '1925-09-19'],
+      'iso with T time' => ['2001-05-04T00:00:00', '2001-05-04'],
+      'iso with space time' => ['2001-05-04 10:30:00', '2001-05-04'],
+      'zeroed day partial' => ['1993-12-00', '1993-12'],
+      'zeroed month and day' => ['1993-00-00', '1993'],
+      'year month partial' => ['1993-12', '1993-12'],
+      'legacy day-monthname-year' => ['19-September-1925', '1925-09-19'],
+      'legacy with spaces' => ['9 September 1925', '1925-09-09'],
+      'bare year' => ['1918', '1918'],
+      'junk zero date' => ['0000-00-00', NULL],
+      'junk zero year' => ['0000', NULL],
+      'prose circa' => ['circa 1918', NULL],
+      'prose decade' => ['early 1960s', NULL],
+      'invalid calendar date' => ['2001-02-30', NULL],
+      'invalid month' => ['2001-13-01', NULL],
+      'unknown month name' => ['19-Septembre-1925', NULL],
+      'empty' => ['', NULL],
+      'whitespace' => ['   ', NULL],
+      'far future year' => ['2150', NULL],
+    ];
+  }
+
+}

--- a/webroot/themes/custom/saho/saho.theme
+++ b/webroot/themes/custom/saho/saho.theme
@@ -15,6 +15,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Site\Settings;
+use Drupal\saho_tools\Schema\ProvenanceIds;
 use Drupal\Core\Url;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\file\Entity\File;
@@ -63,41 +64,10 @@ function saho_page_attachments_alter(array &$page) {
     ];
   }
 
-  // Add Organization Schema.org JSON-LD for site-wide recognition.
-  // Only for anonymous users (not admin/editors).
-  if (!\Drupal::currentUser()->isAuthenticated()) {
-    $organization_schema = [
-      '@context' => 'https://schema.org',
-      '@type' => 'EducationalOrganization',
-      'name' => 'South African History Online',
-      'alternateName' => 'SAHO',
-      'url' => 'https://sahistory.org.za',
-      'logo' => 'https://sahistory.org.za/themes/custom/saho/logo.svg',
-      'description' => 'Towards a People\'s History of South Africa',
-      'foundingDate' => '2000',
-      'sameAs' => [
-        'https://www.facebook.com/sahistoryonline',
-        'https://twitter.com/sahistoryonline',
-      ],
-      'contactPoint' => [
-        '@type' => 'ContactPoint',
-        'contactType' => 'General Inquiries',
-        'url' => 'https://sahistory.org.za/contact',
-      ],
-    ];
-
-    $page['#attached']['html_head'][] = [
-      [
-        '#type' => 'html_tag',
-        '#tag' => 'script',
-        '#attributes' => [
-          'type' => 'application/ld+json',
-        ],
-        '#value' => json_encode($organization_schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT),
-      ],
-      'saho_organization_schema',
-    ];
-  }
+  // Organization JSON-LD deliberately NOT emitted here: saho_tools already
+  // injects the single sitewide [Organization, EducationalOrganization]
+  // entity (with its stable @id) on every page. A second theme-side copy
+  // used to ship conflicting host/logo values to anonymous visitors.
 
   // Preload the LCP image for the current node. Lives in this _alter hook
   // because hook_page_attachments() is not invoked for themes.
@@ -2608,10 +2578,9 @@ function saho_preprocess_node__archive(array &$variables): void {
       }
       $link_title = trim((string) ($link_item['title'] ?? ''));
       // Persistent-ID detection is by HOST - provider pages (Calisphere)
-      // legitimately embed ark:/ in their item paths.
-      $link_host = strtolower((string) (parse_url($link_uri, PHP_URL_HOST) ?: ''));
-      $is_persistent = stripos($link_title, 'persistent') !== FALSE
-        || in_array($link_host, ['ark.cdlib.org', 'n2t.net', 'doi.org', 'dx.doi.org', 'hdl.handle.net', 'purl.org'], TRUE);
+      // legitimately embed ark:/ in their item paths. Shared with the
+      // schema.org identifier mapping so the two never drift.
+      $is_persistent = ProvenanceIds::isPersistent($link_uri, $link_title);
       if ($delta === 0 && !$is_persistent) {
         $link_label = $link_title;
         if ($link_label === '' || $link_label === 'Original record') {


### PR DESCRIPTION
Post-redesign schema.org modernization pass. The audit confirmed the Open Record redesign did NOT break JSON-LD emission (route-based injection fires on every record page) but found the layer dated. This PR brings it current and integrates the #494 Catalyst provenance fields.

## Archive attribution (#494 fields -> schema)
| Field | Property |
|---|---|
| field_original_creator + field_original_creator_role | `creator` with schema.org Role wrappers; institution/publisher roles typed Organization |
| field_original_created_date | `dateCreated` |
| field_original_source_url (provider pages) | `sameAs` |
| field_original_source_url (ARK/DOI/Handle/PURL, host-detected) | typed `identifier` PropertyValues |
| field_provenance_note | `creditText` (import markers stripped) |
| field_copyright | `copyrightNotice` |
| field_media_library_type | `genre` (14k records) |
| field_archive_publication_date -> normalized field_publication_date_archive | `datePublished` - the 21k free-text legacy dates now normalise (`1993-12-00` -> `1993-12`) or are omitted; prose like 'circa 1918' is no longer emitted into a Date property |

Verified on a real DPLA import: ARK on n2t.net -> `identifier` propertyID `ark`, provider page -> `sameAs`, creator Person, DPLA credit text, real publisher inline.

## Identity graph
- Every node schema: `@id` = permanent `/ref/` URL (R-0123456 etc. via saho_refs) + SAHO-ref PropertyValue identifier; `url` stays the canonical alias (matches rel=canonical/sitemap - never inverted).
- Organization `#organization` and WebSite `#website` carry shared @ids; all SAHO self-references (publisher/provider/holdingArchive/creator fallbacks) collapse to @id-linked stubs that keep inline @type+name for validators.
- **One org entity per page** - removed the theme's duplicate anon-only EducationalOrganization emitter that shipped conflicting host/logo values.
- **Canonical host = apex** `https://sahistory.org.za` everywhere (www 301s to it - the old WebSite const had it backwards), overridable per environment via `$settings['saho_canonical_url']`; llm.txt uses the same knob. No more mixed hosts inside one page's structured data. (Image/file contentUrls stay request-relative by design.)

## Also
- Biography dates: structured datetime pair first, then the far better-populated legacy `field_dob`/`field_dod` (2,197/2,575 rows vs 933/859) through a schema-safe normaliser - thousands of biographies gain birthDate/deathDate. `field_people_category` (11k records) now feeds `knowsAbout`.
- Shared `ProvenanceIds` helper replaces the theme's inline persistent-host list (single source of truth with the Record details panel).
- Page-cache correctness: injected head tags bubble `url.path` context + node + system.site tags (stale-JSON-LD-after-edit fix).
- Product schema only claims `Book` with an ISBN, else `Product`.
- **First test coverage for the schema layer**: 46 tests / 216 assertions (unit: date normaliser + persistent-ID detection; kernel: archive provenance mapping, biography date chain, sitewide identity incl. no-host-leakage).

## Verified
phpcs + drupal-check clean (zero new issues), all 46 new tests green, full custom-module suite unaffected. Live sweep on 6 page types: exactly one Organization entity per page (was two), all identity URLs on the apex host, /ref/ @ids present, biography birthDate/deathDate now emitted, archive Record details panel renders identically after the helper swap, watchdog clean.

Post-merge note: run one prod URL per type through Google's Rich Results Test and watch the GSC enhancement reports - this is the schema side of the CTR lever (297M impressions at ~1% CTR).