### PR TITLE
fix(search): config sync carries prod topology - saho_content on saho_prod, local_solr disabled

### DIFF
--- a/config/sync/search_api.index.saho_content.yml
+++ b/config/sync/search_api.index.saho_content.yml
@@ -25,7 +25,7 @@ dependencies:
     - field.storage.node.field_synopsis
     - field.storage.node.field_tags
     - field.storage.node.field_venue
-    - search_api.server.local_solr
+    - search_api.server.saho_prod
   module:
     - node
     - search_api_solr
@@ -420,4 +420,4 @@ options:
   delete_on_fail: true
   index_directly: true
   track_changes_in_references: true
-server: local_solr
+server: saho_prod

--- a/config/sync/search_api.server.local_solr.yml
+++ b/config/sync/search_api.server.local_solr.yml
@@ -1,6 +1,6 @@
 uuid: 1f788652-119d-4969-a526-7233a2258788
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - search_api_solr.solr_cache.cache_document_default_9_0_0

--- a/config/sync/search_api.server.saho_prod.yml
+++ b/config/sync/search_api.server.saho_prod.yml
@@ -1,6 +1,6 @@
 uuid: 79d04ca4-4df4-4974-85de-a1a8a65e8590
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - search_api_solr.solr_cache.cache_document_default_7_0_0


### PR DESCRIPTION
Root cause of the post-deploy search breakage Mads caught on production during the v2.0.0 go-live.

**What happened:** the Open Record branch exported Search API config from DDEV, so the sync directory carried `search_api.index.saho_content: server: local_solr` (host `solr` - the DDEV container), `local_solr: status: true`, `saho_prod: status: false`. v2.0.0 was the first prod config import to include those keys: it re-pointed the index at a non-existent server and disabled saho_prod. The prod settings.php overrides cover the saho_prod connector and statuses but not the index's stored `server` assignment. Manually re-attaching the index (done on prod) fixed the live site - but every future deploy would have repeated the clobber.

**Fix:** sync now carries the production topology (index -> saho_prod + matching config dependency, saho_prod enabled, local_solr disabled). This is what the local environment was designed for all along: `settings.ddev.php` already overrides server/connector/status back to local_solr for DDEV, exactly mirroring prod's settings.php overrides in the other direction.

Verified: this was the ONLY local-environment leakage in config/sync (repo-wide grep for ddev hosts / `host: solr`).

**Must merge before the next production deploy.**