### PR TITLE
feat(citation): Cite this entry parity with the Cite modal - 5 styles + reference-manager exports

### DIFF
--- a/webroot/modules/custom/saho_tools/js/citation.js
+++ b/webroot/modules/custom/saho_tools/js/citation.js
@@ -815,11 +815,13 @@
                         break;
 
                     case 'mla':
-                        citationText = self.generateMLACitation() || 'MLA citation coming soon';
+                        // Server-built (CitationService) with the permanent
+                        // /ref/ URL; the JS builder is only a fallback.
+                        citationText = self.citationData.mla || self.generateMLACitation() || 'MLA citation not available';
                         break;
 
                     case 'chicago':
-                        citationText = self.generateChicagoCitation() || 'Chicago citation coming soon';
+                        citationText = self.citationData.chicago || self.generateChicagoCitation() || 'Chicago citation not available';
                         break;
 
                     default:

--- a/webroot/modules/custom/saho_tools/src/Service/CitationService.php
+++ b/webroot/modules/custom/saho_tools/src/Service/CitationService.php
@@ -94,6 +94,8 @@ class CitationService {
       'harvard' => $this->generateHarvardCitation($data),
       'apa' => $this->generateApaCitation($data),
       'oxford' => $this->generateOxfordCitation($data),
+      'mla' => $this->generateMlaCitation($data),
+      'chicago' => $this->generateChicagoCitation($data),
       'bibtex' => $this->generateBibtexCitation($data),
       'ris' => $this->generateRisCitation($data),
     ];
@@ -416,6 +418,72 @@ class CitationService {
       );
 
     return $citation;
+  }
+
+  /**
+   * Generates an MLA 9th edition citation.
+   *
+   * @param array $data
+   *   The node data for citation generation.
+   *
+   * @return string
+   *   The MLA style citation.
+   */
+  protected function generateMlaCitation(array $data) {
+    // MLA month abbreviations (May, June and July stay unabbreviated).
+    $mla_months = [
+      'January' => 'Jan.', 'February' => 'Feb.', 'March' => 'Mar.',
+      'April' => 'Apr.', 'May' => 'May', 'June' => 'June', 'July' => 'July',
+      'August' => 'Aug.', 'September' => 'Sept.', 'October' => 'Oct.',
+      'November' => 'Nov.', 'December' => 'Dec.',
+    ];
+
+    $created_date = new DrupalDateTime($data['created_formatted']);
+    $created = $created_date->format('j') . ' '
+      . ($mla_months[$created_date->format('F')] ?? $created_date->format('F')) . ' '
+      . $created_date->format('Y');
+
+    $access_date = new DrupalDateTime($data['accessed_date']);
+    $accessed = $access_date->format('j') . ' '
+      . ($mla_months[$access_date->format('F')] ?? $access_date->format('F')) . ' '
+      . $access_date->format('Y');
+
+    // MLA 9 web page with a corporate author identical to the container:
+    // start with the title, italicise the container, day-month-year dates.
+    return sprintf(
+      '"%s." <em>%s</em>, %s, %s. Accessed %s.',
+      Html::escape($data['title']),
+      $data['site_name'],
+      $created,
+      $data['url'],
+      $accessed
+    );
+  }
+
+  /**
+   * Generates a Chicago (17th edition, bibliography) citation.
+   *
+   * @param array $data
+   *   The node data for citation generation.
+   *
+   * @return string
+   *   The Chicago style citation.
+   */
+  protected function generateChicagoCitation(array $data) {
+    $created_date = new DrupalDateTime($data['created_formatted']);
+    $created = $created_date->format('F j, Y');
+
+    // Chicago website citation with a corporate author: Author. "Title."
+    // Site name. Month Day, Year. URL. (Access dates only appear when no
+    // publication date exists, and every record carries one.)
+    return sprintf(
+      '%s. "%s." %s. %s. %s.',
+      $data['site_name'],
+      Html::escape($data['title']),
+      $data['site_name'],
+      $created,
+      $data['url']
+    );
   }
 
   /**

--- a/webroot/themes/custom/saho/components/utilities/saho-citation/saho-citation.component.yml
+++ b/webroot/themes/custom/saho/components/utilities/saho-citation/saho-citation.component.yml
@@ -4,7 +4,7 @@ name: Citation
 machine_name: saho_citation
 status: stable
 group: 'SAHO Provenance'
-description: '"Cite this entry." Selectable citation formats rendered in mono, copyable. Makes attribution a first-class action on every record. The site''s CitationService produces Harvard/APA/Oxford, hence no format enum.'
+description: '"Cite this entry." Selectable citation formats rendered in mono, copyable, with reference-manager exports as no-JS data: downloads. Mirrors the Cite modal: APA 7th / Harvard / Oxford / MLA 9th / Chicago from CitationService, hence no format enum.'
 props:
   type: object
   properties:
@@ -16,6 +16,17 @@ props:
       type: object
       title: 'Format → citation string'
       description: 'Keyed by format name. If omitted, editors supply chicago/apa/mla individually.'
+    exports:
+      type: object
+      title: 'Reference-manager payloads'
+      description: 'bibtex and/or ris plain-text payloads, rendered as data: URI downloads (EndNote shares the RIS payload).'
+    export_name:
+      type: string
+      title: 'Download filename stem'
+      description: 'Usually the record ref, e.g. R-0123151.'
+    learn_more:
+      type: string
+      title: 'Citation-help link'
     chicago:
       type: string
     apa:

--- a/webroot/themes/custom/saho/components/utilities/saho-citation/saho-citation.css
+++ b/webroot/themes/custom/saho/components/utilities/saho-citation/saho-citation.css
@@ -75,3 +75,55 @@
   text-decoration: underline;
   text-underline-offset: 0.14em;
 }
+
+/* Export row: reference-manager downloads + the citation-help link, one
+   quiet mono line under a hairline rule (mirrors the Cite modal's export
+   group). */
+.saho-cite__foot {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2, 0.5rem) var(--space-3, 0.75rem);
+  margin-top: var(--space-2, 0.5rem);
+  padding-top: var(--space-2, 0.5rem);
+  border-top: var(--bw-hair, 1px) solid var(--border-default, rgb(26 26 24 / 20%));
+}
+
+.saho-cite__foot-label {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted, #5d5e52);
+}
+
+.saho-cite__export {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--saho-ink, #1b1c17);
+  text-decoration: none;
+  border: var(--bw-hair, 1px) solid var(--border-default, rgb(26 26 24 / 20%));
+  border-radius: 0;
+  padding: 0.25rem 0.6rem;
+}
+
+.saho-cite__export:hover,
+.saho-cite__export:focus {
+  color: var(--saho-oxblood, #990000);
+  border-color: var(--saho-oxblood, #990000);
+}
+
+.saho-cite__learn {
+  margin-left: auto;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--saho-oxblood, #990000);
+  text-decoration: none;
+}
+
+.saho-cite__learn:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.14em;
+}

--- a/webroot/themes/custom/saho/components/utilities/saho-citation/saho-citation.twig
+++ b/webroot/themes/custom/saho/components/utilities/saho-citation/saho-citation.twig
@@ -23,4 +23,24 @@
     {% endfor %}
     <button type="button" class="saho-cite__copy" data-saho-copy>Copy</button>
   </div>
+  {# Reference-manager exports as data: downloads - no JS involved. EndNote
+     imports RIS, so it shares the payload (same as the Cite modal). #}
+  {% if exports %}
+    <footer class="saho-cite__foot">
+      <span class="saho-cite__foot-label">{{ 'Export'|t }}</span>
+      {% if exports.bibtex %}
+        <a class="saho-cite__export" download="{{ export_name|default('saho-citation') }}.bib"
+           href="data:application/x-bibtex;charset=utf-8,{{ exports.bibtex|url_encode }}">BibTeX (.bib)</a>
+      {% endif %}
+      {% if exports.ris %}
+        <a class="saho-cite__export" download="{{ export_name|default('saho-citation') }}.ris"
+           href="data:application/x-research-info-systems;charset=utf-8,{{ exports.ris|url_encode }}">RIS (.ris)</a>
+        <a class="saho-cite__export" download="{{ export_name|default('saho-citation') }}.ris"
+           href="data:application/x-research-info-systems;charset=utf-8,{{ exports.ris|url_encode }}">EndNote</a>
+      {% endif %}
+      {% if learn_more %}
+        <a class="saho-cite__learn" href="{{ learn_more }}">{{ 'About citation formats'|t }} &rarr;</a>
+      {% endif %}
+    </footer>
+  {% endif %}
 </section>

--- a/webroot/themes/custom/saho/saho.theme
+++ b/webroot/themes/custom/saho/saho.theme
@@ -3597,13 +3597,46 @@ function _saho_record_citation_props(NodeInterface $node): array {
   }
   $cites = \Drupal::service('saho_tools.citation_service')->generateCitations($node);
   $formats = [];
-  foreach (['harvard' => 'Harvard', 'apa' => 'APA', 'oxford' => 'Oxford'] as $key => $label) {
+  // Same five styles, same order and same default as the Cite modal
+  // (saho_tools citation.js) - one citation register, two surfaces.
+  $labels = [
+    'apa' => 'APA 7th',
+    'harvard' => 'Harvard',
+    'oxford' => 'Oxford',
+    'mla' => 'MLA 9th',
+    'chicago' => 'Chicago',
+  ];
+  foreach ($labels as $key => $label) {
     $text = trim(html_entity_decode(strip_tags((string) ($cites[$key] ?? '')), ENT_QUOTES | ENT_HTML5));
     if ($text !== '') {
       $formats[$label] = $text;
     }
   }
-  return $formats !== [] ? ['default_format' => 'Harvard', 'formats' => $formats] : [];
+  if ($formats === []) {
+    return [];
+  }
+
+  // Reference-manager exports ride as plain payloads: the component turns
+  // them into data: downloads, so exporting works without JavaScript.
+  $props = ['default_format' => 'APA 7th', 'formats' => $formats];
+  $bibtex = trim((string) ($cites['bibtex'] ?? ''));
+  $ris = trim((string) ($cites['ris'] ?? ''));
+  if ($bibtex !== '' || $ris !== '') {
+    $name = 'saho-citation';
+    if (\Drupal::hasService('saho_refs.display_ref')) {
+      $ref = \Drupal::service('saho_refs.display_ref')->getRef($node);
+      if ($ref) {
+        $name = $ref;
+      }
+    }
+    $props['exports'] = array_filter([
+      'bibtex' => $bibtex,
+      'ris' => $ris,
+    ]);
+    $props['export_name'] = $name;
+  }
+  $props['learn_more'] = '/content/referencing-resources-historical-research';
+  return $props;
 }
 
 /**


### PR DESCRIPTION
## What

The inline **Cite this entry** block was legacy: three styles (Harvard/APA/Oxford) and a copy button, while the **Cite** modal offered five styles plus exports. They are now one citation system served from `CitationService`:

| | Before | After |
|---|---|---|
| Inline styles | Harvard, APA, Oxford | **APA 7th, Harvard, Oxford, MLA 9th, Chicago** (same order + default as the modal) |
| Inline exports | none | **BibTeX (.bib), RIS (.ris), EndNote** - `data:` URI downloads named after the record ref (`R-0123151.bib`), functional without JavaScript |
| Help link | none | About citation formats → (same target as the modal) |
| Modal MLA/Chicago | client-side placeholders built from `window.location` with "coming soon" fallbacks | real citations from the service, on the permanent `/ref/` URL |

## Implementation

- `CitationService`: proper **MLA 9th** (title-first for corporate author = container, MLA month abbreviations, accessed date) and **Chicago 17th bibliography** generators; both included in `generateCitations()` so the `/api/citation/{node}` endpoint feeds the modal automatically
- `citation.js`: MLA/Chicago cases prefer the served strings (JS builder kept only as fallback)
- `saho-citation` SDC: five tabs, export footer in the Open Record register (mono, hairline, oxblood hover), component schema updated
- Prop builder (`_saho_record_citation_props`): five labelled formats, export payloads, ref-named downloads, help link

## Verified

- `/api/citation/123151` returns all seven formats with correct structure
- Inline block on the record from the report: five tabs switch (keyboard arrows included), copy works, three export downloads with `data:` hrefs and ref filenames, help link present
- phpcs (CI flags) clean on the module; biome clean; existing saho.theme phpcs findings are pre-existing debt outside the touched function

Per request: **PR only - not tagged, not released.**