### PR TITLE
fix(footer): one open-data link - llm.txt as the single discovery document

### DIFF
--- a/webroot/themes/custom/saho/components/page-footer/page-footer.twig
+++ b/webroot/themes/custom/saho/components/page-footer/page-footer.twig
@@ -97,9 +97,11 @@
     <span class="saho-footer__legal-item">
       Accessibility: WCAG 2.2 AA
     </span>
-    {# Built for the open web (R3 #476): the machine-readable record. #}
+    {# Built for the open web (R3 #476): the machine-readable record. One
+       link - /llm.txt is the single discovery document; the topics it
+       covers are plain text (three identical-target links read as a bug). #}
     <span class="saho-footer__legal-item saho-footer__open-data">
-      Open data &middot; <a href="/llm.txt">llm.txt</a> &middot; <a href="/llm.txt">Citations API</a> &middot; <a href="/llm.txt">Schema.org</a>
+      Open data &middot; <a href="/llm.txt">llm.txt</a> (Schema.org &middot; Citations API &middot; Timelines)
     </span>
   </div>
 </footer>


### PR DESCRIPTION
Follow-up to Mads's observation that the footer's three open-data links (llm.txt / Citations API / Schema.org) all lead to the same file. That was deliberate - /llm.txt is the discovery document for all machine-access routes, and the bare API endpoints need a node argument so they have no stable linkable page - but three identical-target links read as a mistake.

Now: `Open data · llm.txt (Schema.org · Citations API · Timelines)` - one link, the topics it documents as plain text. Verified rendering locally.

Related follow-up (not this PR): Lighthouse's new agentic-browsing audit wants /llms.txt in the llmstxt.org markdown format - worth a look when we next touch LlmTxtController.

For the v2.0.1 train alongside #511.