### PR TITLE
fix(tdih): "View more events from this day" label + option to remove the link

### DIFF
--- a/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
@@ -113,6 +113,7 @@ class TdihInteractiveBlock extends BlockBase implements ContainerFactoryPluginIn
       'show_today_history' => TRUE,
       'show_details_button' => TRUE,
       'show_header_title' => TRUE,
+      'show_more_link' => TRUE,
       'use_todays_date' => FALSE,
     ] + parent::defaultConfiguration();
   }
@@ -178,6 +179,13 @@ class TdihInteractiveBlock extends BlockBase implements ContainerFactoryPluginIn
       '#default_value' => $this->configuration['show_details_button'],
     ];
 
+    $form['show_more_link'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show "View more events from this day" link'),
+      '#description' => $this->t('Enable to show the link to the This Day in History page under the events.'),
+      '#default_value' => $this->configuration['show_more_link'],
+    ];
+
     $form['use_todays_date'] = [
       '#type' => 'checkbox',
       '#title' => $this->t("Pre-fill date picker with today's date"),
@@ -199,6 +207,7 @@ class TdihInteractiveBlock extends BlockBase implements ContainerFactoryPluginIn
     $this->configuration['date_picker_mode'] = $form_state->getValue('date_picker_mode');
     $this->configuration['show_today_history'] = $form_state->getValue('show_today_history');
     $this->configuration['show_details_button'] = $form_state->getValue('show_details_button');
+    $this->configuration['show_more_link'] = $form_state->getValue('show_more_link');
     $this->configuration['use_todays_date'] = $form_state->getValue('use_todays_date');
   }
 
@@ -471,6 +480,7 @@ class TdihInteractiveBlock extends BlockBase implements ContainerFactoryPluginIn
       '#show_header_title' => $this->configuration['show_header_title'],
       '#show_today_history' => $show_events,
       '#show_details_button' => $this->configuration['show_details_button'],
+      '#show_more_link' => $this->configuration['show_more_link'] ?? TRUE,
       '#use_todays_date' => $this->configuration['use_todays_date'],
       '#attached' => [
         'library' => [

--- a/webroot/modules/custom/saho_utils/tdih/tdih.module
+++ b/webroot/modules/custom/saho_utils/tdih/tdih.module
@@ -26,6 +26,7 @@ function tdih_theme($existing, $type, $theme, $path) {
         'show_header_title' => TRUE,
         'show_today_history' => TRUE,
         'show_details_button' => TRUE,
+        'show_more_link' => TRUE,
         'use_todays_date' => FALSE,
       ],
       'template' => 'block--tdih-interactive',

--- a/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
+++ b/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
@@ -69,7 +69,10 @@
         <p class="tdih-no-events">{{ 'No events found for today.'|t }}</p>
       {% endif %}
 
-      <a href="/this-day-in-history" class="tdih-timeline-link">{{ 'Open the full timeline'|t }} <span aria-hidden="true">&rarr;</span></a>
+      {# Editors can drop the link per block instance (show_more_link). #}
+      {% if show_more_link %}
+        <a href="/this-day-in-history" class="tdih-timeline-link">{{ 'View more events from this day'|t }} <span aria-hidden="true">&rarr;</span></a>
+      {% endif %}
     </div>
 
     {# The birthday picker expands in place at the panel foot (R3 #478):


### PR DESCRIPTION
## What

Two changes to the interactive This Day in History block's footer link:

1. **Honest label**: "Open the full timeline →" promised the /timeline app but the link lands on /this-day-in-history. It now reads **"View more events from this day →"** - which is what that page shows.
2. **Removable per instance**: new block setting *Show "View more events from this day" link* (checkbox, in the block's configure form). Defaults to on with a `?? TRUE` fallback, so every existing placement keeps its link until an editor opts out - no update hook needed.

## Verified

- Front-page block renders the new label (Playwright)
- Direct block render with `show_more_link => FALSE` drops the anchor entirely; `TRUE` keeps it
- phpcs (CI flags) clean on the tdih module

No config export involved - the setting rides in each block instance's own configuration.