### PR TITLE
fix(classroom): language claim without the 11-language enumeration

### DIFF
--- a/webroot/themes/custom/saho/templates/views/views-view--classroom.html.twig
+++ b/webroot/themes/custom/saho/templates/views/views-view--classroom.html.twig
@@ -23,10 +23,11 @@
   <header class="saho-classroom-hub__head">
     <h1 class="saho-classroom-hub__title">Classroom</h1>
     <p class="saho-classroom-hub__intro">Grade-aligned doors into the record: CAPS-aligned overviews, sources and lesson material for South African history classrooms.</p>
-    {# The multilingual claim, stated as fact in the system voice (R3 #479). #}
+    {# The multilingual claim, stated as fact in the system voice (R3 #479).
+       The full enumeration read as clutter - the count carries the claim,
+       and each deck's own language bar lists the actual translations. #}
     <p class="saho-classroom-hub__languages">
-      {{ 'Available in 11 South African languages'|t }} &middot;
-      <span lang="af">Afrikaans</span> &middot; English &middot; <span lang="nr">isiNdebele</span> &middot; <span lang="xh">isiXhosa</span> &middot; <span lang="zu">isiZulu</span> &middot; <span lang="nso">Sepedi</span> &middot; <span lang="st">Sesotho</span> &middot; <span lang="tn">Setswana</span> &middot; <span lang="ss">siSwati</span> &middot; <span lang="ve">Tshivenda</span> &middot; <span lang="ts">Xitsonga</span>
+      {{ 'Available in 11 South African languages'|t }}
     </p>
     <p class="saho-classroom-hub__count">{{ result_total }} resources</p>
   </header>


### PR DESCRIPTION
Per Mads: the classroom hub header listed every one of the 11 languages after the claim - clutter. Now just 'Available in 11 South African languages'; each deck's own language bar still lists its real translations. Only one template enumerated (verified repo-wide); llm.txt's factual line already states it once. For the v2.0.1 train.