### PR TITLE
fix(tdih): aside header reads 'This day in history'

### DIFF
--- a/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
+++ b/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
@@ -3,7 +3,7 @@
  * @file
  * Template for the TDIH Interactive Block (Open Record 2027).
  *
- * A bordered catalogue aside: a mono header strip "This day - {date}",
+ * A bordered catalogue aside: a mono header strip "This day in history - {date}",
  * ledger entries (square type marker + mono year + display title) separated
  * by hairlines, and a bottom timeline link. Square corners, hairline borders,
  * no shadows or gradients - styled by css/tdih-interactive.css with the
@@ -25,7 +25,7 @@
 <div class="tdih-interactive-block" role="region" aria-labelledby="tdih-heading">
   {% if show_header_title %}
     <h2 id="tdih-heading" class="tdih-block-strip">
-      {{ 'This day'|t }} &middot; {{ "now"|date('j F') }}
+      {{ 'This day in history'|t }} &middot; {{ "now"|date('j F') }}
     </h2>
   {% else %}
     <h2 id="tdih-heading" class="visually-hidden">{{ 'This day in history'|t }}</h2>


### PR DESCRIPTION
Per Mads: the interactive TDIH aside's mono header strip now reads 'This day in history · {date}' instead of 'This day · {date}'. Template string only - block config text stays editable in the UI as before. For the v2.0.1 train.