### PR TITLE
fix(deploy): serialize staging deploys + production-only enrichment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Merges landing in quick succession must not stack parallel full
+    # pipelines on the shared server (2026-07-20: five overlapping staging
+    # deploys drove load ~7 on the box that also serves production).
+    # Queued runs wait; never cancel a deploy mid-flight.
+    concurrency:
+      group: staging-deploy
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code

--- a/scripts/deploy-default.sh
+++ b/scripts/deploy-default.sh
@@ -114,10 +114,16 @@ echo -e "${GREEN}✓ Front page rebuilt${NC}"
 # inside the maintenance window (this is a bulk node write and must not race
 # live traffic). Idempotent (append-only, capped per node, skips existing) and
 # reversible via relations_siblings_rollback.json + drush saho:relations-rollback.
-echo -e "${YELLOW}Enriching record cross-links...${NC}"
-vendor/bin/drush saho:relations-siblings --apply -l "${SITE_URI}" 2>&1 | tee -a "${LOG_FILE}" \
-    || echo -e "${YELLOW}⚠ Relations enrichment skipped/failed (non-fatal)${NC}"
-echo -e "${GREEN}✓ Record cross-links enriched${NC}"
+if [ "${ENVIRONMENT}" = "production" ]; then
+    echo -e "${YELLOW}Enriching record cross-links...${NC}"
+    vendor/bin/drush saho:relations-siblings --apply -l "${SITE_URI}" 2>&1 | tee -a "${LOG_FILE}" \
+        || echo -e "${YELLOW}⚠ Relations enrichment skipped/failed (non-fatal)${NC}"
+    echo -e "${GREEN}✓ Record cross-links enriched${NC}"
+else
+    # ~3 minutes of heavy DB scanning per run; staging does not need 64k
+    # records re-verified on every merge, and it shares mysqld with prod.
+    echo -e "${YELLOW}Skipping relations enrichment on ${ENVIRONMENT}${NC}"
+fi
 
 # Disable maintenance mode (production only, staging stays in maintenance)
 if [ "${ENVIRONMENT}" = "production" ]; then


### PR DESCRIPTION
The two guardrails agreed after tonight's load investigation.

**What happened:** five merges landed within 14 minutes (19:20-19:34 UTC); the staging job has no concurrency control, so GitHub ran five full pipelines in PARALLEL against the shared server - each with ~3 min of drush deploy plus the ~3 min siblings enrichment that entered deploy-default.sh on Jul 13. Load hit ~7 on the box that also serves production; it fell off a cliff the minute the last run finished (verified live against `top`).

**Fix 1 - concurrency on deploy-staging:** `group: staging-deploy, cancel-in-progress: false`. Rapid merges queue and run one at a time. Deliberately NOT cancel-in-progress: killing a deploy mid-run can strand staging in maintenance mode.

**Fix 2 - enrichment gated to production:** staging skips `saho:relations-siblings --apply` with an explicit log line. Staging doesn't need 64k records re-verified on every merge, and the scan competes with production for mysqld. Production deploys are byte-identical in behavior.

Validated: workflow YAML parses, script passes `bash -n`. First merge of this PR itself will demonstrate fix 2's skip line in the staging log.