### PR TITLE
perf(cache): 2h edge TTL for anonymous HTML - the field-LCP lever

### DIFF
--- a/config/sync/system.performance.yml
+++ b/config/sync/system.performance.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: b2cssrj-lOmATIbdehfCqfCFgVR0qCdxxWhwqa2KBVQ
 cache:
   page:
-    max_age: 1800
+    max_age: 7200
 css:
   preprocess: true
   gzip: true


### PR DESCRIPTION
How to get green all over, part 1 of 2 - the decisive part.

**The read:** the only failing Core Web Vital on either form factor is LCP (mobile 3.3s / desktop 2.6s vs 2.5s green line - desktop misses by 0.1s). CLS is 0, INP passes. Both panels show p75 TTFB 1.9s: real users' LCP is mostly WAITING, not rendering (origin renders ~0.4s). The 30-min CF TTL means the long tail of pages misses the edge cache constantly.

**The change:** `system.performance` page max_age 1800 -> 7200. Pages live 4x longer at the edge; p75 TTFB collapses toward CF-hit latency; LCP follows mechanically. Expected: desktop ~1.4s, mobile ~2.0s - both green.

**Trade-offs:** anonymous content freshness up to 2h (daily TDIH rotation unaffected; editorial cadence tolerates it).

**Also needed, Cloudflare-side (dashboard, not repo):** enable Tiered Cache (free toggle, improves hit ratio further) - and purge CF once after this deploys.

**Part 2 (separate project):** critical-CSS split + 51KB unused-CSS diet for the remaining lab-LCP headroom; roadmap documented in project notes.

**Reality check on timing:** the CWV badge reads a 28-day trailing window - after this deploys, expect the field numbers to walk toward green over 2-4 weeks as the window rolls.