### PR TITLE
perf(early-hints): origin Link preload headers make Cloudflare's 103 hints real

### DIFF
--- a/webroot/modules/custom/saho_performance/src/EventSubscriber/ResponseSubscriber.php
+++ b/webroot/modules/custom/saho_performance/src/EventSubscriber/ResponseSubscriber.php
@@ -66,8 +66,12 @@ class ResponseSubscriber implements EventSubscriberInterface {
       $response->headers->set('Vary', 'Accept-Encoding');
     }
 
-    // Add performance hints.
-    $this->addLinkHeaders($response, $request);
+    // Add performance hints. Only anonymous-cacheable pages: Cloudflare
+    // serves Early Hints from cache per URL, and those are the responses
+    // it caches.
+    if ($request->isMethodCacheable() && $is_public && !$has_session) {
+      $this->addLinkHeaders($response, $request);
+    }
 
     // Do NOT set Content-Encoding header here - let Apache handle compression.
     // Setting this header without actual compression causes encoding errors.
@@ -95,17 +99,32 @@ class ResponseSubscriber implements EventSubscriberInterface {
    *   The request object.
    */
   protected function addLinkHeaders($response, $request) {
-    // DNS prefetch for external resources.
-    $dns_prefetch = [
-      '</www.google-analytics.com>; rel=dns-prefetch',
-      '</fonts.gstatic.com>; rel=dns-prefetch',
-    ];
-
-    // Set Link header with resource hints.
-    // Note: Font preloads are handled via HTML <link> tags in saho_performance_page_attachments()
-    // to avoid duplicate fetches. CSS/JS are loaded by Drupal's library system with versioned
-    // query params that won't match a static Link header URL.
-    $response->headers->set('Link', implode(', ', $dns_prefetch));
+    // Preload the page's render-blocking stylesheets via HTTP Link headers.
+    // Cloudflare's Early Hints feature turns exactly these into 103
+    // responses, so browsers fetch the blocking CSS before the HTML body
+    // arrives - attacking the render chain without touching any stylesheet.
+    // The aggregate URLs are hashed per page-set, so they are read from the
+    // response itself rather than configured statically. (The old static
+    // dns-prefetch hints pointed at hosts the redesign no longer uses.)
+    $content = $response->getContent();
+    if (!is_string($content) || $content === '') {
+      return;
+    }
+    // Only the <head> section, and only same-origin stylesheet links.
+    $head_end = strpos($content, '</head>');
+    $head = $head_end === FALSE ? substr($content, 0, 65536) : substr($content, 0, $head_end);
+    if (!preg_match_all('/<link[^>]+rel="stylesheet"[^>]+href="(\/[^"]+\.css[^"]*)"/', $head, $matches)) {
+      return;
+    }
+    $hints = [];
+    foreach (array_slice($matches[1], 0, 4) as $href) {
+      // & in HTML attributes arrives as &amp;.
+      $href = str_replace('&amp;', '&', $href);
+      $hints[] = '<' . $href . '>; rel=preload; as=style';
+    }
+    if ($hints) {
+      $response->headers->set('Link', implode(', ', $hints));
+    }
   }
 
 }


### PR DESCRIPTION
Companion to the Early Hints zone toggle Mads enabled: CF only sends 103 hints built from origin `Link` headers, and Drupal puts stylesheets in markup - so the toggle had nothing to fire. The saho_performance response subscriber (already home to the Vary collapse) now extracts the page's first stylesheets from its own `<head>` and emits `Link: <...>; rel=preload; as=style` headers. On production markup that's exactly the 2 render-blocking aggregates.

- Anonymous-cacheable responses only (same gate as the Vary collapse - the responses CF actually caches and hints for)
- URLs taken verbatim from the response (hashed aggregate URLs can't be statically configured; exact-match required for browser preload reuse), `&amp;` decoded, capped at 4
- Replaces the stale static dns-prefetch hints (google-analytics + fonts.gstatic - neither used since the redesign, and malformed as paths)

**Verified:** extraction proven against both local (unaggregated) and production (aggregated) markup; gate correctly withholds hints on non-public responses. phpcs + drupal-check clean.

**Post-deploy check:** `curl -sv --http2 https://sahistory.org.za/ 2>&1 | grep -i 'HTTP/2 103'` should show the early hint with the CSS preloads.

Zero styling risk - pure HTTP headers. Part of the no-extraction alternative to critical CSS; the bundle-diet-by-subtraction audit is the other half, queued next.