### PR TITLE
perf(fonts): retire dead Inter preloads - front page lab GREEN (LCP 2.3s, score 97)

### DIFF
--- a/webroot/modules/custom/saho_performance/saho_performance.module
+++ b/webroot/modules/custom/saho_performance/saho_performance.module
@@ -40,9 +40,14 @@ function saho_performance_page_attachments_alter(array &$page) {
     ];
   }
 
-  // Add preload hints for critical resources (front-end only)
-  _saho_performance_add_preload_hints($page);
-
+  // NO font preloads - measured decision (2026-07-21, 3-run Lighthouse
+  // medians, mobile/Slow 4G): this hook preloaded three Inter weights that
+  // outlasted the redesign ("preloaded but not used" in every console),
+  // spending ~150 KB of critical-path bandwidth. Removing them took the
+  // front page from LCP 3.9 s / score 87 to LCP 2.3 s / score 97-98; even
+  // a single Caslon preload measurably regressed it (median 3.0 s / 87).
+  // The metric-matched fallback faces (_fonts.scss) keep the font swap
+  // dimensionally invisible, so late fonts are safe by design.
   // Add resource hints for faster connections (front-end only)
   _saho_performance_add_resource_hints($page);
 }
@@ -527,36 +532,6 @@ function _saho_performance_get_critical_css() {
   $critical_css = str_replace(';}', '}', $critical_css);
 
   return trim($critical_css);
-}
-
-/**
- * Add preload hints for critical resources.
- */
-function _saho_performance_add_preload_hints(array &$page) {
-  // Preload self-hosted Inter fonts.
-  $fonts = [
-    '/themes/custom/saho/fonts/inter/Inter-Regular.woff2',
-    '/themes/custom/saho/fonts/inter/Inter-Medium.woff2',
-    '/themes/custom/saho/fonts/inter/Inter-Bold.woff2',
-  ];
-
-  foreach ($fonts as $font) {
-    $page['#attached']['html_head'][] = [
-      [
-        '#type' => 'html_tag',
-        '#tag' => 'link',
-        '#attributes' => [
-          'rel' => 'preload',
-          'href' => $font,
-          'as' => 'font',
-          'type' => 'font/woff2',
-          'crossorigin' => 'anonymous',
-        ],
-      ],
-      'font_preload_' . basename($font),
-    ];
-  }
-
 }
 
 /**


### PR DESCRIPTION
Mads's browser console caught what every Lighthouse run missed: `saho_performance_page_attachments()` still preloaded **three Inter weights from before the redesign** - browsers warned 'preloaded but not used' on every page while ~150 KB of critical-path bandwidth went to a typeface the site no longer renders. Crucially, every font variant measured this week (the v2.0.2 experiment ladder included) carried these as an invisible constant.

**The final ladder** (3-run Lighthouse, mobile/Slow 4G, local):

| Variant | LCP | Score |
|---|---|---|
| v2.0.2-4 shipped state (hidden Inter constant) | 3.9 s | 85-87 |
| Inter gone + one Caslon preload | 2.7-3.6 s (noisy) | 77-93 |
| **Inter gone + zero font preloads (this PR)** | **2.3 / 2.3 / 2.3 s** | **96 / 98 / 98** |

LCP under the 2.5 s green line, rock-stable across runs - **the lab green sphere, reached without touching a single CSS rule**, honoring the no-critical-CSS-extraction constraint.

The preload machinery is deleted rather than emptied; the measured reasoning lives as a comment at the call site so it never gets 'helpfully' reinstated. The metric-matched fallback faces (v2.0.2) keep the font swap dimensionally invisible, so late fonts remain safe by design. Note for review: the hard-refresh fallback-letterform flash Mads noticed is the visible half of this trade - the numbers above are why it's worth keeping, and the Caslon-preload row is the measured cost of softening it.

phpcs clean. For the next patch tag.