### PR TITLE
fix(schema): drop mainEntityOfPage from ProfilePage - clears the GSC warning on 186 biographies

### DIFF
--- a/webroot/modules/custom/saho_tools/src/Service/Builder/BiographySchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/BiographySchemaBuilder.php
@@ -38,10 +38,6 @@ class BiographySchemaBuilder extends SchemaBuilderBase {
       '@id' => ($ref_url ?? $url) . '#person',
       'name' => $node->getTitle(),
       'url' => $url,
-      'mainEntityOfPage' => [
-        '@type' => 'WebPage',
-        '@id' => $url,
-      ],
     ];
 
     // Build full name from components.
@@ -216,6 +212,10 @@ class BiographySchemaBuilder extends SchemaBuilderBase {
     }
 
     // Wrap Person in ProfilePage (Google rich-result type for profiles).
+    // mainEntityOfPage never appears here: on a ProfilePage the page IS
+    // the entity's page (mainEntity carries the relationship), and Search
+    // Console flags the field as unrecognized on Profile page items - the
+    // property is for content entities (Article etc.), not page types.
     $schema = [
       '@context' => 'https://schema.org',
       '@type' => 'ProfilePage',
@@ -223,6 +223,7 @@ class BiographySchemaBuilder extends SchemaBuilderBase {
       'dateModified' => date('c', $node->getChangedTime()),
       'mainEntity' => $person,
     ] + $this->identityProperties($node);
+    unset($schema['mainEntityOfPage']);
     if (!empty($citations)) {
       $schema['citation'] = $citations;
     }


### PR DESCRIPTION
## What

Search Console's **Profile page** report warns *Unrecognized field "mainEntityOfPage"* on 186 biography pages (first detected right after the v2.0.0 schema deploy).

Root cause: the biography JSON-LD emitted the field twice, both semantically wrong for a ProfilePage:

1. On the **ProfilePage itself** (via the shared `identityProperties()`) - self-referential: the page declaring itself the page of its own main entity
2. On the **nested Person** - redundant: `ProfilePage.mainEntity` already carries the page↔person relationship, and Google's ProfilePage validator recognises neither placement

Both removed. `mainEntity` remains the canonical link, per Google's ProfilePage documentation. Content-typed schemas (Article, Event, etc.) keep `mainEntityOfPage` from `identityProperties()` - it's recognised there.

## Verified

- Biography JSON-LD: zero `mainEntityOfPage` occurrences; ProfilePage keys = `@context/@id/@type/citation/dateCreated/dateModified/identifier/mainEntity/url`
- All 46 schema tests pass unchanged; phpcs (CI flags) clean

## After deploy

Use GSC's *Done fixing? → Validate fix* on the Profile page report; the 186 items clear as Google recrawls (URL Inspection → Test live URL on e.g. /people/dennis-brutus gives an immediate check).