### PR TITLE
fix(frontpage): top-collections band counts archive members only

### DIFF
--- a/webroot/modules/custom/saho_frontpage/src/ArchiveCountsService.php
+++ b/webroot/modules/custom/saho_frontpage/src/ArchiveCountsService.php
@@ -255,13 +255,17 @@ final class ArchiveCountsService {
       return $cached->data;
     }
     $rows = [];
-    // Count only published members (c.status = 1) of published collection
-    // parents (n.status = 1); the field row itself must not be deleted.
+    // Count only published ARCHIVE members (c.status = 1, c.type = archive)
+    // of published collection parents (n.status = 1); the field row itself
+    // must not be deleted. The bundle condition matters: these links land on
+    // the /archives register, which only lists archive records - a collection
+    // whose members are biographies (Lives of Courage: 4,114 members, zero
+    // archives) would otherwise rank top-3 and link to an empty result page.
     $result = $this->database->query(
       "SELECT p.field_feature_parent_target_id AS nid, n.title, COUNT(*) AS members
        FROM {node__field_feature_parent} p
        JOIN {node_field_data} n ON n.nid = p.field_feature_parent_target_id AND n.status = 1
-       JOIN {node_field_data} c ON c.nid = p.entity_id AND c.status = 1
+       JOIN {node_field_data} c ON c.nid = p.entity_id AND c.status = 1 AND c.type = 'archive'
        WHERE p.deleted = 0
        GROUP BY p.field_feature_parent_target_id, n.title
        ORDER BY members DESC LIMIT 3"

--- a/webroot/modules/custom/saho_tools/src/Service/Builder/BiographySchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/BiographySchemaBuilder.php
@@ -38,10 +38,6 @@ class BiographySchemaBuilder extends SchemaBuilderBase {
       '@id' => ($ref_url ?? $url) . '#person',
       'name' => $node->getTitle(),
       'url' => $url,
-      'mainEntityOfPage' => [
-        '@type' => 'WebPage',
-        '@id' => $url,
-      ],
     ];
 
     // Build full name from components.
@@ -216,6 +212,10 @@ class BiographySchemaBuilder extends SchemaBuilderBase {
     }
 
     // Wrap Person in ProfilePage (Google rich-result type for profiles).
+    // mainEntityOfPage never appears here: on a ProfilePage the page IS
+    // the entity's page (mainEntity carries the relationship), and Search
+    // Console flags the field as unrecognized on Profile page items - the
+    // property is for content entities (Article etc.), not page types.
     $schema = [
       '@context' => 'https://schema.org',
       '@type' => 'ProfilePage',
@@ -223,6 +223,7 @@ class BiographySchemaBuilder extends SchemaBuilderBase {
       'dateModified' => date('c', $node->getChangedTime()),
       'mainEntity' => $person,
     ] + $this->identityProperties($node);
+    unset($schema['mainEntityOfPage']);
     if (!empty($citations)) {
       $schema['citation'] = $citations;
     }


### PR DESCRIPTION
Reported: https://sahistory.org.za/archives?collection=64243 gives 0 results despite a 100% index.

**Root cause**: the index is fine - 64243 (Lives of Courage) genuinely has zero archive-bundle members. Its 4,114 `field_feature_parent` children are 4,094 biographies + 17 articles + 1 image + 2 events. The dead link comes from the front page: `ArchiveCountsService::getTopCollections()` ranks collections by member count across **all bundles**, then links each to the /archives register, which only lists **archive** records. Lives of Courage ranked #2; Robben Island (#3) showed 1,755 but landed on 13 records.

**Fix**: count only `c.type = 'archive'` members. Rank, displayed count, and register result now agree - verified locally: front page emits DISA (20,181), SALDRU (1,566), Mandela (961), and each link returns exactly that many records.

The theme-side `_saho_record_collection_count` (the 'Part of' row on archive records) already counted archive-only - this was the one emitter with the mismatch.

phpcs clean; saho_frontpage unit tests green. Cache: TOP_COLLECTIONS_CID is node_list-tagged, refreshes on deploy cr.