### PR TITLE
fix(archive): sidebar source links stay inside their box

### DIFF
--- a/webroot/themes/custom/saho/css/url-truncation.css
+++ b/webroot/themes/custom/saho/css/url-truncation.css
@@ -56,7 +56,7 @@
   .saho-references a,
   .saho-saho-sources a,
   .saho-reference-list a {
-    max-width: 250px; /* Shorter on mobile */
+    max-width: min(250px, 100%); /* Shorter on mobile, never wider than the box */
   }
 }
 
@@ -65,7 +65,7 @@
   .saho-references a,
   .saho-saho-sources a,
   .saho-reference-list a {
-    max-width: 350px; /* Medium length on tablet */
+    max-width: min(350px, 100%); /* Medium on tablet, never wider than the box */
   }
 }
 
@@ -74,7 +74,7 @@
   .saho-references a,
   .saho-saho-sources a,
   .saho-reference-list a {
-    max-width: 450px; /* Longer on desktop */
+    max-width: min(450px, 100%); /* Longer on desktop, never wider than the box - fixed caps overflowed the ~250px sidebar rail */
   }
 }
 
@@ -147,6 +147,9 @@
   margin-bottom: 2rem;
 }
 
+/* The template renders the section heading as h2 (record sections sit
+   directly under the h1); the size stays a modest label, not a page h2. */
+.saho-saho-sources h2,
 .saho-saho-sources h4 {
   color: #B88A2E;
   font-size: 1.125rem;

--- a/webroot/themes/custom/saho/templates/content/node--archive.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--archive.html.twig
@@ -276,7 +276,7 @@
       {% if node.field_references_saho_source.value %}
         <div class="saho-references">
           <div class="saho-saho-sources">
-            <h5>{{ 'SAHO Sources'|t }}</h5>
+            <h2>{{ 'SAHO Sources'|t }}</h2>
             {# Render through the field text format (.processed) so its filters
                strip scripts and event-handler/javascript: attributes; striptags
                alone kept dangerous attributes on allowed tags. #}


### PR DESCRIPTION
Reported via screenshot: on archive records (e.g. /archive/xenophobia-south-africa-reflections-narratives-and-recommendations-hussein-solomon-and) the raw file URL in the **SAHO Sources** panel overflows the yellow box and the white card behind it.

**Root cause**: `css/url-truncation.css` gives links in `.saho-saho-sources` / `.saho-references` / `.saho-further-reading` a fixed `max-width: 450px` on desktop (350px tablet), overriding the base `max-width: 100%`. The sidebar rail box is only ~250px wide, and `display:inline-block; white-space:nowrap` means the link clips at 450px - well outside its container.

**Fix**:
- `max-width: min(450px, 100%)` (and tablet/mobile equivalents) - keeps the long-URL cap in wide columns, never exceeds the container; ellipsis clips at the box edge. This is the shared rule, so further-reading/reference link lists get the same containment.
- The SAHO Sources heading rendered as an unstyled `h5` because the style rule targeted `h4` (dead selector), and it skipped heading levels under the promoted h2 record sections (#529). Now an `h2` carrying the intended gold 1.125rem label style.

Verified with Playwright on a local node with sources content: link 194px inside the 246px box, `text-overflow: ellipsis` active, heading H2/18px/gold. url-truncation.css is served raw (library-attached), no dist rebuild involved.