### PR TITLE
feat(terms): term pages become filtered registers - 301 into the landing with the term applied

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -150,6 +150,7 @@ module:
   telephone: 0
   term_merge: 0
   term_reference_change: 0
+  term_registers: 0
   text: 0
   token: 0
   toolbar: 0

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_media_library_type.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_media_library_type.yml
@@ -1,4 +1,4 @@
-index: true
+index: false
 priority: '0.5'
 changefreq: ''
 include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_people_category.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_people_category.yml
@@ -1,4 +1,4 @@
-index: true
+index: false
 priority: '0.5'
 changefreq: ''
 include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_people_level3_cat.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_people_level3_cat.yml
@@ -1,4 +1,4 @@
-index: true
+index: false
 priority: '0.5'
 changefreq: ''
 include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_place_type.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_place_type.yml
@@ -1,4 +1,4 @@
-index: true
+index: false
 priority: '0.5'
 changefreq: ''
 include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_places_level3.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_places_level3.yml
@@ -1,4 +1,4 @@
-index: true
+index: false
 priority: '0.5'
 changefreq: ''
 include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.prison_list.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.prison_list.yml
@@ -1,4 +1,4 @@
-index: true
+index: false
 priority: '0.5'
 changefreq: ''
 include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.saldru_archive_topic.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.saldru_archive_topic.yml
@@ -1,4 +1,4 @@
-index: true
+index: false
 priority: '0.5'
 changefreq: ''
 include_images: false

--- a/config/sync/term_registers.settings.yml
+++ b/config/sync/term_registers.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: kkNfkkMGsCEaNNeK_ZFcUALS34BlCzBrtzF9-9td9pM
+enabled: true

--- a/config/sync/views.view.biographies.yml
+++ b/config/sync/views.view.biographies.yml
@@ -9,6 +9,8 @@ dependencies:
     - system.menu.main
     - taxonomy.vocabulary.field_people_category
     - taxonomy.vocabulary.field_people_level3_cat
+    - taxonomy.vocabulary.member_of_organisation
+    - taxonomy.vocabulary.prison_list
   module:
     - better_exposed_filters
     - image
@@ -204,6 +206,20 @@ display:
                   hide_label: false
                   sort_options_order: count_desc
               field_people_level3_cat_target_id:
+                plugin_id: bef_hidden
+                advanced:
+                  rewrite:
+                    filter_rewrite_values: ''
+                  collapsible: false
+                  is_secondary: false
+              field_member_of_organisation_target_id:
+                plugin_id: bef_hidden
+                advanced:
+                  rewrite:
+                    filter_rewrite_values: ''
+                  collapsible: false
+                  is_secondary: false
+              field_prison_target_id:
                 plugin_id: bef_hidden
                 advanced:
                   rewrite:
@@ -417,6 +433,74 @@ display:
             group_items: {  }
           reduce_duplicates: false
           vid: field_people_level3_cat
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+        field_member_of_organisation_target_id:
+          id: field_member_of_organisation_target_id
+          table: node__field_member_of_organisation
+          field: field_member_of_organisation_target_id
+          relationship: none
+          group_type: group
+          admin_label: 'Organisation (URL-driven, BEF hidden)'
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: org_op
+            label: Organisation
+            description: ''
+            use_operator: false
+            operator: org_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: org
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          reduce_duplicates: false
+          vid: member_of_organisation
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+        field_prison_target_id:
+          id: field_prison_target_id
+          table: node__field_prison
+          field: field_prison_target_id
+          relationship: none
+          group_type: group
+          admin_label: 'Prison (URL-driven, BEF hidden)'
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: prison_op
+            label: Prison
+            description: ''
+            use_operator: false
+            operator: prison_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: prison
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          reduce_duplicates: false
+          vid: prison_list
           type: select
           hierarchy: false
           limit: true

--- a/config/sync/views.view.places.yml
+++ b/config/sync/views.view.places.yml
@@ -7,6 +7,7 @@ dependencies:
     - image.style.lp_new
     - node.type.place
     - system.menu.main
+    - taxonomy.vocabulary.field_place_type
     - taxonomy.vocabulary.field_place_type_category
     - taxonomy.vocabulary.field_places_level3
   module:
@@ -215,6 +216,13 @@ display:
                   is_secondary: false
                   hide_label: false
                   sort_options_order: count_desc
+              field_place_type_target_id:
+                plugin_id: bef_hidden
+                advanced:
+                  rewrite:
+                    filter_rewrite_values: ''
+                  collapsible: false
+                  is_secondary: false
       access:
         type: perm
         options:
@@ -456,6 +464,40 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_place_type_target_id:
+          id: field_place_type_target_id
+          table: node__field_place_type
+          field: field_place_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: 'Place type (URL-driven, BEF hidden)'
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ptype_op
+            label: 'Place type'
+            description: ''
+            use_operator: false
+            operator: ptype_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ptype
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          reduce_duplicates: false
+          vid: field_place_type
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
       style:
         type: grid
         options:

--- a/webroot/modules/custom/saho_utils/term_registers/config/install/term_registers.settings.yml
+++ b/webroot/modules/custom/saho_utils/term_registers/config/install/term_registers.settings.yml
@@ -1,0 +1,1 @@
+enabled: true

--- a/webroot/modules/custom/saho_utils/term_registers/config/schema/term_registers.schema.yml
+++ b/webroot/modules/custom/saho_utils/term_registers/config/schema/term_registers.schema.yml
@@ -1,0 +1,7 @@
+term_registers.settings:
+  type: config_object
+  label: 'Term registers settings'
+  mapping:
+    enabled:
+      type: boolean
+      label: 'Redirect mapped term pages to their landing register'

--- a/webroot/modules/custom/saho_utils/term_registers/src/EventSubscriber/TermRegisterRedirectSubscriber.php
+++ b/webroot/modules/custom/saho_utils/term_registers/src/EventSubscriber/TermRegisterRedirectSubscriber.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\term_registers\EventSubscriber;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Routing\LocalRedirectResponse;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\taxonomy\TermInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Redirects mapped taxonomy term pages to their filtered landing register.
+ *
+ * A term page is a dead-end listing; the Open Record landings carry the
+ * full register UX (facet chips, search, table/cards toggle, load-more).
+ * For mapped vocabularies the canonical term route 301s to the landing
+ * with the term pre-applied through its URL-only exposed filter, so every
+ * term link on a record page opens the register instead.
+ *
+ * Unmapped vocabularies fall through untouched - which also preserves the
+ * Africa term's special same-path view display and the classroom/keyword
+ * term pages. Kill-switch: term_registers.settings:enabled (the config
+ * cache tag rides every 301, so flipping it invalidates cached redirects
+ * without a deploy).
+ */
+final class TermRegisterRedirectSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Vocabulary => register target.
+   *
+   * 'mode' tid: the landing filter is taxonomy_index_tid - the URL carries
+   * ?param[TID]=TID (BEF's own checkbox format, so visible facet widgets
+   * tick where they exist). 'mode' label: the /archives facets key their
+   * values by term LABEL strings.
+   */
+  private const MAP = [
+    'member_of_organisation' => ['path' => '/biographies', 'param' => 'org', 'mode' => 'tid'],
+    'prison_list' => ['path' => '/biographies', 'param' => 'prison', 'mode' => 'tid'],
+    'field_people_category' => ['path' => '/biographies', 'param' => 'tid_1', 'mode' => 'tid'],
+    'field_people_level3_cat' => ['path' => '/biographies', 'param' => 'register', 'mode' => 'tid'],
+    'field_place_type' => ['path' => '/places', 'param' => 'ptype', 'mode' => 'tid'],
+    'field_places_level3' => ['path' => '/places', 'param' => 'tid_2', 'mode' => 'tid'],
+    'saldru_archive_topic' => ['path' => '/archives', 'param' => 'saldru', 'mode' => 'label'],
+    'field_media_library_type' => ['path' => '/archives', 'param' => 'type', 'mode' => 'label'],
+  ];
+
+  public function __construct(
+    private readonly RouteMatchInterface $routeMatch,
+    private readonly ConfigFactoryInterface $configFactory,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    // After routing (priority 32) so the route match is resolved; before
+    // dynamic_page_cache and the controller build the term page.
+    return [KernelEvents::REQUEST => ['onRequest', 30]];
+  }
+
+  /**
+   * Issues the register redirect for mapped term canonical routes.
+   */
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+    // Canonical route only: edit/delete/admin/JSON:API routes have their
+    // own route names and pass through untouched.
+    if ($this->routeMatch->getRouteName() !== 'entity.taxonomy_term.canonical') {
+      return;
+    }
+    $settings = $this->configFactory->get('term_registers.settings');
+    if (!$settings->get('enabled')) {
+      return;
+    }
+    $term = $this->routeMatch->getParameter('taxonomy_term');
+    if (!$term instanceof TermInterface) {
+      return;
+    }
+    $target = self::MAP[$term->bundle()] ?? NULL;
+    if ($target === NULL) {
+      return;
+    }
+
+    $key = $target['mode'] === 'label' ? $term->label() : $term->id();
+    $url = $target['path'] . '?' . http_build_query([$target['param'] => [$key => $key]]);
+
+    $response = new LocalRedirectResponse($url, 301);
+    $response->addCacheableDependency(
+      CacheableMetadata::createFromObject($term)
+        ->addCacheableDependency($settings)
+    );
+    $event->setResponse($response);
+  }
+
+}

--- a/webroot/modules/custom/saho_utils/term_registers/term_registers.info.yml
+++ b/webroot/modules/custom/saho_utils/term_registers/term_registers.info.yml
@@ -1,0 +1,9 @@
+name: 'SAHO Term Registers'
+type: module
+description: 'Redirects mapped taxonomy term pages to their filtered landing register (biographies/places/archives) so term links open the full register UX.'
+package: SAHO
+core_version_requirement: ^10 || ^11
+dependencies:
+  - drupal:taxonomy
+  - better_exposed_filters:better_exposed_filters
+  - saho_utils:saho_utils

--- a/webroot/modules/custom/saho_utils/term_registers/term_registers.services.yml
+++ b/webroot/modules/custom/saho_utils/term_registers/term_registers.services.yml
@@ -1,0 +1,8 @@
+services:
+  term_registers.redirect_subscriber:
+    class: Drupal\term_registers\EventSubscriber\TermRegisterRedirectSubscriber
+    arguments:
+      - '@current_route_match'
+      - '@config.factory'
+    tags:
+      - { name: event_subscriber }

--- a/webroot/modules/custom/saho_utils/term_registers/tests/src/Kernel/TermRegisterRedirectSubscriberTest.php
+++ b/webroot/modules/custom/saho_utils/term_registers/tests/src/Kernel/TermRegisterRedirectSubscriberTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\term_registers\Kernel;
+
+use Drupal\Core\Routing\LocalRedirectResponse;
+use Drupal\Core\Routing\RouteMatch;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\term_registers\EventSubscriber\TermRegisterRedirectSubscriber;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * The term-register redirect maps term pages onto filtered landings.
+ *
+ * @group term_registers
+ */
+final class TermRegisterRedirectSubscriberTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'taxonomy',
+    'term_registers',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('user');
+    $this->installConfig(['term_registers']);
+    foreach (['member_of_organisation', 'saldru_archive_topic', 'african_country'] as $vid) {
+      Vocabulary::create(['vid' => $vid, 'name' => $vid])->save();
+    }
+  }
+
+  /**
+   * Dispatches the subscriber for a term on a given route name.
+   */
+  private function dispatch(Term $term, string $route_name = 'entity.taxonomy_term.canonical'): RequestEvent {
+    $route = new Route('/taxonomy/term/{taxonomy_term}');
+    $route_match = new RouteMatch($route_name, $route, ['taxonomy_term' => $term], ['taxonomy_term' => $term->id()]);
+    $subscriber = new TermRegisterRedirectSubscriber($route_match, $this->container->get('config.factory'));
+    $event = new RequestEvent(
+      $this->container->get('http_kernel'),
+      Request::create('/taxonomy/term/' . $term->id()),
+      HttpKernelInterface::MAIN_REQUEST
+    );
+    $subscriber->onRequest($event);
+    return $event;
+  }
+
+  /**
+   * A tid-mode vocabulary redirects to its landing with the tid applied.
+   */
+  public function testTidModeRedirect(): void {
+    $term = Term::create(['vid' => 'member_of_organisation', 'name' => '(ANC) African National Congress']);
+    $term->save();
+    $event = $this->dispatch($term);
+    $response = $event->getResponse();
+    $this->assertInstanceOf(LocalRedirectResponse::class, $response);
+    $this->assertSame(301, $response->getStatusCode());
+    $tid = $term->id();
+    $this->assertSame("/biographies?org%5B$tid%5D=$tid", $response->getTargetUrl());
+  }
+
+  /**
+   * A label-mode vocabulary redirects with the term label as facet value.
+   */
+  public function testLabelModeRedirect(): void {
+    $term = Term::create(['vid' => 'saldru_archive_topic', 'name' => 'Labour']);
+    $term->save();
+    $event = $this->dispatch($term);
+    $response = $event->getResponse();
+    $this->assertInstanceOf(LocalRedirectResponse::class, $response);
+    $this->assertSame('/archives?saldru%5BLabour%5D=Labour', $response->getTargetUrl());
+  }
+
+  /**
+   * Unmapped vocabularies pass through - the Africa architecture survives.
+   */
+  public function testUnmappedVocabularyPassesThrough(): void {
+    $term = Term::create(['vid' => 'african_country', 'name' => 'Ghana']);
+    $term->save();
+    $event = $this->dispatch($term);
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * An empty (untagged) term still redirects to the register empty state.
+   */
+  public function testEmptyTermStillRedirects(): void {
+    $term = Term::create(['vid' => 'member_of_organisation', 'name' => 'AOL African Orthodox Church']);
+    $term->save();
+    $event = $this->dispatch($term);
+    $this->assertNotNull($event->getResponse());
+  }
+
+  /**
+   * The kill-switch disables every redirect without a code change.
+   */
+  public function testKillSwitch(): void {
+    $this->config('term_registers.settings')->set('enabled', FALSE)->save();
+    $term = Term::create(['vid' => 'member_of_organisation', 'name' => 'ANC']);
+    $term->save();
+    $event = $this->dispatch($term);
+    $this->assertNull($event->getResponse());
+  }
+
+  /**
+   * Non-canonical term routes (edit forms etc.) are never redirected.
+   */
+  public function testNonCanonicalRoutePassesThrough(): void {
+    $term = Term::create(['vid' => 'member_of_organisation', 'name' => 'ANC']);
+    $term->save();
+    $event = $this->dispatch($term, 'entity.taxonomy_term.edit_form');
+    $this->assertNull($event->getResponse());
+  }
+
+}

--- a/webroot/themes/custom/saho/includes/view.theme
+++ b/webroot/themes/custom/saho/includes/view.theme
@@ -1119,6 +1119,43 @@ function saho_preprocess_views_view__saho_landing_shell(array &$variables): void
   $variables['record_rows'] = $record_rows;
   $variables['record_cards'] = $record_cards;
   $variables['result_total'] = $variables['landing_count'];
+
+  // Hidden URL-only filters (org/prison/ptype/register/bio - the term
+  // register redirects and register tiles) have no visible widget; resolve
+  // their term labels into a "Filtered:" head with a clear link so readers
+  // landing from a term page can SEE and drop the applied scope. The
+  // wholesale url.query_args cache context below covers the params.
+  $request = \Drupal::request();
+  $filter_labels = [];
+  $present_params = [];
+  $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+  foreach (['org', 'prison', 'ptype', 'register', 'bio'] as $hidden_param) {
+    $raw = $request->query->all()[$hidden_param] ?? NULL;
+    $ids = is_array($raw) ? array_values($raw) : (($raw !== NULL && (string) $raw !== '') ? [$raw] : []);
+    if ($ids === []) {
+      continue;
+    }
+    $present_params[] = $hidden_param;
+    foreach ($ids as $id) {
+      if (!ctype_digit((string) $id)) {
+        continue;
+      }
+      $term = $term_storage->load((int) $id);
+      if ($term !== NULL) {
+        $filter_labels[] = $term->label();
+        $variables['#cache']['tags'][] = 'taxonomy_term:' . $term->id();
+      }
+    }
+  }
+  if ($filter_labels !== []) {
+    $clear_query = array_diff_key($request->query->all(), array_flip(array_merge($present_params, ['page'])));
+    $landing_path = '/' . $variables['view']->getDisplay()->getPath();
+    $variables['filter_head'] = [
+      'labels' => $filter_labels,
+      'clear_url' => Url::fromUserInput($landing_path, $clear_query !== [] ? ['query' => $clear_query] : [])->toString(),
+    ];
+  }
+
   // Places: the clustered Leaflet register (places_map view) rides along as
   // a third results layout - same records, spatial reading. It is unpaged
   // and unfiltered (all geolocated places); the exposed filters and pager

--- a/webroot/themes/custom/saho/templates/views/views-view--saho-landing-shell.html.twig
+++ b/webroot/themes/custom/saho/templates/views/views-view--saho-landing-shell.html.twig
@@ -33,6 +33,16 @@
        (the chip earns its keep on record pages, where type != title). #}
     <h1 class="saho-landing-head__title">{{ landing_label }}</h1>
     <p class="saho-landing-head__count">{{ landing_count }} records</p>
+    {# Hidden URL-only filters made visible (term-register redirects):
+       mono head line in the archive collection-head register. #}
+    {% if filter_head %}
+      <p class="saho-archive-collection">
+        <span class="saho-archive-collection__label">{{ 'Filtered:'|t }}</span>
+        {{ filter_head.labels|join(' · ') }}
+        <a class="saho-archive-collection__clear" href="{{ filter_head.clear_url }}"
+           aria-label="{{ 'Clear this filter'|t }}">&#215;</a>
+      </p>
+    {% endif %}
     {# Places carry coordinates, but the map is a results layout (the Map tab
        below), not a separate destination - no header link needed. #}
     {# Timelines carry dates: offer the interactive timeline as an alternate


### PR DESCRIPTION
## What

Term pages like `/taxonomy/member-organisation/anc-african-national-congress` were dead-end listings. For eight mapped vocabularies the canonical term route now 301s into the Open Record landing with the term pre-applied - so every term tag on a record page opens the full register (facet chips, search, table/cards/map toggle, load-more) one click deeper into the archive.

| Vocabulary | Target |
|---|---|
| member_of_organisation (47) | `/biographies?org[TID]` *(new URL-only filter)* |
| prison_list (26) | `/biographies?prison[TID]` *(new)* |
| field_people_category (10) | `/biographies?tid_1[TID]` |
| field_people_level3_cat (49) | `/biographies?register[TID]` |
| field_place_type (96) | `/places?ptype[TID]` *(new)* |
| field_places_level3 (10) | `/places?tid_2[TID]` |
| saldru_archive_topic (45) | `/archives?saldru[Label]` |
| field_media_library_type (41) | `/archives?type[Label]` |

**Untouched**: african_country (the Africa page_2 architecture), caps_topic (classroom), keywords/features/tags (junk vocabs - 99.8% of keywords terms are empty). Their term pages render as before.

## How

- **`term_registers` submodule** (saho_utils): REQUEST-phase subscriber, priority 30, canonical route only (edit/admin/JSON:API routes untouched). Cacheable `LocalRedirectResponse` 301 carrying the term's and the settings' cache tags. **Kill-switch**: `drush cset term_registers.settings enabled 0` - verified flipping redirects off/on live with zero cache rebuild.
- **Three new bef_hidden view filters** (org/prison/ptype) cloned from the established `register` recipe - inert without URL params.
- **Visible scope**: the landing shell resolves hidden filter params to a mono "Filtered: {term} ×" head (archive collection-head classes, zero new CSS) with a surgical clear link.
- **SEO**: mapped vocabs dropped from the XML sitemap; aliases keep resolving (alias → canonical → 301; term links on record pages need no theme change).

## Verified (Playwright + curl)

- ANC → `/biographies?org[35281]`: 180 records, filter head visible; **composition**: + Lives of Courage chip = 113 (intersection); **load-more keeps the filter** through appended pages (90 of 113); clear × drops only the org param
- All eight vocabs redirect to correct targets (tid- and label-keyed); redirect chains from unaliased `/taxonomy/term/N` complete
- Algeria (african_country) and keywords terms: no redirect; `?page=3` dropped cleanly; empty term (AOL, 0 members) lands on the register empty state; `/edit` routes untouched
- 6 kernel tests (mapped tid/label, unmapped passthrough, empty term, kill-switch, non-canonical route); phpcs CI flags + drupal-check clean

## Deploy notes

- `cim` carries everything (module enable, filters, sitemap flips, settings); `drush simple-sitemap:generate` after deploy
- Rollback without deploy: `drush cset term_registers.settings enabled 0`

**PR only - no release tag.**