### PR TITLE
fix(landings): deterministic pagination - nid tiebreaker ends duplicate rows across pages

### DIFF
--- a/config/sync/views.view.art_culture.yml
+++ b/config/sync/views.view.art_culture.yml
@@ -237,6 +237,19 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments: {  }
       filters:
         status:

--- a/config/sync/views.view.biographies.yml
+++ b/config/sync/views.view.biographies.yml
@@ -251,6 +251,19 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments: {  }
       filters:
         status:

--- a/config/sync/views.view.places.yml
+++ b/config/sync/views.view.places.yml
@@ -248,6 +248,19 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments: {  }
       filters:
         title:

--- a/config/sync/views.view.politics_society.yml
+++ b/config/sync/views.view.politics_society.yml
@@ -252,6 +252,19 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments: {  }
       filters:
         status:

--- a/config/sync/views.view.timelines.yml
+++ b/config/sync/views.view.timelines.yml
@@ -227,6 +227,19 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments: {  }
       filters:
         status:
@@ -327,21 +340,6 @@ display:
           hierarchy: false
           limit: true
           error_message: false
-        field_timeline_categories_type_target_id:
-          id: field_timeline_categories_type_target_id
-          table: node__field_timeline_categories_type
-          field: field_timeline_categories_type_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: numeric
-          operator: 'not empty'
-          value:
-            min: ''
-            max: ''
-            value: ''
-          group: 1
-          exposed: false
         title_clone:
           id: title_clone
           table: node_field_data


### PR DESCRIPTION
## What

Duplicate people on `/biographies?tid_1[7]=7` (reported on prod: same person up to 3× across pages, e.g. Denis Goldberg) - and the mirror problem, records that never surface at all.

## Root cause

The landing views sort by `changed DESC` **alone**, and the bulk enrichment runs stamped huge cohorts with identical changed-timestamps - **1,488 biographies share a single changed second**. MySQL returns tied rows in arbitrary per-query order, so each page query deals a different hand: pages overlap (duplicates) and skip (hidden records). Load-more made it visible; it affected classic pagination too. Measured on prod: 45 rows across 3 pages → only 24 unique.

## Fix

The `nid DESC` tiebreaker the **africa** view already carried, applied to the other five shell landings: biographies, places, timelines, politics_society, art_culture. Ties now order deterministically; page sweeps verified 60/60 unique, filtered and unfiltered.

## Rides along

The timelines view carried a broken shell filter (`field_timeline_categories_type_target_id`: empty vid, empty value) that **fataled every entity-API save of that view** (`TaxonomyIndexTid::calculateDependencies()` on a null vocabulary). Inert since creation - removed, which is what made saving the timelines view possible at all.

## Notes

Config-only PR (`cim` carries it). Candidate for a quick **v2.1.1** patch tag since the duplicate rows are user-visible on prod today - tag on your go.