### PR TITLE
feat(terms): topic-category term pages join the register redirects (art-culture, politics-society)

### DIFF
--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_arts_culture_categories.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_arts_culture_categories.yml
@@ -1,4 +1,4 @@
-index: true
+index: false
 priority: '0.5'
 changefreq: ''
 include_images: false

--- a/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_politics_society_categorie.yml
+++ b/config/sync/simple_sitemap.bundle_settings.default.taxonomy_term.field_politics_society_categorie.yml
@@ -1,4 +1,4 @@
-index: true
+index: false
 priority: '0.5'
 changefreq: ''
 include_images: false

--- a/webroot/modules/custom/saho_utils/term_registers/src/EventSubscriber/TermRegisterRedirectSubscriber.php
+++ b/webroot/modules/custom/saho_utils/term_registers/src/EventSubscriber/TermRegisterRedirectSubscriber.php
@@ -47,6 +47,10 @@ final class TermRegisterRedirectSubscriber implements EventSubscriberInterface {
     'field_places_level3' => ['path' => '/places', 'param' => 'tid_2', 'mode' => 'tid'],
     'saldru_archive_topic' => ['path' => '/archives', 'param' => 'saldru', 'mode' => 'label'],
     'field_media_library_type' => ['path' => '/archives', 'param' => 'type', 'mode' => 'label'],
+    // Topic-section categories land on their topic shell; both filters are
+    // EXPOSED chips there, so the applied term ticks visibly on arrival.
+    'field_arts_culture_categories' => ['path' => '/art-culture', 'param' => 'tid_1', 'mode' => 'tid'],
+    'field_politics_society_categorie' => ['path' => '/politics-society', 'param' => 'tid', 'mode' => 'tid'],
   ];
 
   public function __construct(

--- a/webroot/modules/custom/saho_utils/term_registers/tests/src/Kernel/TermRegisterRedirectSubscriberTest.php
+++ b/webroot/modules/custom/saho_utils/term_registers/tests/src/Kernel/TermRegisterRedirectSubscriberTest.php
@@ -43,7 +43,7 @@ final class TermRegisterRedirectSubscriberTest extends KernelTestBase {
     $this->installEntitySchema('taxonomy_term');
     $this->installEntitySchema('user');
     $this->installConfig(['term_registers']);
-    foreach (['member_of_organisation', 'saldru_archive_topic', 'african_country'] as $vid) {
+    foreach (['member_of_organisation', 'saldru_archive_topic', 'african_country', 'field_arts_culture_categories'] as $vid) {
       Vocabulary::create(['vid' => $vid, 'name' => $vid])->save();
     }
   }
@@ -88,6 +88,19 @@ final class TermRegisterRedirectSubscriberTest extends KernelTestBase {
     $response = $event->getResponse();
     $this->assertInstanceOf(LocalRedirectResponse::class, $response);
     $this->assertSame('/archives?saldru%5BLabour%5D=Labour', $response->getTargetUrl());
+  }
+
+  /**
+   * Topic-section categories land on their topic shell with the chip set.
+   */
+  public function testTopicCategoryRedirect(): void {
+    $term = Term::create(['vid' => 'field_arts_culture_categories', 'name' => 'Sport']);
+    $term->save();
+    $event = $this->dispatch($term);
+    $response = $event->getResponse();
+    $this->assertInstanceOf(LocalRedirectResponse::class, $response);
+    $tid = $term->id();
+    $this->assertSame("/art-culture?tid_1%5B$tid%5D=$tid", $response->getTargetUrl());
   }
 
   /**


### PR DESCRIPTION
## What

Extends the term-register redirects (#535) to the topic-section category vocabularies, as expected from `/taxonomy/arts-culture-categories/sport`:

| Vocabulary | Target |
|---|---|
| field_arts_culture_categories (9) | `/art-culture?tid_1[TID]` |
| field_politics_society_categorie (10) | `/politics-society?tid[TID]` |

Both filters are **exposed chips** on those landings - the applied category ticks visibly on arrival, so no new view filters and no filter-head work were needed. Two MAP rows + sitemap exclusions.

## Verified

- `/taxonomy/arts-culture-categories/sport` → 301 → `/art-culture?tid_1[58]=58` (6 records, Sport chip checked)
- politics category term → 301 → `/politics-society?tid[46]=46`
- 7 kernel tests (new topic-category case), phpcs CI flags clean

Config-only + one const row; `cim` carries it. **No release tag** - rides with #537 whenever you tag.