### PR TITLE
fix(brand): SAHO was founded in 1998, not 2000

### DIFF
--- a/webroot/modules/custom/saho_tools/src/Service/Builder/OrganizationSchemaBuilder.php
+++ b/webroot/modules/custom/saho_tools/src/Service/Builder/OrganizationSchemaBuilder.php
@@ -37,7 +37,7 @@ class OrganizationSchemaBuilder extends SchemaBuilderBase {
       'legalName' => 'South African History Online',
       'url' => $base_url,
       'description' => 'South African History Online (SAHO) is a non-profit organization dedicated to making South African history accessible to all. We provide free, educational resources about South African history, including articles, biographies, archives, and educational materials.',
-      'foundingDate' => '2000',
+      'foundingDate' => '1998',
       'slogan' => 'Towards a people\'s history',
     ];
 

--- a/webroot/modules/custom/saho_tools/templates/llm-txt.html.twig
+++ b/webroot/modules/custom/saho_tools/templates/llm-txt.html.twig
@@ -3,7 +3,7 @@
 > South African History Online (SAHO) is a non-profit educational organization dedicated to making South African history accessible to all. We provide free, peer-reviewed historical content including articles, biographies, archives, events, and educational resources. Content is licensed CC BY-NC-SA 4.0. Last updated: {{ last_updated }}.
 
 **Mission**: Towards a people's history
-**Founded**: 2000
+**Founded**: 1998
 **License**: Creative Commons BY-NC-SA 4.0
 **Base URL**: {{ base_url }}
 

--- a/webroot/themes/custom/saho/templates/content/header.html.twig
+++ b/webroot/themes/custom/saho/templates/content/header.html.twig
@@ -26,7 +26,7 @@
       <span class="saho-logo-wordmark" aria-hidden="true">
         <span class="saho-logo-wordmark__line1">South African</span>
         <span class="saho-logo-wordmark__line2">History Online</span>
-        <span class="saho-logo-wordmark__tagline">The open record &middot; est. 2000</span>
+        <span class="saho-logo-wordmark__tagline">The open record &middot; est. 1998</span>
       </span>
     </a>
 


### PR DESCRIPTION
The site claimed est. 2000 in three baked-in places; SAHO was founded in **1998**. Fixed:

- Header wordmark tagline: "The open record · est. 1998"
- schema.org Organization `foundingDate`: 1998
- `/llms.txt` **Founded** line: 1998

Verified all three rendering locally; repo-wide sweep found no other founding-year references. No release tag - rides the next one (with a Cloudflare purge, since the header is on every cached page).