### PR TITLE
fix(relations): deterministic sibling builds - ordered query + sorted cap selection

### DIFF
--- a/webroot/modules/custom/saho_relations/src/Drush/Commands/SahoRelationsCommands.php
+++ b/webroot/modules/custom/saho_relations/src/Drush/Commands/SahoRelationsCommands.php
@@ -463,12 +463,20 @@ final class SahoRelationsCommands extends DrushCommands {
     $source_bundles = ['article', 'biography', 'event', 'place', 'image'];
     $target_bundles = ['biography', 'article'];
 
-    // One pass: published parent -> [child => bundle].
+    // One pass: published parent -> [child => bundle]. ORDER BY matters:
+    // without it, MySQL's physical row order decides which candidates fill
+    // each node's cap - and that order shifts whenever tables are rebuilt
+    // (backups, OPTIMIZE/repair). A shifted order made the 2026-07-21
+    // deploy append 10,112 "new" edges to already-converged nodes. With a
+    // deterministic order the same candidates win every run, so a
+    // converged graph stays converged.
     $q = $this->database->select('node__field_feature_parent', 'p');
     $q->join('node_field_data', 'n', 'n.nid = p.entity_id AND n.status = 1');
     $q->addField('p', 'field_feature_parent_target_id', 'pid');
     $q->addField('p', 'entity_id', 'nid');
     $q->addField('n', 'type', 'bundle');
+    $q->orderBy('p.field_feature_parent_target_id');
+    $q->orderBy('p.entity_id');
     $collections = [];
     foreach ($q->execute() as $row) {
       $collections[(int) $row->pid][(int) $row->nid] = $row->bundle;
@@ -501,7 +509,14 @@ final class SahoRelationsCommands extends DrushCommands {
       }
     }
 
-    // Build capped edges (cap is now a real per-node total).
+    // Build capped edges (cap is now a real per-node total). Sorting the
+    // sources and each node's targets pins WHICH candidates fill the cap
+    // (lowest nid first) - the second half of the determinism guarantee.
+    ksort($by_source);
+    foreach ($by_source as &$sort_targets) {
+      ksort($sort_targets);
+    }
+    unset($sort_targets);
     $edges = [];
     $processed = 0;
     foreach ($by_source as $nid => $targets) {


### PR DESCRIPTION
## The bug

`saho:relations-siblings` built candidates from a no-ORDER-BY select and filled each node's cap-12 with the **first candidates in physical row order**. Table rebuilds (the backup/check-repair session) reshuffled that order, so the 2026-07-21 v2.2.1 deploy appended **10,112 'new' edges to 1,469 converged nodes** - hundreds of nodes now sit at exactly 24 links (cap-12 picked twice under two orderings). Nothing was ever deleted; watchdog + revision forensics confirmed it, and prod's 24-wall was the fingerprint.

## The fix

- `ORDER BY` parent/child on the collections select
- `ksort` on sources and each node's target set before the cap - lowest-nid candidates win, every run, on every environment

**Proof**: two consecutive full dry runs now produce byte-identical plans (`IDENTICAL` diff); 19 relations kernel tests green, phpcs CI-flags clean.

## Data decision (made)

The doubled links stay - spot-checks found the additions good, and they are genuine collection siblings. Expect **one more settling apply** on the next prod deploy (the deterministic picks joining the existing set), after which every run reads `0 added` - and the enrichment becomes a candidate to move out of the deploy pipeline into a weekly cron (separate follow-up, along with checksum-skipping the deck sync).

**No release tag.**