### PR TITLE
fix(tdih): de-dupe the event-page date-search card

### DIFF
--- a/webroot/modules/custom/saho_utils/tdih/js/tdih-interactive.js
+++ b/webroot/modules/custom/saho_utils/tdih/js/tdih-interactive.js
@@ -25,17 +25,6 @@
         }
       });
 
-      // Ensure Today in History section is always visible
-      once('tdih-visibility', '.tdih-interactive-block', context).forEach(function (element) {
-        var $block = $(element);
-        var $wrapper = $block.find('.tdih-today-history-wrapper');
-
-        // Ensure the wrapper is always visible
-        if ($wrapper.length) {
-          $wrapper.show();
-        }
-      });
-
       // Add hover effects to event items.
       once('tdih-hover', '.tdih-event-item', context).forEach(function (element) {
         $(element).hover(

--- a/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Plugin/Block/TdihInteractiveBlock.php
@@ -482,6 +482,7 @@ class TdihInteractiveBlock extends BlockBase implements ContainerFactoryPluginIn
       '#show_details_button' => $this->configuration['show_details_button'],
       '#show_more_link' => $this->configuration['show_more_link'] ?? TRUE,
       '#use_todays_date' => $this->configuration['use_todays_date'],
+      '#picker_open' => $this->configuration['picker_open'] ?? NULL,
       '#attached' => [
         'library' => [
           'tdih/tdih-interactive',

--- a/webroot/modules/custom/saho_utils/tdih/tdih.libraries.yml
+++ b/webroot/modules/custom/saho_utils/tdih/tdih.libraries.yml
@@ -1,5 +1,5 @@
 tdih-interactive:
-  version: 1.0
+  version: 1.1
   css:
     theme:
       css/tdih-interactive.css: {}
@@ -10,3 +10,12 @@ tdih-interactive:
     - core/drupal
     - core/drupalSettings
     - core/once
+    - core/drupal.ajax
+
+tdih-page:
+  version: 1.1
+  css:
+    theme:
+      css/tdih-page.css: {}
+  dependencies:
+    - core/drupal

--- a/webroot/modules/custom/saho_utils/tdih/tdih.module
+++ b/webroot/modules/custom/saho_utils/tdih/tdih.module
@@ -28,6 +28,7 @@ function tdih_theme($existing, $type, $theme, $path) {
         'show_details_button' => TRUE,
         'show_more_link' => TRUE,
         'use_todays_date' => FALSE,
+        'picker_open' => NULL,
       ],
       'template' => 'block--tdih-interactive',
     ],
@@ -50,45 +51,6 @@ function tdih_theme($existing, $type, $theme, $path) {
       'template' => 'tdih-birthday-events',
     ],
   ];
-}
-
-/**
- * Implements hook_library_info_build().
- */
-function tdih_library_info_build() {
-  $libraries = [];
-
-  $libraries['tdih-interactive'] = [
-    'version' => '1.0',
-    'css' => [
-      'theme' => [
-        'css/tdih-interactive.css' => [],
-      ],
-    ],
-    'js' => [
-      'js/tdih-interactive.js' => [],
-    ],
-    'dependencies' => [
-      'core/jquery',
-      'core/drupal',
-      'core/drupalSettings',
-      'core/drupal.ajax',
-    ],
-  ];
-
-  $libraries['tdih-page'] = [
-    'version' => '1.0',
-    'css' => [
-      'theme' => [
-        'css/tdih-page.css' => [],
-      ],
-    ],
-    'dependencies' => [
-      'core/drupal',
-    ],
-  ];
-
-  return $libraries;
 }
 
 /**

--- a/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
+++ b/webroot/modules/custom/saho_utils/tdih/templates/block--tdih-interactive.html.twig
@@ -79,9 +79,12 @@
        a quiet mono invitation, not a form block. On instances that do
        NOT show the today-ledger (the /this-day-in-history page), the
        form and its default today results ARE the page's content, so the
-       disclosure defaults open - a closed one left that page empty. #}
+       disclosure defaults open - a closed one left that page empty.
+       picker_open (when set) overrides that heuristic: the event-node
+       embed hides the ledger too but is an aside, not the page. #}
     {% if date_picker_form %}
-      <details class="tdih-birthday-disclosure"{% if not show_today_history %} open{% endif %}>
+      {% set birthday_open = picker_open is same as(null) ? not show_today_history : picker_open %}
+      <details class="tdih-birthday-disclosure"{% if birthday_open %} open{% endif %}>
         <summary class="tdih-birthday-summary">{{ 'What happened on your birthday?'|t }} <span aria-hidden="true">&rarr;</span></summary>
         <div class="tdih-birthday-picker" role="search" aria-label="{{ 'Search historical events by date'|t }}">
           {{ date_picker_form }}

--- a/webroot/themes/custom/saho/saho.theme
+++ b/webroot/themes/custom/saho/saho.theme
@@ -450,6 +450,11 @@ function saho_preprocess_node(array &$variables) {
       'show_today_history' => FALSE,
       'show_explore_button' => FALSE,
       'show_header_title' => FALSE,
+      // The card is an aside on an event page: one closed picker
+      // disclosure and one view-more link (the footer fallback), not
+      // the /this-day-in-history everything-open arrangement.
+      'show_more_link' => FALSE,
+      'picker_open' => FALSE,
     ];
 
     $plugin_block = $block_manager->createInstance('tdih_interactive_block', $config);


### PR DESCRIPTION
The 'Search events by date' card on event nodes stacked **two** 'View more events from this day' links, the birthday summary **and** its open picker form with its own heading - four doors to the same place.

### Causes and fixes
1. **JS force-show**: `tdih-interactive.js` unconditionally showed `.tdih-today-history-wrapper`, defeating the template's `show_today_history` hiding and leaking the wrapper's view-more link. Removed - the day/month form renders results into its own container.
2. **Disclosure open-heuristic too broad**: the picker opened whenever the ledger was hidden (designed for /this-day-in-history where the form IS the page). New `picker_open` theme variable (default NULL keeps the heuristic) lets the event embed close it.
3. **Event embed config**: now passes `show_more_link: FALSE` + `picker_open: FALSE` - exactly one view-more link remains.

### Bonus root-cause
`tdih_library_info_build()` re-defined `tdih-interactive` in PHP (v1.0, missing `core/once`), silently clobbering `tdih.libraries.yml` - version bumps there were no-ops so browsers kept stale JS. Hook deleted; both libraries consolidated in YAML at v1.1 (busts every client cache).

### Verified (Playwright)
- Event card: header + closed 'What happened on your birthday?' line + one link
- Picker AJAX: 16 June → 18 events rendered in-card
- No regression: front page ledger + lead image intact; /this-day-in-history keeps open form with default today results
- Console: only pre-existing noise (CSP report-only, one unrelated 404 derivative)

phpcs clean (CI flags) on tdih + saho.theme.