### PR TITLE
perf(cache): cache the two hottest custom queries as nid lists

### DIFF
--- a/webroot/modules/custom/saho_suggested_reading/saho_suggested_reading.module
+++ b/webroot/modules/custom/saho_suggested_reading/saho_suggested_reading.module
@@ -371,72 +371,12 @@ function _saho_suggested_reading_get_entity_image_url(FieldableEntityInterface $
 
 /**
  * Query entities that have images using database joins.
+ *
+ * Thin shim over the cached SuggestedReadingQuery service - the 10-join
+ * query behind this was the site's biggest database consumer, so its nid
+ * lists are cached per condition set (6h TTL, saho_suggested_reading tag).
  */
 function _saho_suggested_reading_query_entities_with_images($conditions = [], $limit = 6) {
-  $database = \Drupal::database();
-
-  // Build the base query.
-  $query = $database->select('node_field_data', 'n');
-  $query->fields('n', ['nid']);
-  $query->condition('n.status', 1);
-  $query->condition('n.type', ['article', 'biography', 'archive', 'place', 'event'], 'IN');
-
-  // Exclude specific node if provided.
-  if (!empty($conditions['exclude_nid'])) {
-    $query->condition('n.nid', $conditions['exclude_nid'], '!=');
-  }
-
-  // Join with image field tables to ensure images exist.
-  $image_joins = [
-    // Articles: field_article_image OR field_feature_banner.
-    'article' => ['field_article_image', 'field_feature_banner'],
-    // Biographies: field_bio_pic OR field_feature_banner.
-    'biography' => ['field_bio_pic', 'field_feature_banner'],
-    // Archives: field_archive_image OR field_image.
-    'archive' => ['field_archive_image', 'field_image'],
-    // Places: field_place_image OR field_feature_banner.
-    'place' => ['field_place_image', 'field_feature_banner'],
-    // Events: field_event_image OR field_tdih_image.
-    'event' => ['field_event_image', 'field_tdih_image'],
-  ];
-
-  // Create a complex OR condition for images across all content types.
-  $image_condition = $query->orConditionGroup();
-
-  foreach ($image_joins as $bundle => $fields) {
-    $bundle_condition = $query->andConditionGroup();
-    $bundle_condition->condition('n.type', $bundle);
-
-    $field_condition = $query->orConditionGroup();
-    foreach ($fields as $field) {
-      $alias = 'img_' . $bundle . '_' . str_replace('field_', '', $field);
-      $query->leftJoin('node__' . $field, $alias, $alias . '.entity_id = n.nid AND ' . $alias . '.bundle = :bundle_' . $alias, [':bundle_' . $alias => $bundle]);
-      $field_condition->isNotNull($alias . '.' . $field . '_target_id');
-    }
-
-    $bundle_condition->condition($field_condition);
-    $image_condition->condition($bundle_condition);
-  }
-
-  $query->condition($image_condition);
-
-  // Add specific field conditions.
-  if (!empty($conditions['field_feature_parent'])) {
-    $query->join('node__field_feature_parent', 'fp', 'fp.entity_id = n.nid');
-    $query->condition('fp.field_feature_parent_target_id', $conditions['field_feature_parent']);
-  }
-
-  if (!empty($conditions['field_tags'])) {
-    $query->join('node__field_tags', 'ft', 'ft.entity_id = n.nid');
-    $query->condition('ft.field_tags_target_id', $conditions['field_tags'], 'IN');
-  }
-
-  // Order and limit.
-  $query->orderBy('n.created', 'DESC');
-  $query->range(0, $limit);
-
-  $result = $query->execute();
-  $nids = $result->fetchCol();
-
-  return !empty($nids) ? \Drupal::entityTypeManager()->getStorage('node')->loadMultiple($nids) : [];
+  return \Drupal::service('saho_suggested_reading.query')
+    ->getEntitiesWithImages($conditions, (int) $limit);
 }

--- a/webroot/modules/custom/saho_suggested_reading/saho_suggested_reading.services.yml
+++ b/webroot/modules/custom/saho_suggested_reading/saho_suggested_reading.services.yml
@@ -1,0 +1,4 @@
+services:
+  saho_suggested_reading.query:
+    class: Drupal\saho_suggested_reading\SuggestedReadingQuery
+    arguments: ['@database', '@entity_type.manager', '@cache.default', '@datetime.time']

--- a/webroot/modules/custom/saho_suggested_reading/src/SuggestedReadingQuery.php
+++ b/webroot/modules/custom/saho_suggested_reading/src/SuggestedReadingQuery.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\saho_suggested_reading;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Component\Utility\Crypt;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Cached lookup of nodes that have images, for the suggested-reading band.
+ *
+ * The underlying query joins ten image field tables (five bundles x two
+ * fields each) behind an OR of IS NOT NULL conditions - a shape no index
+ * can serve, so every execution walks thousands of rows. It fires up to
+ * four times per cold full-node render, which made it the site's single
+ * biggest database consumer. The nid lists are therefore cached in
+ * cache.default, keyed by the normalized condition set.
+ *
+ * Invalidation is deliberately TTL-only: the five bundles involved are
+ * written continuously (editors plus enrichment tooling), so node_list
+ * tags would flush this cache as often as the render cache above it and
+ * it would never be warm. A suggested-reading band tolerates hours of
+ * staleness invisibly; unpublished or deleted nodes are filtered out on
+ * every hit. The custom tag is an editorial kill switch:
+ *
+ * @code
+ * drush ev '\Drupal::service("cache_tags.invalidator")
+ *   ->invalidateTags(["saho_suggested_reading"]);'
+ * @endcode
+ */
+class SuggestedReadingQuery {
+
+  /**
+   * Cache tag used as a manual kill switch for all cached lists.
+   */
+  public const CACHE_TAG = 'saho_suggested_reading';
+
+  /**
+   * Seconds a cached nid list stays valid.
+   */
+  protected const CACHE_MAX_AGE = 21600;
+
+  /**
+   * Nids fetched and cached per condition set.
+   *
+   * Always the band maximum (12) regardless of the caller's limit, so one
+   * cache entry serves every call site and still has headroom after the
+   * excluded nid and any stale unpublished nodes are dropped in PHP.
+   */
+  protected const FETCH_LIMIT = 12;
+
+  /**
+   * Constructs the service.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
+   *   The default cache bin.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   */
+  public function __construct(
+    protected readonly Connection $database,
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
+    protected readonly CacheBackendInterface $cache,
+    protected readonly TimeInterface $time,
+  ) {}
+
+  /**
+   * Returns published nodes with images matching the given conditions.
+   *
+   * @param array $conditions
+   *   Supported keys: field_feature_parent (parent nid), field_tags
+   *   (array of term ids), exclude_nid (nid to omit from the result).
+   * @param int $limit
+   *   Maximum number of nodes to return.
+   *
+   * @return \Drupal\node\NodeInterface[]
+   *   Published nodes keyed by nid, newest first, at most $limit items.
+   */
+  public function getEntitiesWithImages(array $conditions, int $limit): array {
+    // exclude_nid is stripped from both the query and the cache key and
+    // applied in PHP below - otherwise every node on the site would get
+    // its own copy of an otherwise identical list. Most importantly the
+    // unfiltered "popular" fallback collapses to one sitewide entry.
+    $exclude_nid = (int) ($conditions['exclude_nid'] ?? 0);
+    $normalized = $this->normalizeConditions($conditions);
+    $cid = $this->buildCid($normalized);
+
+    $cached = $this->cache->get($cid);
+    if ($cached !== FALSE) {
+      $nodes = $this->filterNodes($cached->data, $exclude_nid);
+      if ($nodes !== [] || $cached->data === []) {
+        return array_slice($nodes, 0, $limit, TRUE);
+      }
+      // A non-empty cached list that filters down to nothing means the
+      // listed nodes were unpublished or deleted mid-TTL - recompute once
+      // rather than serving an empty band for hours.
+    }
+
+    $nids = $this->queryNids($normalized);
+    $this->cache->set(
+      $cid,
+      $nids,
+      $this->time->getRequestTime() + static::CACHE_MAX_AGE,
+      [static::CACHE_TAG]
+    );
+    return array_slice($this->filterNodes($nids, $exclude_nid), 0, $limit, TRUE);
+  }
+
+  /**
+   * Runs the image-availability query and returns matching nids.
+   *
+   * Protected so tests can substitute fixture nids instead of mocking the
+   * dynamic select builder.
+   *
+   * @param array $conditions
+   *   Normalized conditions (no exclude_nid, sorted tag ids).
+   *
+   * @return array
+   *   Node ids, newest first, at most FETCH_LIMIT items.
+   */
+  protected function queryNids(array $conditions): array {
+    $query = $this->database->select('node_field_data', 'n');
+    $query->fields('n', ['nid']);
+    $query->condition('n.status', 1);
+    $query->condition('n.type', ['article', 'biography', 'archive', 'place', 'event'], 'IN');
+
+    // Join with image field tables to ensure images exist.
+    $image_joins = [
+      // Articles: field_article_image OR field_feature_banner.
+      'article' => ['field_article_image', 'field_feature_banner'],
+      // Biographies: field_bio_pic OR field_feature_banner.
+      'biography' => ['field_bio_pic', 'field_feature_banner'],
+      // Archives: field_archive_image OR field_image.
+      'archive' => ['field_archive_image', 'field_image'],
+      // Places: field_place_image OR field_feature_banner.
+      'place' => ['field_place_image', 'field_feature_banner'],
+      // Events: field_event_image OR field_tdih_image.
+      'event' => ['field_event_image', 'field_tdih_image'],
+    ];
+
+    // Create a complex OR condition for images across all content types.
+    $image_condition = $query->orConditionGroup();
+
+    foreach ($image_joins as $bundle => $fields) {
+      $bundle_condition = $query->andConditionGroup();
+      $bundle_condition->condition('n.type', $bundle);
+
+      $field_condition = $query->orConditionGroup();
+      foreach ($fields as $field) {
+        $alias = 'img_' . $bundle . '_' . str_replace('field_', '', $field);
+        $query->leftJoin('node__' . $field, $alias, $alias . '.entity_id = n.nid AND ' . $alias . '.bundle = :bundle_' . $alias, [':bundle_' . $alias => $bundle]);
+        $field_condition->isNotNull($alias . '.' . $field . '_target_id');
+      }
+
+      $bundle_condition->condition($field_condition);
+      $image_condition->condition($bundle_condition);
+    }
+
+    $query->condition($image_condition);
+
+    // Add specific field conditions.
+    if (!empty($conditions['field_feature_parent'])) {
+      $query->join('node__field_feature_parent', 'fp', 'fp.entity_id = n.nid');
+      $query->condition('fp.field_feature_parent_target_id', $conditions['field_feature_parent']);
+    }
+
+    if (!empty($conditions['field_tags'])) {
+      $query->join('node__field_tags', 'ft', 'ft.entity_id = n.nid');
+      $query->condition('ft.field_tags_target_id', $conditions['field_tags'], 'IN');
+    }
+
+    // Order and limit.
+    $query->orderBy('n.created', 'DESC');
+    $query->range(0, static::FETCH_LIMIT);
+
+    return array_map('intval', $query->execute()->fetchCol());
+  }
+
+  /**
+   * Normalizes a conditions array into a canonical, cache-safe form.
+   *
+   * Equivalent inputs must produce identical cache keys: exclude_nid is
+   * dropped (handled in PHP), tag ids are cast and sorted, keys are
+   * ordered, and empty values are removed to match the query's own
+   * empty() guards.
+   *
+   * @param array $conditions
+   *   Raw caller conditions.
+   *
+   * @return array
+   *   The canonical conditions.
+   */
+  protected function normalizeConditions(array $conditions): array {
+    unset($conditions['exclude_nid']);
+    if (!empty($conditions['field_tags'])) {
+      $tags = array_map('intval', (array) $conditions['field_tags']);
+      sort($tags, SORT_NUMERIC);
+      $conditions['field_tags'] = array_values($tags);
+    }
+    if (!empty($conditions['field_feature_parent'])) {
+      $conditions['field_feature_parent'] = (int) $conditions['field_feature_parent'];
+    }
+    $conditions = array_filter($conditions, static fn($value) => !empty($value));
+    ksort($conditions);
+    return $conditions;
+  }
+
+  /**
+   * Builds the cache id for a normalized condition set.
+   *
+   * @param array $normalized
+   *   The canonical conditions.
+   *
+   * @return string
+   *   The cache id.
+   */
+  protected function buildCid(array $normalized): string {
+    return 'saho_suggested_reading:img_nids:' . Crypt::hashBase64(serialize($normalized));
+  }
+
+  /**
+   * Loads a nid list and drops excluded, unpublished and deleted nodes.
+   *
+   * Cached lists can go stale within the TTL window: deleted nodes fall
+   * out of loadMultiple() by themselves, unpublished ones are filtered
+   * here. Published-only is also the effective access policy - the site
+   * has no node-grants modules, so no per-user check is needed on a
+   * shared cache.
+   *
+   * @param array $nids
+   *   The nid list.
+   * @param int $exclude_nid
+   *   A nid to omit (0 for none).
+   *
+   * @return \Drupal\node\NodeInterface[]
+   *   Published nodes keyed by nid.
+   */
+  protected function filterNodes(array $nids, int $exclude_nid): array {
+    $nids = array_filter($nids, static fn($nid) => (int) $nid !== $exclude_nid);
+    if ($nids === []) {
+      return [];
+    }
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+    return array_filter(
+      $nodes,
+      static fn($node) => $node instanceof NodeInterface && $node->isPublished()
+    );
+  }
+
+}

--- a/webroot/modules/custom/saho_suggested_reading/tests/src/Unit/SuggestedReadingQueryTest.php
+++ b/webroot/modules/custom/saho_suggested_reading/tests/src/Unit/SuggestedReadingQueryTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_suggested_reading\Unit;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\saho_suggested_reading\SuggestedReadingQuery;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the cached nid-list layer of the suggested-reading query.
+ *
+ * The SQL itself is not under test - the test subclass substitutes
+ * fixture nids for queryNids() - the caching contract is: stable cache
+ * ids for equivalent conditions, exclude_nid handled outside the cache,
+ * unpublished nodes filtered on hits, empty results cached, and a
+ * recompute when a stale list filters down to nothing.
+ *
+ * @coversDefaultClass \Drupal\saho_suggested_reading\SuggestedReadingQuery
+ * @group saho_suggested_reading
+ */
+class SuggestedReadingQueryTest extends UnitTestCase {
+
+  /**
+   * Frozen request time used across the tests.
+   */
+  private const REQUEST_TIME = 1_700_000_000;
+
+  /**
+   * Builds the test service with fixture nids and a node map.
+   *
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
+   *   The cache mock.
+   * @param array $fixture_nids
+   *   Nids queryNids() returns on every invocation.
+   * @param array $node_map
+   *   Available nodes keyed by nid; loadMultiple() intersects with them.
+   *
+   * @return \Drupal\Tests\saho_suggested_reading\Unit\TestSuggestedReadingQuery
+   *   The service, with a public $queryCalls invocation log.
+   */
+  private function buildService(CacheBackendInterface $cache, array $fixture_nids = [], array $node_map = []): TestSuggestedReadingQuery {
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('loadMultiple')->willReturnCallback(
+      static fn(array $nids) => array_intersect_key($node_map, array_flip($nids))
+    );
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('node')->willReturn($storage);
+
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getRequestTime')->willReturn(self::REQUEST_TIME);
+
+    return new TestSuggestedReadingQuery(
+      $this->createMock(Connection::class),
+      $entity_type_manager,
+      $cache,
+      $time,
+      $fixture_nids,
+    );
+  }
+
+  /**
+   * Builds a node mock with a fixed published state.
+   */
+  private function mockNode(bool $published): NodeInterface {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('isPublished')->willReturn($published);
+    return $node;
+  }
+
+  /**
+   * @covers ::normalizeConditions
+   * @covers ::buildCid
+   */
+  public function testEquivalentConditionsShareOneCacheId(): void {
+    $seen_cids = [];
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cache->method('get')->willReturnCallback(function (string $cid) use (&$seen_cids) {
+      $seen_cids[] = $cid;
+      return FALSE;
+    });
+
+    $service = $this->buildService($cache);
+    // Different tag order, string vs int ids, different excluded nid,
+    // different key order - all the same effective query.
+    $service->getEntitiesWithImages(['field_tags' => [3, 1, 2], 'exclude_nid' => 7], 4);
+    $service->getEntitiesWithImages(['exclude_nid' => 9, 'field_tags' => ['2', '3', '1']], 4);
+
+    $this->assertCount(2, $seen_cids);
+    $this->assertSame($seen_cids[0], $seen_cids[1]);
+    $this->assertSame(
+      [['field_tags' => [1, 2, 3]], ['field_tags' => [1, 2, 3]]],
+      $service->queryCalls,
+      'queryNids receives normalized conditions without exclude_nid.'
+    );
+  }
+
+  /**
+   * @covers ::getEntitiesWithImages
+   */
+  public function testColdPathPrimesCacheWithFullList(): void {
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cache->method('get')->willReturn(FALSE);
+    $cache->expects($this->once())->method('set')->with(
+      $this->stringStartsWith('saho_suggested_reading:img_nids:'),
+      [11, 12],
+      self::REQUEST_TIME + 21600,
+      [SuggestedReadingQuery::CACHE_TAG],
+    );
+
+    $node_map = [11 => $this->mockNode(TRUE), 12 => $this->mockNode(TRUE)];
+    $service = $this->buildService($cache, [11, 12], $node_map);
+
+    $nodes = $service->getEntitiesWithImages(['field_feature_parent' => '42'], 6);
+    $this->assertSame([11, 12], array_keys($nodes));
+    $this->assertSame([['field_feature_parent' => 42]], $service->queryCalls);
+  }
+
+  /**
+   * @covers ::getEntitiesWithImages
+   * @covers ::filterNodes
+   */
+  public function testWarmPathFiltersExcludedAndUnpublished(): void {
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cache->method('get')->willReturn((object) ['data' => [1, 2, 3, 4]]);
+    $cache->expects($this->never())->method('set');
+
+    $node_map = [
+      1 => $this->mockNode(TRUE),
+      // Nid 2 was unpublished after the list was cached.
+      2 => $this->mockNode(FALSE),
+      3 => $this->mockNode(TRUE),
+      4 => $this->mockNode(TRUE),
+    ];
+    $service = $this->buildService($cache, [], $node_map);
+
+    // Nid 3 is the page being viewed - excluded in PHP, not in the key.
+    $nodes = $service->getEntitiesWithImages(['exclude_nid' => 3], 6);
+    $this->assertSame([1, 4], array_keys($nodes));
+    $this->assertSame([], $service->queryCalls, 'A warm hit never runs the query.');
+
+    // A tighter caller limit slices the same cached list.
+    $this->assertSame([1], array_keys($service->getEntitiesWithImages(['exclude_nid' => 3], 1)));
+  }
+
+  /**
+   * @covers ::getEntitiesWithImages
+   */
+  public function testEmptyResultsAreCachedAndServed(): void {
+    // Cold: an empty result is still written to cache...
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cache->method('get')->willReturn(FALSE);
+    $cache->expects($this->once())->method('set')->with(
+      $this->anything(),
+      [],
+      self::REQUEST_TIME + 21600,
+      [SuggestedReadingQuery::CACHE_TAG],
+    );
+    $service = $this->buildService($cache, []);
+    $this->assertSame([], $service->getEntitiesWithImages([], 6));
+    $this->assertCount(1, $service->queryCalls);
+
+    // ...and a warm empty hit is a valid answer, not a recompute trigger.
+    $warm_cache = $this->createMock(CacheBackendInterface::class);
+    $warm_cache->method('get')->willReturn((object) ['data' => []]);
+    $warm_cache->expects($this->never())->method('set');
+    $warm_service = $this->buildService($warm_cache, [99]);
+    $this->assertSame([], $warm_service->getEntitiesWithImages([], 6));
+    $this->assertSame([], $warm_service->queryCalls);
+  }
+
+  /**
+   * @covers ::getEntitiesWithImages
+   */
+  public function testStaleListFilteringToNothingRecomputes(): void {
+    $cache = $this->createMock(CacheBackendInterface::class);
+    // The cached list only holds a node that has since been unpublished.
+    $cache->method('get')->willReturn((object) ['data' => [5]]);
+    $cache->expects($this->once())->method('set')->with(
+      $this->anything(),
+      [6],
+      self::REQUEST_TIME + 21600,
+      [SuggestedReadingQuery::CACHE_TAG],
+    );
+
+    $node_map = [5 => $this->mockNode(FALSE), 6 => $this->mockNode(TRUE)];
+    $service = $this->buildService($cache, [6], $node_map);
+
+    $nodes = $service->getEntitiesWithImages([], 6);
+    $this->assertSame([6], array_keys($nodes), 'The recompute serves fresh nodes.');
+    $this->assertCount(1, $service->queryCalls, 'Exactly one recompute, not a loop.');
+  }
+
+}

--- a/webroot/modules/custom/saho_suggested_reading/tests/src/Unit/TestSuggestedReadingQuery.php
+++ b/webroot/modules/custom/saho_suggested_reading/tests/src/Unit/TestSuggestedReadingQuery.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_suggested_reading\Unit;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\saho_suggested_reading\SuggestedReadingQuery;
+
+/**
+ * Test double that substitutes fixture nids for the SQL layer.
+ *
+ * QueryNids() is the only override: the dynamic select builder is not
+ * worth mocking, and everything else under test is the caching contract.
+ */
+class TestSuggestedReadingQuery extends SuggestedReadingQuery {
+
+  /**
+   * Normalized conditions received by each queryNids() invocation.
+   *
+   * @var array
+   */
+  public array $queryCalls = [];
+
+  /**
+   * Constructs the test double.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
+   *   The default cache bin.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   * @param array $fixtureNids
+   *   Nids queryNids() returns on every invocation.
+   */
+  public function __construct(
+    Connection $database,
+    EntityTypeManagerInterface $entity_type_manager,
+    CacheBackendInterface $cache,
+    TimeInterface $time,
+    private readonly array $fixtureNids,
+  ) {
+    parent::__construct($database, $entity_type_manager, $cache, $time);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function queryNids(array $conditions): array {
+    $this->queryCalls[] = $conditions;
+    return $this->fixtureNids;
+  }
+
+}

--- a/webroot/modules/custom/saho_utils/tdih/src/Service/NodeFetcher.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Service/NodeFetcher.php
@@ -2,13 +2,27 @@
 
 namespace Drupal\tdih\Service;
 
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Service to fetch nodes for "Today in History" logic.
+ *
+ * The month-day lookups use a leading-wildcard LIKE on field_event_date,
+ * which no index can serve - every execution scans the full event table.
+ * The nid lists are therefore cached in cache.default per month-day, tagged
+ * with node_list:event so event saves refresh them immediately, and capped
+ * at 24 hours as a garbage-collection backstop.
  */
 class NodeFetcher {
+
+  /**
+   * Seconds a cached nid list may live without invalidation.
+   */
+  protected const CACHE_MAX_AGE = 86400;
 
   /**
    * The entity type manager.
@@ -25,19 +39,41 @@ class NodeFetcher {
   protected $database;
 
   /**
+   * The default cache bin.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cache;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
    * Constructs a new NodeFetcher object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\Database\Connection $database
    *   The database connection.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
+   *   The default cache bin.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
    */
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     Connection $database,
+    CacheBackendInterface $cache,
+    TimeInterface $time,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->database = $database;
+    $this->cache = $cache;
+    $this->time = $time;
   }
 
   /**
@@ -53,30 +89,36 @@ class NodeFetcher {
    */
   public function loadPotentialEvents($month_day = NULL) {
     try {
-      $query = $this->entityTypeManager->getStorage('node')->getQuery();
-      $query->condition('type', 'event')
-        ->condition('status', 1)
-        ->condition('field_home_page_feature', 1)
-        ->accessCheck(TRUE)
-        ->sort('field_event_date', 'DESC');
+      $filtered = $month_day && $this->isValidMonthDay($month_day);
+      $cid = 'tdih:potential_events:' . ($filtered ? $month_day : 'all');
+      $nids = $this->getCachedNids($cid, function () use ($filtered, $month_day) {
+        $query = $this->entityTypeManager->getStorage('node')->getQuery();
+        $query->condition('type', 'event')
+          ->condition('status', 1)
+          ->condition('field_home_page_feature', 1)
+          // Published-only content feeding a shared, permission-unaware
+          // cache: no per-user access check. The site has no
+          // hook_node_grants() implementations and saho_api_guard never
+          // restricts viewing published nodes - revisit if a node-grants
+          // module is ever installed.
+          ->accessCheck(FALSE)
+          ->sort('field_event_date', 'DESC');
 
-      // If a specific month-day is provided, use LIKE to get potential matches.
-      // Validate format (MM-DD) to prevent LIKE injection attacks.
-      if ($month_day && $this->isValidMonthDay($month_day)) {
-        // Escape LIKE wildcards to prevent injection.
-        $safe_month_day = $this->escapeLikeWildcards($month_day);
-        $query->condition('field_event_date', "%-$safe_month_day", 'LIKE');
-      }
+        // If a specific month-day is provided, use LIKE to get potential
+        // matches. The format was validated (MM-DD) to prevent LIKE
+        // injection attacks; wildcards are escaped as belt-and-braces.
+        if ($filtered) {
+          $safe_month_day = $this->escapeLikeWildcards($month_day);
+          $query->condition('field_event_date', "%-$safe_month_day", 'LIKE');
+        }
 
-      // Limit to reasonable number for performance.
-      $query->range(0, 500);
+        // Limit to reasonable number for performance.
+        $query->range(0, 500);
 
-      $nids = $query->execute();
+        return $query->execute();
+      });
 
-      if ($nids) {
-        $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
-        return $nodes;
-      }
+      return $this->loadPublishedNodes($nids);
     }
     catch (\Exception $e) {
     }
@@ -97,29 +139,29 @@ class NodeFetcher {
    */
   public function loadAllBirthdayEvents($month_day) {
     try {
-      $query = $this->entityTypeManager->getStorage('node')->getQuery();
-      $query->condition('type', 'event')
-        ->condition('status', 1)
-        ->accessCheck(TRUE)
-        ->sort('field_event_date', 'DESC');
+      $filtered = $month_day && $this->isValidMonthDay($month_day);
+      $cid = 'tdih:birthday_events:' . ($filtered ? $month_day : 'all');
+      $nids = $this->getCachedNids($cid, function () use ($filtered, $month_day) {
+        $query = $this->entityTypeManager->getStorage('node')->getQuery();
+        $query->condition('type', 'event')
+          ->condition('status', 1)
+          // See loadPotentialEvents(): shared cache, published-only query,
+          // no grants modules installed.
+          ->accessCheck(FALSE)
+          ->sort('field_event_date', 'DESC');
 
-      // If a specific month-day is provided, use LIKE to get potential matches.
-      // Validate format (MM-DD) to prevent LIKE injection attacks.
-      if ($month_day && $this->isValidMonthDay($month_day)) {
-        // Escape LIKE wildcards to prevent injection.
-        $safe_month_day = $this->escapeLikeWildcards($month_day);
-        $query->condition('field_event_date', "%-$safe_month_day", 'LIKE');
-      }
+        if ($filtered) {
+          $safe_month_day = $this->escapeLikeWildcards($month_day);
+          $query->condition('field_event_date', "%-$safe_month_day", 'LIKE');
+        }
 
-      // Limit to reasonable number for performance.
-      $query->range(0, 500);
+        // Limit to reasonable number for performance.
+        $query->range(0, 500);
 
-      $nids = $query->execute();
+        return $query->execute();
+      });
 
-      if ($nids) {
-        $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
-        return $nodes;
-      }
+      return $this->loadPublishedNodes($nids);
     }
     catch (\Exception $e) {
     }
@@ -137,6 +179,11 @@ class NodeFetcher {
    *   Array of month-day combinations that have events.
    */
   public function getAvailableDates() {
+    $cached = $this->cache->get('tdih:available_dates');
+    if ($cached !== FALSE) {
+      return $cached->data;
+    }
+
     $dates = [];
 
     try {
@@ -168,11 +215,71 @@ class NodeFetcher {
       // Sort the dates for better user experience.
       sort($dates);
 
+      $this->cache->set(
+        'tdih:available_dates',
+        $dates,
+        $this->time->getRequestTime() + static::CACHE_MAX_AGE,
+        ['node_list:event']
+      );
     }
     catch (\Exception $e) {
     }
 
     return $dates;
+  }
+
+  /**
+   * Returns a cached nid list, running the query callback on a miss.
+   *
+   * Empty lists are cached too - a FALSE from the backend is the only
+   * miss signal - so days with no events do not re-scan the event table
+   * on every request.
+   *
+   * @param string $cid
+   *   The cache id.
+   * @param callable $query
+   *   Callback executing the entity query and returning nids.
+   *
+   * @return array
+   *   The nid list.
+   */
+  protected function getCachedNids($cid, callable $query) {
+    $cached = $this->cache->get($cid);
+    if ($cached !== FALSE) {
+      return $cached->data;
+    }
+    $nids = array_values($query() ?: []);
+    $this->cache->set(
+      $cid,
+      $nids,
+      $this->time->getRequestTime() + static::CACHE_MAX_AGE,
+      ['node_list:event']
+    );
+    return $nids;
+  }
+
+  /**
+   * Loads nodes for a nid list, dropping anything no longer published.
+   *
+   * Cached lists can go stale within the TTL window: deleted nodes simply
+   * fall out of loadMultiple(), unpublished ones are filtered here. This
+   * filter is also the access guard that replaced the per-user entity
+   * query access check (published nodes are world-visible on this site).
+   *
+   * @param array $nids
+   *   The nid list.
+   *
+   * @return array
+   *   Array of published Node objects keyed by nid.
+   */
+  protected function loadPublishedNodes(array $nids) {
+    if (!$nids) {
+      return [];
+    }
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+    return array_filter($nodes, function ($node) {
+      return $node instanceof NodeInterface && $node->isPublished();
+    });
   }
 
   /**

--- a/webroot/modules/custom/saho_utils/tdih/tdih.services.yml
+++ b/webroot/modules/custom/saho_utils/tdih/tdih.services.yml
@@ -1,4 +1,4 @@
 services:
   tdih.node_fetcher:
     class: Drupal\tdih\Service\NodeFetcher
-    arguments: ['@entity_type.manager', '@database']
+    arguments: ['@entity_type.manager', '@database', '@cache.default', '@datetime.time']

--- a/webroot/modules/custom/saho_utils/tdih/tests/src/Unit/Service/NodeFetcherTest.php
+++ b/webroot/modules/custom/saho_utils/tdih/tests/src/Unit/Service/NodeFetcherTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\tdih\Unit\Service;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\node\NodeInterface;
+use Drupal\tdih\Service\NodeFetcher;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the cached nid-list layer in the TDIH node fetcher.
+ *
+ * @coversDefaultClass \Drupal\tdih\Service\NodeFetcher
+ * @group tdih
+ */
+class NodeFetcherTest extends UnitTestCase {
+
+  /**
+   * Frozen request time used across the tests.
+   */
+  private const REQUEST_TIME = 1_700_000_000;
+
+  /**
+   * Builds a node mock with a fixed published state.
+   */
+  private function mockNode(bool $published): NodeInterface {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('isPublished')->willReturn($published);
+    return $node;
+  }
+
+  /**
+   * Builds a time mock returning the frozen request time.
+   */
+  private function mockTime(): TimeInterface {
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getRequestTime')->willReturn(self::REQUEST_TIME);
+    return $time;
+  }
+
+  /**
+   * Builds a connection mock whose escapeLike() is a pass-through.
+   */
+  private function mockDatabase(): Connection {
+    $database = $this->createMock(Connection::class);
+    $database->method('escapeLike')->willReturnArgument(0);
+    return $database;
+  }
+
+  /**
+   * @covers ::loadPotentialEvents
+   * @covers ::getCachedNids
+   * @covers ::loadPublishedNodes
+   */
+  public function testColdPathQueriesAndPrimesCache(): void {
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('condition')->willReturnSelf();
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('sort')->willReturnSelf();
+    $query->method('range')->willReturnSelf();
+    $query->method('execute')->willReturn([5 => 5, 9 => 9]);
+
+    $published = $this->mockNode(TRUE);
+    $also_published = $this->mockNode(TRUE);
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('getQuery')->willReturn($query);
+    $storage->method('loadMultiple')->with([5, 9])
+      ->willReturn([5 => $published, 9 => $also_published]);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('node')->willReturn($storage);
+
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cache->method('get')->willReturn(FALSE);
+    $cache->expects($this->once())->method('set')->with(
+      'tdih:potential_events:03-21',
+      [5, 9],
+      self::REQUEST_TIME + 86400,
+      ['node_list:event'],
+    );
+
+    $fetcher = new NodeFetcher($entity_type_manager, $this->mockDatabase(), $cache, $this->mockTime());
+    $nodes = $fetcher->loadPotentialEvents('03-21');
+    $this->assertSame([5 => $published, 9 => $also_published], $nodes);
+  }
+
+  /**
+   * @covers ::loadPotentialEvents
+   * @covers ::getCachedNids
+   * @covers ::loadPublishedNodes
+   */
+  public function testWarmPathSkipsQueryAndFiltersUnpublished(): void {
+    $published = $this->mockNode(TRUE);
+    $unpublished = $this->mockNode(FALSE);
+
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->expects($this->never())->method('getQuery');
+    $storage->method('loadMultiple')->with([5, 9])
+      ->willReturn([5 => $published, 9 => $unpublished]);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('node')->willReturn($storage);
+
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cache->method('get')->with('tdih:potential_events:03-21')
+      ->willReturn((object) ['data' => [5, 9]]);
+    $cache->expects($this->never())->method('set');
+
+    $fetcher = new NodeFetcher($entity_type_manager, $this->mockDatabase(), $cache, $this->mockTime());
+    $nodes = $fetcher->loadPotentialEvents('03-21');
+    $this->assertSame([5 => $published], $nodes, 'The stale unpublished nid is filtered out on hit.');
+  }
+
+  /**
+   * @covers ::loadPotentialEvents
+   * @covers ::loadAllBirthdayEvents
+   * @covers ::getCachedNids
+   */
+  public function testCidsMirrorTheEffectiveQuery(): void {
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('condition')->willReturnSelf();
+    $query->method('accessCheck')->willReturnSelf();
+    $query->method('sort')->willReturnSelf();
+    $query->method('range')->willReturnSelf();
+    $query->method('execute')->willReturn([]);
+
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('getQuery')->willReturn($query);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('node')->willReturn($storage);
+
+    $seen_cids = [];
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cache->method('get')->willReturnCallback(function (string $cid) use (&$seen_cids) {
+      $seen_cids[] = $cid;
+      return FALSE;
+    });
+
+    $fetcher = new NodeFetcher($entity_type_manager, $this->mockDatabase(), $cache, $this->mockTime());
+    // NULL and an impossible date both drop the LIKE condition, so both
+    // must read the unfiltered "all" entry - never a poisoned day key.
+    $fetcher->loadPotentialEvents(NULL);
+    $fetcher->loadPotentialEvents('99-99');
+    // Feb 29 is a valid month-day (leap-year aware) and the birthday list
+    // uses its own prefix so featured and unfeatured lists never mix.
+    $fetcher->loadAllBirthdayEvents('02-29');
+
+    $this->assertSame([
+      'tdih:potential_events:all',
+      'tdih:potential_events:all',
+      'tdih:birthday_events:02-29',
+    ], $seen_cids);
+  }
+
+  /**
+   * @covers ::loadAllBirthdayEvents
+   * @covers ::getCachedNids
+   */
+  public function testEmptyResultsAreCached(): void {
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->expects($this->never())->method('getQuery');
+    $storage->expects($this->never())->method('loadMultiple');
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->with('node')->willReturn($storage);
+
+    // A cached empty list is a valid hit - only FALSE means miss - so a
+    // day without events must not re-run the full event-table scan.
+    $cache = $this->createMock(CacheBackendInterface::class);
+    $cache->method('get')->with('tdih:birthday_events:01-01')
+      ->willReturn((object) ['data' => []]);
+    $cache->expects($this->never())->method('set');
+
+    $fetcher = new NodeFetcher($entity_type_manager, $this->mockDatabase(), $cache, $this->mockTime());
+    $this->assertSame([], $fetcher->loadAllBirthdayEvents('01-01'));
+  }
+
+}


### PR DESCRIPTION
## Why

Production digest profiling (performance_schema enabled 2026-07-22 during the server-tuning session) identified the two top DB-time consumers. Both are index-hostile by construction, so this fixes them with Drupal's cache API at the service layer, where every caller benefits.

| Query | Before | Shape problem |
|---|---|---|
| suggested-reading images query | ~972 calls / 90 min, ~12k rows examined each, 66 ms | 10 LEFT JOINs + OR-of-IS-NOT-NULL across 5 bundles x 2 image fields |
| TDIH month-day lookups (x2 variants) | 151 calls each / 90 min, full event-table scan | leading-wildcard `LIKE '%-MM-DD'` on field_event_date |

## What

**saho_suggested_reading** - new `SuggestedReadingQuery` service (mirrors the `ArchiveCountsService` precedent): nid lists cached per normalized condition set, 6 h TTL, custom `saho_suggested_reading` kill-switch tag (pure TTL because the five bundles are written continuously - node_list tags would flush it as fast as the render cache above it). Key structural win: `exclude_nid` is stripped from the SQL and the cache key and applied in PHP, so the unfiltered popular fallback collapses to **one sitewide cache entry** and sibling/child lookups share one entry per collection parent. The `.module` function is now a thin shim; render-level tags unchanged.

**TDIH** - `NodeFetcher` now caches nid lists per month-day (24 h TTL + `node_list:event` tag, so a newly featured event appears immediately). Covers TdihBlock, TdihInteractiveBlock (build + AJAX), both date forms and the dashboard on-this-day strip with zero caller changes. Empty days are cached too - the AJAX path no longer re-scans the event table for dates with no events.

Both caches store **nids only**, load fresh entities per request, and filter unpublished/deleted nodes on every hit. Queries move to `accessCheck(FALSE)` with an in-code note: no `hook_node_grants()` exists on this site, published nodes are world-visible; revisit if a grants module ever lands.

## Verification

- phpcs (CI flags) clean, drupal-check clean, full unit suite 125/125 passing (9 new tests)
- DDEV: cache rows appear with designed CIDs/tags/expiries; **9 warm page renders added zero executions** of either query digest (render cache disabled locally, so this isolates the data cache)
- Event save invalidates `tdih:*` entries, leaves suggested-reading entries (tag semantics verified through the cache API)
- Playwright: reading band renders 6 image cards on /article/cradle-humankind; homepage TDIH shows 22 July events; date-picker AJAX for 16 June returns Soweto-uprising-day events and primes `tdih:birthday_events:06-16`

## Expected prod effect

The images query drops from ~972/90 min to low tens (TTL lapses only); the LIKE scans drop to a handful per day. Kill switch if the band ever needs a manual refresh:
`drush ev '\Drupal::service("cache_tags.invalidator")->invalidateTags(["saho_suggested_reading"]);'`