### PR TITLE
perf(cache): restrict local-tasks blocks to authenticated users

### DIFF
--- a/config/sync/block.block.saho_primary_local_tasks.yml
+++ b/config/sync/block.block.saho_primary_local_tasks.yml
@@ -19,4 +19,11 @@ settings:
   provider: core
   primary: true
   secondary: false
-visibility: {  }
+visibility:
+  user_role:
+    id: user_role
+    roles:
+      authenticated: authenticated
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'

--- a/config/sync/block.block.saho_secondary_local_tasks.yml
+++ b/config/sync/block.block.saho_secondary_local_tasks.yml
@@ -19,4 +19,11 @@ settings:
   provider: core
   primary: false
   secondary: true
-visibility: {  }
+visibility:
+  user_role:
+    id: user_role
+    roles:
+      authenticated: authenticated
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'


### PR DESCRIPTION
## Why

Follow-up to the query-caching work (#548). The production Redis status page showed the two single biggest render-cache consumers were the local-tasks blocks: `saho_primary_local_tasks` (~9,019 variations) and `saho_secondary_local_tasks` (~8,968), varying by `route` + `url.query_args`.

Those blocks render editorial tabs (View / Edit / Delete / Revisions / ...) that are permission-gated - **anonymous visitors see nothing**. But Drupal still cached the empty render per route, and anonymous/bot traffic with endless tracking and facet query strings minted a fresh entry each time, which is what inflated them to ~18k combined variations.

## What

Adds a `user_role` (authenticated) visibility condition to both blocks, so anonymous requests skip rendering and caching them entirely. The ~18k anon variations collapse to a handful of real editorial ones.

## Verification (DDEV)

- Config applied via partial import (only the two block configs touched; `config:status` was clean beforehand).
- **Anonymous**: node pages render zero tab markup and stay HTTP 200 - confirmed no anon-visible tab is lost (there were none: verified before and after).
- **Authenticated**: full tab set intact - View / Edit / Delete / Revisions / Clone / Usage (Playwright, logged in as admin).

Pure config change; no custom code. On deploy this needs a `drush cim` like any config change.