### PR TITLE
perf(cache): guard getAvailableDates cache read (missed the #548 merge)

### DIFF
--- a/webroot/modules/custom/saho_suggested_reading/saho_suggested_reading.module
+++ b/webroot/modules/custom/saho_suggested_reading/saho_suggested_reading.module
@@ -375,6 +375,12 @@ function _saho_suggested_reading_get_entity_image_url(FieldableEntityInterface $
  * Thin shim over the cached SuggestedReadingQuery service - the 10-join
  * query behind this was the site's biggest database consumer, so its nid
  * lists are cached per condition set (6h TTL, saho_suggested_reading tag).
+ *
+ * Note the two caches here have deliberately different invalidation: the
+ * render array below carries node_list:{bundle} tags (busts on any save),
+ * while the nid-list data cache is TTL-only behind its own tag - so a cold
+ * render stays cheap even though the query result is intentionally allowed
+ * to lag saves by up to its TTL. This mismatch is by design, not a bug.
  */
 function _saho_suggested_reading_query_entities_with_images($conditions = [], $limit = 6) {
   return \Drupal::service('saho_suggested_reading.query')

--- a/webroot/modules/custom/saho_utils/tdih/src/Service/NodeFetcher.php
+++ b/webroot/modules/custom/saho_utils/tdih/src/Service/NodeFetcher.php
@@ -179,14 +179,14 @@ class NodeFetcher {
    *   Array of month-day combinations that have events.
    */
   public function getAvailableDates() {
-    $cached = $this->cache->get('tdih:available_dates');
-    if ($cached !== FALSE) {
-      return $cached->data;
-    }
-
     $dates = [];
 
     try {
+      $cached = $this->cache->get('tdih:available_dates');
+      if ($cached !== FALSE) {
+        return $cached->data;
+      }
+
       // Query to extract month and day from the date field.
       $query = $this->database->select('node_field_data', 'n');
       $query->join('node__field_event_date', 'f', 'n.nid = f.entity_id');


### PR DESCRIPTION
## Why

This is a small review-driven follow-up to #548 that was pushed just after that PR was merged, so it never reached main. Restoring it here.

The `drupal-reviewer` pass on #548 flagged that in `NodeFetcher::getAvailableDates()`, the new `cache->get('tdih:available_dates')` call sat **outside** the method's try/catch - so a cache-backend fault there would propagate uncaught, unlike every other method in the class (which degrade to an empty list). Cosmetic in normal operation, but the whole point of the surrounding defensiveness is to never let a lookup fault surface a fatal.

## What

- Move the `tdih:available_dates` cache read inside the try/catch so a cache fault degrades gracefully like the rest of `NodeFetcher`.
- Add a one-line note in the `saho_suggested_reading` shim documenting that the render-array `node_list` tags and the TTL-only nid-list cache have deliberately different invalidation, so a future maintainer does not read it as a mismatch to "fix".

No behavior change on the happy path; phpcs clean, tdih unit tests pass.