### PR TITLE
seo(phase1): noindex the faceted search-result routes

### DIFF
--- a/webroot/modules/custom/saho_performance/saho_performance.services.yml
+++ b/webroot/modules/custom/saho_performance/saho_performance.services.yml
@@ -4,6 +4,12 @@ services:
     tags:
       - { name: event_subscriber }
 
+  saho_performance.seo_robots_subscriber:
+    class: Drupal\saho_performance\EventSubscriber\SeoRobotsSubscriber
+    arguments: ['@current_route_match']
+    tags:
+      - { name: event_subscriber }
+
   saho_performance.css_optimizer:
     class: Drupal\saho_performance\Asset\CssOptimizer
     arguments: ['@config.factory']

--- a/webroot/modules/custom/saho_performance/src/EventSubscriber/SeoRobotsSubscriber.php
+++ b/webroot/modules/custom/saho_performance/src/EventSubscriber/SeoRobotsSubscriber.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\saho_performance\EventSubscriber;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Sends X-Robots-Tag: noindex on the faceted search-result routes.
+ *
+ * The /search and /archives Views expose an effectively infinite faceted
+ * URL space (search_api_fulltext + sort_by + page + facets_*), which
+ * Google crawls and then discards as "Crawled - currently not indexed" -
+ * ~50k such URLs were burning crawl budget that should reach real content.
+ *
+ * We de-index them with a "noindex, follow" header rather than a robots.txt
+ * Disallow: Googlebot must be able to fetch these URLs to see the noindex
+ * and drop them, and "follow" preserves link equity to real content while
+ * they drain. A robots.txt Disallow (crawl budget reclamation) is a
+ * deliberate SECOND step, applied only after the index has drained -
+ * disallowing first would trap the URLs in the index permanently.
+ *
+ * Matching is by exact route name, which is immune to language-prefix
+ * variation (/zu/search), trailing slashes and query strings, and cannot
+ * accidentally match a real content page aliased under a similar path.
+ */
+class SeoRobotsSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Route names of the faceted search-result pages to de-index.
+   */
+  protected const NOINDEX_ROUTES = [
+    // /search - global Search API results.
+    'view.saho_global_search.page_1',
+    // /archives - archive Search API results.
+    'view.saho_archive_search.page_1',
+    // /archive - legacy archive listing.
+    'view.archive.page_1',
+  ];
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a new SeoRobotsSubscriber object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      KernelEvents::RESPONSE => ['onResponse', -10],
+    ];
+  }
+
+  /**
+   * Adds a noindex X-Robots-Tag on the faceted search-result routes.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The response event.
+   */
+  public function onResponse(ResponseEvent $event) {
+    if (!in_array($this->routeMatch->getRouteName(), static::NOINDEX_ROUTES, TRUE)) {
+      return;
+    }
+
+    $response = $event->getResponse();
+
+    // Only HTML responses carry an indexable document.
+    $content_type = $response->headers->get('Content-Type');
+    if (!$content_type || strpos($content_type, 'text/html') === FALSE) {
+      return;
+    }
+
+    // "follow" keeps internal links to real content passing equity while
+    // Google recrawls and drops these URLs from the index.
+    $response->headers->set('X-Robots-Tag', 'noindex, follow');
+  }
+
+}

--- a/webroot/modules/custom/saho_performance/tests/src/Unit/SeoRobotsSubscriberTest.php
+++ b/webroot/modules/custom/saho_performance/tests/src/Unit/SeoRobotsSubscriberTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_performance\Unit;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\saho_performance\EventSubscriber\SeoRobotsSubscriber;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Tests that only the faceted search routes get a noindex header.
+ *
+ * The negative cases (a node route, the homepage, a non-HTML response) are
+ * the guard against accidentally de-indexing real content.
+ *
+ * @coversDefaultClass \Drupal\saho_performance\EventSubscriber\SeoRobotsSubscriber
+ * @group saho_performance
+ */
+class SeoRobotsSubscriberTest extends UnitTestCase {
+
+  /**
+   * Runs the subscriber for a route + response and returns the robots header.
+   *
+   * @param string $route_name
+   *   The current route name.
+   * @param \Symfony\Component\HttpFoundation\Response $response
+   *   The response to pass through the subscriber.
+   *
+   * @return string|null
+   *   The X-Robots-Tag header value, or NULL if unset.
+   */
+  private function runFor(string $route_name, Response $response): ?string {
+    $route_match = $this->createMock(RouteMatchInterface::class);
+    $route_match->method('getRouteName')->willReturn($route_name);
+
+    $event = new ResponseEvent(
+      $this->createMock(HttpKernelInterface::class),
+      new Request(),
+      HttpKernelInterface::MAIN_REQUEST,
+      $response
+    );
+
+    (new SeoRobotsSubscriber($route_match))->onResponse($event);
+    return $event->getResponse()->headers->get('X-Robots-Tag');
+  }
+
+  /**
+   * Builds an HTML response.
+   */
+  private function htmlResponse(): Response {
+    return new Response('<html></html>', 200, ['Content-Type' => 'text/html; charset=UTF-8']);
+  }
+
+  /**
+   * @covers ::onResponse
+   */
+  public function testSearchRoutesGetNoindex(): void {
+    foreach ([
+      'view.saho_global_search.page_1',
+      'view.saho_archive_search.page_1',
+      'view.archive.page_1',
+    ] as $route) {
+      $this->assertSame(
+        'noindex, follow',
+        $this->runFor($route, $this->htmlResponse()),
+        "Route $route should be de-indexed."
+      );
+    }
+  }
+
+  /**
+   * @covers ::onResponse
+   */
+  public function testRealContentRoutesAreUntouched(): void {
+    // A node page and the homepage must never be de-indexed.
+    $this->assertNull($this->runFor('entity.node.canonical', $this->htmlResponse()));
+    $this->assertNull($this->runFor('view.frontpage.page_1', $this->htmlResponse()));
+    $this->assertNull($this->runFor('<front>', $this->htmlResponse()));
+  }
+
+  /**
+   * @covers ::onResponse
+   */
+  public function testNonHtmlResponseOnSearchRouteIsUntouched(): void {
+    $json = new Response('{}', 200, ['Content-Type' => 'application/json']);
+    $this->assertNull($this->runFor('view.saho_global_search.page_1', $json));
+  }
+
+}


### PR DESCRIPTION
## Why

Phase 1 of the technical-SEO recovery. Google Search Console shows **50,731 pages "Crawled – currently not indexed"**, dominated by an *infinite* faceted search-URL space (`/search?search_api_fulltext=…&page=1349`, `/archives?…`). Google crawls this endlessly and discards it, burning the crawl budget that should reach real content (which sits in "Discovered – not indexed", 13,948). The `/search` and `/archives` Views currently inherit the global `index, follow` default — nothing tells Google not to index them.

## What

New `SeoRobotsSubscriber` in `saho_performance` sends `X-Robots-Tag: noindex, follow` on the three search-result View routes, matched by **exact route name** (immune to language prefixes, query strings, trailing slashes, and can't accidentally hit a real page):

- `view.saho_global_search.page_1` (`/search`)
- `view.saho_archive_search.page_1` (`/archives`)
- `view.archive.page_1` (`/archive`)

`follow` preserves link equity to real content while the junk drains. New dedicated subscriber (not overloading the existing `ResponseSubscriber`) for single responsibility and clean rollback — delete the one service entry to revert.

## The critical sequencing (why robots.txt is NOT touched here)

De-indexing requires Googlebot to **fetch** these URLs to **see** the `noindex`. So this PR leaves robots.txt untouched — the pages stay crawlable so Google can recrawl, see the directive, and drop the 50k over 2–10 weeks. A `robots.txt Disallow` to reclaim crawl budget is a deliberate **Phase 1b**, applied only after GSC confirms the drain. Disallowing first would stop the crawl before Google sees the noindex and **freeze the junk in the index permanently**.

## Verification (DDEV)

- `/search?search_api_fulltext=zulu` and `/archives?…&page=5` → `X-Robots-Tag: noindex, follow` ✓
- `/archive` → 301 to `/archives` (already covered; a redirect needs no noindex) ✓
- Homepage and a `/people/` biography → **no** noindex, stay `index, follow` ✓
- Homepage `SearchAction` JSON-LD (sitelinks searchbox) intact ✓
- Unit test: the three search routes get the header; **negative cases** (node route, homepage, non-HTML response) get nothing — the guard against noindexing real content. phpcs + drupal-check clean.

## Rollback

Delete the `saho_performance.seo_robots_subscriber` service entry (or the class); header vanishes on next `drush cr`. No data or content changes.

## Expected GSC signal

"Crawled – not indexed" (50,731) declines over 2–10 weeks as Google recrawls; "Discovered – not indexed" improves as a lagging indicator as crawl budget reallocates. This gates Phase 1b (the robots.txt tightening).
