### PR TITLE
seo(classroom): noindex facet URLs + reject facet-flood requests

### DIFF
--- a/webroot/modules/custom/saho_performance/saho_performance.services.yml
+++ b/webroot/modules/custom/saho_performance/saho_performance.services.yml
@@ -10,6 +10,12 @@ services:
     tags:
       - { name: event_subscriber }
 
+  saho_performance.facet_flood_subscriber:
+    class: Drupal\saho_performance\EventSubscriber\FacetFloodSubscriber
+    arguments: ['@current_route_match']
+    tags:
+      - { name: event_subscriber }
+
   saho_performance.css_optimizer:
     class: Drupal\saho_performance\Asset\CssOptimizer
     arguments: ['@config.factory']

--- a/webroot/modules/custom/saho_performance/src/EventSubscriber/FacetFloodSubscriber.php
+++ b/webroot/modules/custom/saho_performance/src/EventSubscriber/FacetFloodSubscriber.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Drupal\saho_performance\EventSubscriber;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Rejects absurd facet combinations on the classroom browse page.
+ *
+ * On 2026-07-24 a ~13.6k-IP scraper fleet enumerated the caps_topic[] x
+ * grade[] checkbox space of /classroom/presentations (20k+ distinct query
+ * strings in under two hours). Every unique query string misses the edge
+ * cache and costs a full Drupal bootstrap plus a Views render.
+ *
+ * A Cloudflare challenge rule is the first line of defence; this subscriber
+ * is the origin backstop for traffic that bypasses or outlives it. Requests
+ * selecting more facet values than any person plausibly would are answered
+ * with a cheap 400 immediately after routing, before the controller and
+ * Views ever run. Per-IP rate limiting is useless against this fleet (max
+ * 14 requests per IP), so the cap keys on the request shape instead.
+ */
+class FacetFloodSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Route name of the classroom deck browse page.
+   */
+  protected const CLASSROOM_ROUTE = 'view.classroom_presentations.page_1';
+
+  /**
+   * Exposed filter identifiers whose selected values are counted.
+   */
+  protected const FACET_PARAMS = ['caps_topic', 'grade'];
+
+  /**
+   * Maximum total selected facet values before the request is rejected.
+   *
+   * The UI offers ~50 topics and ~12 grades; a person narrows, a bot
+   * enumerates. Eight total selections is well past any real usage.
+   */
+  protected const MAX_FACET_VALUES = 8;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a new FacetFloodSubscriber object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // Priority 30: directly after routing (RouterListener runs at 32) so the
+    // route name is known, but before any controller work happens.
+    return [
+      KernelEvents::REQUEST => ['onRequest', 30],
+    ];
+  }
+
+  /**
+   * Replies 400 when too many facet values are selected.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The request event.
+   */
+  public function onRequest(RequestEvent $event) {
+    if (!$event->isMainRequest()
+      || $this->routeMatch->getRouteName() !== static::CLASSROOM_ROUTE) {
+      return;
+    }
+
+    $selected = 0;
+    foreach (static::FACET_PARAMS as $param) {
+      $values = $event->getRequest()->query->all()[$param] ?? [];
+      $selected += is_array($values) ? count($values) : 1;
+    }
+
+    if ($selected <= static::MAX_FACET_VALUES) {
+      return;
+    }
+
+    $event->setResponse(new Response(
+      'Too many filters selected. Please narrow your selection to ' . static::MAX_FACET_VALUES . ' or fewer.',
+      400,
+      ['Content-Type' => 'text/plain; charset=UTF-8']
+    ));
+  }
+
+}

--- a/webroot/modules/custom/saho_performance/src/EventSubscriber/SeoRobotsSubscriber.php
+++ b/webroot/modules/custom/saho_performance/src/EventSubscriber/SeoRobotsSubscriber.php
@@ -41,6 +41,19 @@ class SeoRobotsSubscriber implements EventSubscriberInterface {
   ];
 
   /**
+   * Routes de-indexed only when a query string is present.
+   *
+   * These are real landing pages whose bare URL should stay indexed, but
+   * whose exposed checkbox filters (caps_topic[]/grade[] on the classroom
+   * browse page) span a combinatorial URL space - the same trap shape as
+   * /search, and the target of a 20k-URL scraper sweep on 2026-07-24.
+   */
+  protected const NOINDEX_FILTERED_ROUTES = [
+    // /classroom/presentations - deck browse page with facet checkboxes.
+    'view.classroom_presentations.page_1',
+  ];
+
+  /**
    * The current route match.
    *
    * @var \Drupal\Core\Routing\RouteMatchInterface
@@ -73,7 +86,11 @@ class SeoRobotsSubscriber implements EventSubscriberInterface {
    *   The response event.
    */
   public function onResponse(ResponseEvent $event) {
-    if (!in_array($this->routeMatch->getRouteName(), static::NOINDEX_ROUTES, TRUE)) {
+    $route_name = $this->routeMatch->getRouteName();
+    $always = in_array($route_name, static::NOINDEX_ROUTES, TRUE);
+    $filtered = in_array($route_name, static::NOINDEX_FILTERED_ROUTES, TRUE)
+      && $event->getRequest()->getQueryString() !== NULL;
+    if (!$always && !$filtered) {
       return;
     }
 

--- a/webroot/modules/custom/saho_performance/tests/src/Unit/FacetFloodSubscriberTest.php
+++ b/webroot/modules/custom/saho_performance/tests/src/Unit/FacetFloodSubscriberTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_performance\Unit;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\saho_performance\EventSubscriber\FacetFloodSubscriber;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Tests the facet-flood cap on the classroom browse route.
+ *
+ * The negative cases guard against rejecting real people: a handful of
+ * selections, the bare page, and other routes must always pass through.
+ *
+ * @coversDefaultClass \Drupal\saho_performance\EventSubscriber\FacetFloodSubscriber
+ * @group saho_performance
+ */
+class FacetFloodSubscriberTest extends UnitTestCase {
+
+  /**
+   * Runs the subscriber for a route + URI and returns the set response.
+   *
+   * @param string $route_name
+   *   The current route name.
+   * @param string $uri
+   *   The request URI including any query string.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response|null
+   *   The short-circuit response, or NULL when the request passes through.
+   */
+  private function runFor(string $route_name, string $uri) {
+    $route_match = $this->createMock(RouteMatchInterface::class);
+    $route_match->method('getRouteName')->willReturn($route_name);
+
+    $event = new RequestEvent(
+      $this->createMock(HttpKernelInterface::class),
+      Request::create($uri),
+      HttpKernelInterface::MAIN_REQUEST
+    );
+
+    (new FacetFloodSubscriber($route_match))->onRequest($event);
+    return $event->getResponse();
+  }
+
+  /**
+   * Builds a classroom URI selecting the given number of facet values.
+   */
+  private function classroomUri(int $topics, int $grades): string {
+    $params = [];
+    for ($i = 0; $i < $topics; $i++) {
+      $tid = 35804 + $i;
+      $params[] = "caps_topic%5B$tid%5D=$tid";
+    }
+    for ($i = 0; $i < $grades; $i++) {
+      $tid = 35779 + $i;
+      $params[] = "grade%5B$tid%5D=$tid";
+    }
+    return '/classroom/presentations?' . implode('&', $params);
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testEnumerationSweepIsRejected(): void {
+    // Shape taken from the 2026-07-24 scraper sweep: 22 topics + 4 grades.
+    $response = $this->runFor(
+      'view.classroom_presentations.page_1',
+      $this->classroomUri(22, 4)
+    );
+    $this->assertNotNull($response);
+    $this->assertSame(400, $response->getStatusCode());
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testJustOverTheCapIsRejected(): void {
+    $response = $this->runFor(
+      'view.classroom_presentations.page_1',
+      $this->classroomUri(6, 3)
+    );
+    $this->assertNotNull($response);
+    $this->assertSame(400, $response->getStatusCode());
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testRealisticSelectionPassesThrough(): void {
+    // A teacher picking a few topics and a couple of grades.
+    $this->assertNull($this->runFor(
+      'view.classroom_presentations.page_1',
+      $this->classroomUri(3, 2)
+    ));
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testBareBrowsePagePassesThrough(): void {
+    $this->assertNull($this->runFor(
+      'view.classroom_presentations.page_1',
+      '/classroom/presentations'
+    ));
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testOtherRoutesAreNeverCapped(): void {
+    // Same flood-shaped query string on another route must pass through.
+    $this->assertNull($this->runFor(
+      'view.saho_global_search.page_1',
+      '/search?' . substr($this->classroomUri(22, 4), strlen('/classroom/presentations?'))
+    ));
+  }
+
+}

--- a/webroot/modules/custom/saho_performance/tests/src/Unit/SeoRobotsSubscriberTest.php
+++ b/webroot/modules/custom/saho_performance/tests/src/Unit/SeoRobotsSubscriberTest.php
@@ -30,17 +30,19 @@ class SeoRobotsSubscriberTest extends UnitTestCase {
    *   The current route name.
    * @param \Symfony\Component\HttpFoundation\Response $response
    *   The response to pass through the subscriber.
+   * @param \Symfony\Component\HttpFoundation\Request|null $request
+   *   The request, or NULL for a bare query-string-less request.
    *
    * @return string|null
    *   The X-Robots-Tag header value, or NULL if unset.
    */
-  private function runFor(string $route_name, Response $response): ?string {
+  private function runFor(string $route_name, Response $response, ?Request $request = NULL): ?string {
     $route_match = $this->createMock(RouteMatchInterface::class);
     $route_match->method('getRouteName')->willReturn($route_name);
 
     $event = new ResponseEvent(
       $this->createMock(HttpKernelInterface::class),
-      new Request(),
+      $request ?? new Request(),
       HttpKernelInterface::MAIN_REQUEST,
       $response
     );
@@ -89,6 +91,27 @@ class SeoRobotsSubscriberTest extends UnitTestCase {
   public function testNonHtmlResponseOnSearchRouteIsUntouched(): void {
     $json = new Response('{}', 200, ['Content-Type' => 'application/json']);
     $this->assertNull($this->runFor('view.saho_global_search.page_1', $json));
+  }
+
+  /**
+   * @covers ::onResponse
+   */
+  public function testFilteredClassroomUrlGetsNoindex(): void {
+    $request = Request::create('/classroom/presentations?grade%5B35779%5D=35779');
+    $this->assertSame(
+      'noindex, follow',
+      $this->runFor('view.classroom_presentations.page_1', $this->htmlResponse(), $request)
+    );
+  }
+
+  /**
+   * @covers ::onResponse
+   */
+  public function testBareClassroomBrowsePageStaysIndexable(): void {
+    $request = Request::create('/classroom/presentations');
+    $this->assertNull(
+      $this->runFor('view.classroom_presentations.page_1', $this->htmlResponse(), $request)
+    );
   }
 
 }


### PR DESCRIPTION
## What happened

On 2026-07-24 a distributed scraper fleet hammered `/classroom/presentations`:

- **20,813 requests, every URL a unique `caps_topic[]` x `grade[]` facet combination** - programmatic enumeration of the checkbox space, not link-following
- **13,638 distinct IPs, max 14 requests each** (rate-limit-proof by design), all Vultr cloud ranges (45.32/45.76/45.77/64.176/139.180.x) across their global regions - which is exactly the 'Malaysia/Vietnam/Pakistan' bubble spread seen in GA4 realtime
- Spoofed `Chrome/145.0.0.0` (Mac) UA, headless with JS enabled (hence ~4.9k fake GA 'users'/30min with `first_visit = session_start = page_view`)
- ~600 req/min at origin; every unique query string busts the Cloudflare cache, so each hit was a full Drupal bootstrap + Views render

A Cloudflare managed-challenge rule (any query string on the classroom browse path, plus the fleet's exact UA) was deployed 2026-07-24 ~15:58 CEST and stopped the fleet at the edge instantly (origin dropped ~600/min -> ~120/min). This PR is the **origin backstop** for traffic that bypasses or outlives the edge rule.

## Changes

- **SeoRobotsSubscriber**: new `NOINDEX_FILTERED_ROUTES` list - sends `noindex, follow` on `view.classroom_presentations.page_1` only when a query string is present. The bare browse page stays indexable (unlike the always-noindexed /search routes from #551).
- **FacetFloodSubscriber** (new): rejects requests selecting more than 8 total facet values with a cheap 400 immediately after routing, before the controller/Views run. A teacher narrows to a few topics and grades; only an enumerator selects 20+.

## Verification

- 10/10 unit tests green (5 new flood-cap cases incl. the real sweep shape 22 topics + 4 grades, plus classroom noindex/bare-page cases)
- phpcs (CI flags) clean, drupal-check clean
- Live on DDEV: flood URL -> 400; single-facet URL -> 200 + `x-robots-tag: noindex, follow`; bare page -> 200 with no robots header