### PR TITLE
refactor(connections): extract ConnectionsBuilder service from saho.theme

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -110,6 +110,7 @@ module:
   saho_chrome: 0
   saho_classroom: 0
   saho_cleanup: 0
+  saho_connections: 0
   saho_dashboard: 0
   saho_donate: 0
   saho_featured_articles: 0

--- a/webroot/modules/custom/saho_connections/saho_connections.info.yml
+++ b/webroot/modules/custom/saho_connections/saho_connections.info.yml
@@ -1,0 +1,7 @@
+name: 'SAHO Connections'
+type: module
+description: 'Read-side builder for a record''s cross-references: the rail tabs, the toolbar count, and the full paged lists behind them.'
+package: SAHO
+core_version_requirement: ^11
+dependencies:
+  - drupal:node

--- a/webroot/modules/custom/saho_connections/saho_connections.services.yml
+++ b/webroot/modules/custom/saho_connections/saho_connections.services.yml
@@ -1,0 +1,11 @@
+services:
+  # Single source of truth for a record's connections: the related-tabs rail,
+  # the toolbar pill count, and the hub page all read this one builder so the
+  # numbers can never drift apart.
+  saho_connections.builder:
+    class: Drupal\saho_connections\ConnectionsBuilder
+    arguments: ['@database', '@entity_type.manager']
+
+  # Interface alias so blocks, controllers and other services can type-hint
+  # ConnectionsBuilderInterface and get autowired (saho_classroom pattern).
+  Drupal\saho_connections\ConnectionsBuilderInterface: '@saho_connections.builder'

--- a/webroot/modules/custom/saho_connections/src/ConnectionsBuilder.php
+++ b/webroot/modules/custom/saho_connections/src/ConnectionsBuilder.php
@@ -1,0 +1,643 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\saho_connections;
+
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+
+/**
+ * Builds a record's cross-reference tabs, counts and full paged lists.
+ *
+ * Extracted verbatim from the saho theme's _saho_record_related_props()
+ * pipeline (typed *_related_tab fields + curated feature-parent inventory +
+ * reverse gallery edges, with rerouting, same-id merge, href dedupe and
+ * threshold collapse) so that modules - the connections hub controller in
+ * particular - can read the same spec the rail renders. tabs() output is
+ * shape-identical to the pre-extraction theme output; items() exposes the
+ * full lists the rail deliberately bounds.
+ */
+final class ConnectionsBuilder implements ConnectionsBuilderInterface {
+
+  /**
+   * Cross-reference lists past this length collapse to count + samples.
+   *
+   * "A rail is for apparatus; 20k records is a query": high-degree nodes
+   * render a bounded collection summary, and the index page IS the list.
+   */
+  public const THRESHOLD = 10;
+
+  /**
+   * Term 51 "Organisations" - the classifier the old view filtered on.
+   */
+  public const ORG_TID = 51;
+
+  /**
+   * Article-type 2985 "Timeline" - the other feature_children classifier.
+   */
+  public const TIMELINE_TYPE = 2985;
+
+  /**
+   * Bundles whose typed fields feed the tabs, keyed by field name.
+   */
+  private const TYPED_FIELD_MAP = [
+    'field_people_related_tab' => ['id' => 'people', 'label' => 'People'],
+    'field_organizations_related_tab' => ['id' => 'organisations', 'label' => 'Organisations'],
+    'field_topics_related_tab' => ['id' => 'topics', 'label' => 'Topics'],
+    'field_timelines_related_tab' => ['id' => 'timelines', 'label' => 'Timelines'],
+  ];
+
+  /**
+   * Per-request memo of built specs, keyed by nid.
+   *
+   * A record page builds its rail more than once per render; an instance
+   * property (not a static) so kernel tests can reset it.
+   */
+  private array $memo = [];
+
+  public function __construct(
+    private readonly Connection $database,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tabs(NodeInterface $node): array {
+    $tabs = array_column($this->build($node)['tabs'], 'props');
+    return $tabs !== [] ? ['title' => 'Cross-references', 'tabs' => $tabs] : [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function inventory(NodeInterface $node): array {
+    $inventory = [];
+    foreach ($this->build($node)['tabs'] as $id => $tab) {
+      $inventory[$id] = [
+        'label' => $tab['props']['label'],
+        'count' => $tab['props']['count'],
+      ];
+    }
+    return $inventory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function totalCount(NodeInterface $node): int {
+    $total = 0;
+    foreach ($this->build($node)['tabs'] as $tab) {
+      $total += $tab['props']['count'];
+    }
+    return $total;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function items(NodeInterface $node, string $tab_id, int $page, int $page_size): array {
+    $spec = $this->build($node)['tabs'][$tab_id] ?? NULL;
+    if ($spec === NULL || $page < 0 || $page_size < 1) {
+      return ['label' => '', 'total' => 0, 'items' => []];
+    }
+    $offset = $page * $page_size;
+    $items = match ($spec['source']) {
+      // Typed/merged/small tabs: the full list is already materialized in
+      // the props (the rail never truncates these).
+      'materialized' => array_slice($spec['props']['items'], $offset, $page_size),
+      // Curated collection tabs: the rail holds a bounded sample; page over
+      // the full ordered nid list captured from the inventory query.
+      'curated' => $this->materialize(array_slice($spec['nids'], $offset, $page_size)),
+      // Reverse gallery edges: re-run the indexed query for the window.
+      'gallery' => $this->materialize($this->galleryWindowNids((int) $node->id(), $offset, $page_size)),
+    };
+    return [
+      'label' => $spec['props']['label'],
+      'total' => $spec['props']['count'],
+      'items' => $items,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function cacheTags(): array {
+    // Image joins the set for the reverse Galleries tab (images referencing
+    // a record change what the tab shows).
+    return [
+      'node_list:article',
+      'node_list:biography',
+      'node_list:place',
+      'node_list:archive',
+      'node_list:image',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resetCache(): void {
+    $this->memo = [];
+  }
+
+  /**
+   * Builds the record's full connections spec, memoized per nid.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The record node.
+   *
+   * @return array
+   *   ['tabs' => [tab_id => ['props' => array, 'source' => string, ...]]]
+   *   where props is the exact rail tab array and source is one of
+   *   'materialized' (props items ARE the full list), 'curated' (full
+   *   ordered nid list in 'nids'), or 'gallery' (window re-queried).
+   */
+  private function build(NodeInterface $node): array {
+    $nid = (int) $node->id();
+    if (isset($this->memo[$nid])) {
+      return $this->memo[$nid];
+    }
+
+    $threshold = self::THRESHOLD;
+    $tabs = [];
+    $rerouted = [];
+    foreach (self::TYPED_FIELD_MAP as $field => $tab) {
+      if (!$node->hasField($field) || $node->get($field)->isEmpty()) {
+        continue;
+      }
+      $items = [];
+      foreach ($node->get($field)->referencedEntities() as $ref) {
+        $item = $this->relatedItem($ref);
+        if ($item === NULL) {
+          continue;
+        }
+        // The People tab must list people. field_people_related_tab's legacy
+        // config accepts article targets, and the sibling enrichment fills it
+        // with whole collections ("people-relation-capable" was the only typed
+        // field biographies carry) - so route every non-biography reference to
+        // the tab its actual bundle belongs on instead of mislabelling it.
+        // The other typed fields are article-target fields where the editor's
+        // field choice IS the classification; they pass through untouched.
+        if ($field === 'field_people_related_tab' && $item['type'] !== 'biography') {
+          $home = $this->tabForBundle($item['type']);
+          $rerouted[$home['id']]['tab'] = $home;
+          $rerouted[$home['id']]['items'][] = $item;
+          continue;
+        }
+        $items[] = $item;
+      }
+      if ($items !== []) {
+        $tabs[$tab['id']] = $tab + ['count' => count($items), 'items' => $items];
+      }
+    }
+    foreach ($rerouted as $id => $bucket) {
+      if (!isset($tabs[$id])) {
+        $tabs[$id] = $bucket['tab'] + ['count' => 0, 'items' => []];
+      }
+      $seen = array_column($tabs[$id]['items'], 'href');
+      foreach ($bucket['items'] as $item) {
+        if (!in_array($item['href'], $seen, TRUE)) {
+          $tabs[$id]['items'][] = $item;
+        }
+      }
+      $tabs[$id]['count'] = count($tabs[$id]['items']);
+    }
+
+    // Every typed tab is fully materialized: its props items ARE the full
+    // list, whatever the merge below does to them.
+    $sources = array_fill_keys(array_keys($tabs), ['source' => 'materialized']);
+
+    // The curated feature-children (the legacy rail accordion) join the same
+    // cross-reference engine as tabs, per wireframes wf03/wf04: one engine,
+    // typed dots, counts. Same-id tabs merge and dedupe by href; a collapsed
+    // curated tab (collection summary) owns its slot wholesale - the whole
+    // point is that the full list never renders in-page.
+    $curated = $this->curatedTabs($node);
+    $gallery = $this->galleryTab($node);
+    $merged_tabs = [];
+    foreach ($curated['tabs'] as $curated_tab) {
+      $merged_tabs[] = ['tab' => $curated_tab, 'is_gallery' => FALSE];
+    }
+    if ($gallery !== NULL) {
+      $merged_tabs[] = ['tab' => $gallery, 'is_gallery' => TRUE];
+    }
+    foreach ($merged_tabs as $merged) {
+      $tab = $merged['tab'];
+      $id = $tab['id'];
+      $is_gallery_source = $merged['is_gallery'];
+      if (isset($tab['summary']) && isset($tabs[$id]['summary'])) {
+        // Two collapsed summaries for one slot cannot merge honestly; the
+        // curated one (first in) wins.
+        continue;
+      }
+      if (isset($tab['summary']) || !isset($tabs[$id])) {
+        $tabs[$id] = $tab;
+        if (isset($tab['summary'])) {
+          // Collapsed slot: the props hold a bounded sample; record where the
+          // full list lives so items() can page it.
+          $sources[$id] = $is_gallery_source
+            ? ['source' => 'gallery']
+            : ['source' => 'curated', 'nids' => $curated['full'][$id]['nids']];
+        }
+        else {
+          $sources[$id] = ['source' => 'materialized'];
+        }
+        continue;
+      }
+      $seen = array_column($tabs[$id]['items'], 'href');
+      foreach ($tab['items'] as $item) {
+        if (!in_array($item['href'], $seen, TRUE)) {
+          $tabs[$id]['items'][] = $item;
+        }
+      }
+      $tabs[$id]['count'] = count($tabs[$id]['items']);
+      $sources[$id] = ['source' => 'materialized'];
+    }
+
+    // Past the threshold a tab gets a count line, but the typed *_related_tab
+    // sets are editorially curated, already fully loaded, and have no index
+    // page to defer to - so keep every item and let the panel scroll (the
+    // count line pins to the top), instead of stranding the reader at three
+    // rows with no way to reach the rest. Curated feature-children tabs keep
+    // their own count-plus-samples summary and browse CTA (set above),
+    // untouched here.
+    foreach ($tabs as $id => $tab) {
+      if (!isset($tab['summary']) && count($tab['items']) > $threshold) {
+        $tabs[$id]['summary'] = [
+          'count_line' => number_format($tab['count']) . ' ' . mb_strtoupper($tab['label']),
+        ];
+      }
+    }
+
+    $spec = ['tabs' => []];
+    foreach ($tabs as $id => $tab) {
+      $spec['tabs'][$id] = $sources[$id] + ['props' => $tab];
+    }
+    return $this->memo[$nid] = $spec;
+  }
+
+  /**
+   * Builds cross-reference tabs from the curated feature-parent inventory.
+   *
+   * These curated per-bundle child listings used to render as the rail
+   * accordion; the Open Record design folds them into related-tabs.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The record node.
+   *
+   * @return array
+   *   ['tabs' => tab arrays keyed by id,
+   *    'full' => [tab_id => ['nids' => int[], 'total' => int]] for every
+   *    bucket, in the same order the rail samples them].
+   */
+  private function curatedTabs(NodeInterface $node): array {
+    $empty = ['tabs' => [], 'full' => []];
+    if (!in_array($node->bundle(), ['article', 'archive', 'biography', 'place'], TRUE)) {
+      return $empty;
+    }
+    $nid = (int) $node->id();
+    // Parity with the retired feature_children views, whose parent-status
+    // filter meant an unpublished record rendered no curated tabs.
+    if (!$node->isPublished()) {
+      return $empty;
+    }
+
+    // One indexed inventory query replaces the seven feature_children view
+    // executions (and their per-display COUNTs) this pipeline used to run.
+    // The views' rendered output was discarded anyway - only each child's
+    // bundle plus two flags decide its bucket, mirroring the view displays:
+    // Organisations = article carrying term 51, Timelines = article with
+    // field_article_type 2985, Articles = article with neither (an article
+    // carrying both appears under Organisations AND Timelines, as the views
+    // did). Children are deduped across translations (default_langcode) and,
+    // unlike the views, counted only when published - the old totals silently
+    // included unpublished children the visitor could never see.
+    $rows = $this->database->query(
+      'SELECT DISTINCT c.nid, c.type, c.title, c.created,
+        (org.nid IS NOT NULL) AS is_org,
+        (tl.entity_id IS NOT NULL) AS is_timeline
+      FROM {node__field_feature_parent} p
+      INNER JOIN {node_field_data} c
+        ON c.nid = p.entity_id AND c.status = 1 AND c.default_langcode = 1
+      LEFT JOIN {taxonomy_index} org
+        ON org.nid = c.nid AND org.tid = :org_tid
+      LEFT JOIN {node__field_article_type} tl
+        ON tl.entity_id = c.nid AND tl.deleted = 0
+        AND tl.field_article_type_target_id = :timeline_type
+      WHERE p.field_feature_parent_target_id = :nid AND p.deleted = 0',
+      [
+        ':nid' => $nid,
+        ':org_tid' => self::ORG_TID,
+        ':timeline_type' => self::TIMELINE_TYPE,
+      ]
+    )->fetchAll();
+    if ($rows === []) {
+      return $empty;
+    }
+
+    $buckets = [
+      'articles' => ['label' => 'Articles', 'rows' => []],
+      'people' => ['label' => 'People', 'rows' => []],
+      'places' => ['label' => 'Places', 'rows' => []],
+      'organisations' => ['label' => 'Organisations', 'rows' => []],
+      'timelines' => ['label' => 'Timelines', 'rows' => []],
+      'archive' => ['label' => 'Archive', 'rows' => []],
+    ];
+    foreach ($rows as $row) {
+      switch ($row->type) {
+        case 'biography':
+          $buckets['people']['rows'][] = $row;
+          break;
+
+        case 'place':
+          $buckets['places']['rows'][] = $row;
+          break;
+
+        case 'archive':
+          $buckets['archive']['rows'][] = $row;
+          break;
+
+        case 'article':
+          if ($row->is_org) {
+            $buckets['organisations']['rows'][] = $row;
+          }
+          if ($row->is_timeline) {
+            $buckets['timelines']['rows'][] = $row;
+          }
+          if (!$row->is_org && !$row->is_timeline) {
+            $buckets['articles']['rows'][] = $row;
+          }
+          break;
+      }
+    }
+
+    // Ordering parity: the Timelines/Archive views sorted the child title
+    // ascending; the other displays only sorted parent columns (constant per
+    // query), leaving child order undefined - newest-first is the
+    // deterministic replacement. Nid tiebreaks keep runs stable.
+    $by_title = static fn(object $a, object $b): int => strcasecmp($a->title, $b->title) ?: $a->nid <=> $b->nid;
+    $by_newest = static fn(object $a, object $b): int => $b->created <=> $a->created ?: $b->nid <=> $a->nid;
+    $threshold = self::THRESHOLD;
+
+    // Fetch one row past the collapse threshold per bucket (never an unbounded
+    // child list - the DISA head has 20k+); one loadMultiple covers every tab.
+    // The full ordered nid list per bucket is retained so the hub page can
+    // page over it without a second counting path.
+    $slices = [];
+    $full = [];
+    $load_nids = [];
+    foreach ($buckets as $id => $bucket) {
+      if ($bucket['rows'] === []) {
+        continue;
+      }
+      usort($bucket['rows'], in_array($id, ['timelines', 'archive'], TRUE) ? $by_title : $by_newest);
+      $ordered_nids = array_map(static fn(object $row): int => (int) $row->nid, $bucket['rows']);
+      $full[$id] = [
+        'nids' => $ordered_nids,
+        'total' => count($ordered_nids),
+      ];
+      $slice_nids = array_slice($ordered_nids, 0, $threshold + 1);
+      $slices[$id] = [
+        'label' => $bucket['label'],
+        'total' => count($ordered_nids),
+        'nids' => $slice_nids,
+      ];
+      $load_nids = array_merge($load_nids, $slice_nids);
+    }
+    $children = $this->entityTypeManager->getStorage('node')->loadMultiple(array_unique($load_nids));
+
+    $tabs = [];
+    foreach ($slices as $id => $spec) {
+      $items = [];
+      foreach ($spec['nids'] as $child_nid) {
+        $item = isset($children[$child_nid]) ? $this->relatedItem($children[$child_nid]) : NULL;
+        if ($item !== NULL) {
+          $items[] = $item;
+        }
+      }
+      if ($items === []) {
+        continue;
+      }
+      $total = max($spec['total'], count($items));
+      if ($total > $threshold) {
+        // Collection summary: mono count line, then the bounded set of already
+        // loaded rows (up to the threshold) inside a scrollable panel, and one
+        // CTA to the pre-filtered index. The full list still lives on the
+        // index - we never load 20k rows into the rail - but a dead 3-row stub
+        // gave no sense of the collection, so surface as many as were cheaply
+        // fetched. Only the archive index exists today, so only the Archive
+        // tab gets the browse CTA.
+        $summary = [
+          'count_line' => number_format($total) . ' ' . ($id === 'archive' ? 'ARCHIVE ITEMS' : mb_strtoupper($spec['label'])),
+        ];
+        if ($id === 'archive') {
+          $summary['cta'] = [
+            'label' => 'Browse the ' . $node->label() . ' collection',
+            'href' => Url::fromUserInput('/archives', ['query' => ['collection' => $node->id()]])->toString(),
+          ];
+        }
+        $tabs[$id] = [
+          'id' => $id,
+          'label' => $spec['label'],
+          'count' => $total,
+          'items' => array_slice($items, 0, $threshold),
+          'summary' => $summary,
+        ];
+      }
+      else {
+        $tabs[$id] = [
+          'id' => $id,
+          'label' => $spec['label'],
+          'count' => $total,
+          'items' => $items,
+        ];
+      }
+    }
+
+    // Galleries parity: the block_7 display aggregated the record's OWN
+    // field_gallery_tag (no child in sight), so a gallery-tagged collection
+    // head surfaced itself as a single Galleries item. Quirk preserved
+    // verbatim - the tab still only appears when the record has children,
+    // exactly as the old has-children short-circuit guaranteed.
+    if ($node->hasField('field_gallery_tag') && !$node->get('field_gallery_tag')->isEmpty()) {
+      $self = $this->relatedItem($node);
+      if ($self !== NULL) {
+        $tabs['galleries'] = [
+          'id' => 'galleries',
+          'label' => 'Galleries',
+          'count' => 1,
+          'items' => [$self],
+        ];
+      }
+    }
+
+    return ['tabs' => $tabs, 'full' => $full];
+  }
+
+  /**
+   * Builds the reverse Galleries tab: images that reference this record.
+   *
+   * The image -> biography edges written by the saho_relations title-match
+   * pipeline live on the IMAGE side (field_people_related_tab), so the
+   * biography surfaces them at render time - one indexed COUNT when empty
+   * (the common case), threshold+1 loads when not. Rolling back the image
+   * edges empties this tab automatically.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The record node.
+   *
+   * @return array|null
+   *   A tab shaped like a curated tab (id 'galleries', so the same-id merge
+   *   folds it into any existing Galleries tab), or NULL when no images
+   *   reference this record.
+   */
+  private function galleryTab(NodeInterface $node): ?array {
+    // Phase A: biographies. Places follow once image.field_topics_related_tab
+    // accepts place targets.
+    if ($node->bundle() !== 'biography') {
+      return NULL;
+    }
+    $nid = (int) $node->id();
+    $threshold = self::THRESHOLD;
+    $query = $this->entityTypeManager->getStorage('node')->getQuery()
+      ->condition('type', 'image')
+      ->condition('status', 1)
+      ->condition('field_people_related_tab', $nid)
+      ->accessCheck(FALSE);
+    $total = (int) (clone $query)->count()->execute();
+    if ($total === 0) {
+      return NULL;
+    }
+    $image_nids = $query->sort('created', 'DESC')
+      ->range(0, $threshold + 1)
+      ->execute();
+    $items = $this->materialize(array_map('intval', array_values($image_nids)));
+    if ($items === []) {
+      return NULL;
+    }
+    $tab = [
+      'id' => 'galleries',
+      'label' => 'Galleries',
+      'count' => max($total, count($items)),
+      'items' => $total > $threshold ? array_slice($items, 0, $threshold) : $items,
+    ];
+    if ($total > $threshold) {
+      $tab['summary'] = [
+        'count_line' => number_format($total) . ' IMAGES',
+      ];
+    }
+    return $tab;
+  }
+
+  /**
+   * Fetches one page window of reverse-gallery image nids.
+   *
+   * @param int $nid
+   *   The record nid the images reference.
+   * @param int $offset
+   *   Zero-based row offset.
+   * @param int $limit
+   *   Window size.
+   *
+   * @return int[]
+   *   Image nids, newest first (nid tiebreak keeps pages stable).
+   */
+  private function galleryWindowNids(int $nid, int $offset, int $limit): array {
+    $image_nids = $this->entityTypeManager->getStorage('node')->getQuery()
+      ->condition('type', 'image')
+      ->condition('status', 1)
+      ->condition('field_people_related_tab', $nid)
+      ->accessCheck(FALSE)
+      ->sort('created', 'DESC')
+      ->sort('nid', 'DESC')
+      ->range($offset, $limit)
+      ->execute();
+    return array_map('intval', array_values($image_nids));
+  }
+
+  /**
+   * Loads nodes and builds item rows, preserving the given nid order.
+   *
+   * @param int[] $nids
+   *   Node ids in display order.
+   *
+   * @return array
+   *   Item rows; nodes the current user cannot view are skipped.
+   */
+  private function materialize(array $nids): array {
+    if ($nids === []) {
+      return [];
+    }
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+    $items = [];
+    foreach ($nids as $nid) {
+      $item = isset($nodes[$nid]) ? $this->relatedItem($nodes[$nid]) : NULL;
+      if ($item !== NULL) {
+        $items[] = $item;
+      }
+    }
+    return $items;
+  }
+
+  /**
+   * Builds one related-tabs item from a referenced node, or NULL.
+   *
+   * @param mixed $ref
+   *   The candidate entity.
+   *
+   * @return array|null
+   *   Item props (label/href/note/type), or NULL when not viewable.
+   */
+  private function relatedItem($ref): ?array {
+    $known_types = ['article', 'biography', 'place', 'archive', 'event', 'topic', 'image'];
+    if (!$ref instanceof NodeInterface || !$ref->access('view')) {
+      return NULL;
+    }
+    $note = '';
+    foreach (['field_synopsis', 'body'] as $note_field) {
+      if ($ref->hasField($note_field) && !$ref->get($note_field)->isEmpty()) {
+        $note = trim(html_entity_decode(strip_tags((string) $ref->get($note_field)->value), ENT_QUOTES | ENT_HTML5));
+        if ($note !== '') {
+          break;
+        }
+      }
+    }
+    return [
+      'label' => (string) $ref->label(),
+      'href' => $ref->toUrl()->toString(),
+      'note' => $note !== '' ? Unicode::truncate($note, 90, TRUE, TRUE) : '',
+      'type' => in_array($ref->bundle(), $known_types, TRUE) ? $ref->bundle() : 'article',
+    ];
+  }
+
+  /**
+   * Maps a related item's bundle to the cross-reference tab it belongs on.
+   *
+   * Ids reuse the curated-tab slots so the same-id merge folds everything
+   * into one tab per kind. Articles read as Topics (the dictionary's own
+   * article -> topic kind mapping); unknown bundles land there too rather
+   * than under People.
+   *
+   * @param string $bundle
+   *   The referenced node's bundle.
+   *
+   * @return array
+   *   ['id' => string, 'label' => string].
+   */
+  private function tabForBundle(string $bundle): array {
+    return match ($bundle) {
+      'biography' => ['id' => 'people', 'label' => 'People'],
+      'place' => ['id' => 'places', 'label' => 'Places'],
+      'archive' => ['id' => 'archive', 'label' => 'Archive'],
+      'event' => ['id' => 'events', 'label' => 'Events'],
+      'image' => ['id' => 'galleries', 'label' => 'Galleries'],
+      default => ['id' => 'topics', 'label' => 'Topics'],
+    };
+  }
+
+}

--- a/webroot/modules/custom/saho_connections/src/ConnectionsBuilderInterface.php
+++ b/webroot/modules/custom/saho_connections/src/ConnectionsBuilderInterface.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\saho_connections;
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Builds a record's cross-reference data: rail tabs, counts, full lists.
+ *
+ * One merged/deduped spec backs every surface (rail tabs, toolbar count,
+ * hub page chips and lists), so the numbers can never drift apart.
+ */
+interface ConnectionsBuilderInterface {
+
+  /**
+   * Builds saho:saho-related-tabs props for the record rail.
+   *
+   * Output is the exact shape the rail rendered before extraction:
+   * ['title' => 'Cross-references', 'tabs' => [...]] or [] when the record
+   * has no relations. High-degree tabs carry a bounded item sample plus a
+   * 'summary' (count line, optional CTA).
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The record node.
+   *
+   * @return array
+   *   Component props, or [] when there are no relations.
+   */
+  public function tabs(NodeInterface $node): array;
+
+  /**
+   * Counts-only inventory of the record's tabs, in rail order.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The record node.
+   *
+   * @return array
+   *   [tab_id => ['label' => string, 'count' => int]], consistent with the
+   *   counts tabs() reports.
+   */
+  public function inventory(NodeInterface $node): array;
+
+  /**
+   * One tab's items, paged over the full list.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The record node.
+   * @param string $tab_id
+   *   A tab id from inventory().
+   * @param int $page
+   *   Zero-based page number.
+   * @param int $page_size
+   *   Items per page.
+   *
+   * @return array
+   *   ['label' => string, 'total' => int, 'items' => array] where items are
+   *   ['label', 'href', 'note', 'type'] rows; empty items past the end.
+   *   ['total' => 0, 'label' => '', 'items' => []] for an unknown tab.
+   */
+  public function items(NodeInterface $node, string $tab_id, int $page, int $page_size): array;
+
+  /**
+   * Sum of all tab counts - the toolbar "Connections · N" figure.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The record node.
+   *
+   * @return int
+   *   Total connected records.
+   */
+  public function totalCount(NodeInterface $node): int;
+
+  /**
+   * List cache tags the connections data depends on.
+   *
+   * @return string[]
+   *   node_list:<bundle> tags for the bundles that can appear as children.
+   */
+  public function cacheTags(): array;
+
+  /**
+   * Clears the per-request memo (kernel tests re-running fixtures).
+   */
+  public function resetCache(): void;
+
+}

--- a/webroot/modules/custom/saho_connections/tests/src/Kernel/ConnectionsBuilderTest.php
+++ b/webroot/modules/custom/saho_connections/tests/src/Kernel/ConnectionsBuilderTest.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_connections\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\saho_connections\ConnectionsBuilder;
+use Drupal\saho_connections\ConnectionsBuilderInterface;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+
+/**
+ * Tests the connections builder: rail parity, counts, full paged lists.
+ *
+ * @group saho_connections
+ */
+final class ConnectionsBuilderTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'node',
+    'taxonomy',
+    'saho_connections',
+  ];
+
+  /**
+   * The builder under test.
+   */
+  private ConnectionsBuilderInterface $builder;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installSchema('node', ['node_access']);
+    // maintain_index_table: the curated org classifier reads taxonomy_index.
+    $this->installConfig(['taxonomy']);
+
+    foreach (['article', 'biography', 'place', 'archive', 'image', 'event'] as $bundle) {
+      NodeType::create(['type' => $bundle, 'name' => $bundle])->save();
+    }
+    Vocabulary::create(['vid' => 'tags', 'name' => 'Tags'])->save();
+
+    // The typed relation field lives on biographies (enrichment) and images
+    // (reverse gallery edges).
+    FieldStorageConfig::create([
+      'field_name' => 'field_people_related_tab',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'node'],
+      'cardinality' => -1,
+    ])->save();
+    foreach (['biography', 'image'] as $bundle) {
+      FieldConfig::create([
+        'field_name' => 'field_people_related_tab',
+        'entity_type' => 'node',
+        'bundle' => $bundle,
+      ])->save();
+    }
+
+    // Curated collection membership.
+    FieldStorageConfig::create([
+      'field_name' => 'field_feature_parent',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'node'],
+    ])->save();
+    foreach (['article', 'biography', 'place', 'archive'] as $bundle) {
+      FieldConfig::create([
+        'field_name' => 'field_feature_parent',
+        'entity_type' => 'node',
+        'bundle' => $bundle,
+      ])->save();
+    }
+
+    // The two curated classifiers: term ORG_TID via taxonomy_index, and the
+    // article-type target TIMELINE_TYPE (a raw target_id - the builder never
+    // loads the term).
+    FieldStorageConfig::create([
+      'field_name' => 'field_article_type',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'taxonomy_term'],
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_article_type',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+    ])->save();
+    FieldStorageConfig::create([
+      'field_name' => 'field_tags',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'taxonomy_term'],
+      'cardinality' => -1,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_tags',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+    ])->save();
+
+    // Admin current user: relatedItem() honours access('view').
+    $this->setUpCurrentUser(['uid' => 1]);
+
+    $this->builder = $this->container->get('saho_connections.builder');
+  }
+
+  /**
+   * Creates a published node.
+   */
+  private function makeNode(string $bundle, string $title, array $values = []): Node {
+    $node = Node::create($values + ['type' => $bundle, 'title' => $title, 'status' => 1]);
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * Returns the term whose tid is the organisations classifier.
+   */
+  private function makeOrgTerm(): Term {
+    $term = NULL;
+    do {
+      $term = Term::create(['vid' => 'tags', 'name' => 'term']);
+      $term->save();
+    } while ((int) $term->id() < ConnectionsBuilder::ORG_TID);
+    $this->assertSame(ConnectionsBuilder::ORG_TID, (int) $term->id());
+    return $term;
+  }
+
+  /**
+   * Returns the tab with the given id from a tabs() result.
+   */
+  private function tab(array $props, string $id): ?array {
+    foreach ($props['tabs'] ?? [] as $tab) {
+      if ($tab['id'] === $id) {
+        return $tab;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Typed field items build tabs; non-biography refs reroute by bundle.
+   */
+  public function testTypedTabsAndRerouting(): void {
+    $person = $this->makeNode('biography', 'Person A');
+    $place = $this->makeNode('place', 'Place A');
+    $article = $this->makeNode('article', 'Article A');
+    $host = $this->makeNode('biography', 'Host', [
+      'field_people_related_tab' => [$person->id(), $place->id(), $article->id()],
+    ]);
+
+    $props = $this->builder->tabs($host);
+    $this->assertSame('Cross-references', $props['title']);
+
+    $people = $this->tab($props, 'people');
+    $this->assertNotNull($people);
+    $this->assertSame(1, $people['count']);
+    $this->assertSame('Person A', $people['items'][0]['label']);
+    $this->assertSame('biography', $people['items'][0]['type']);
+    $this->assertArrayNotHasKey('summary', $people);
+
+    $places = $this->tab($props, 'places');
+    $this->assertSame(1, $places['count']);
+    $this->assertSame('Place A', $places['items'][0]['label']);
+
+    // Articles land on Topics (the dictionary's article -> topic mapping).
+    $topics = $this->tab($props, 'topics');
+    $this->assertSame(1, $topics['count']);
+    $this->assertSame('Article A', $topics['items'][0]['label']);
+  }
+
+  /**
+   * Curated buckets classify children and collapse past the threshold.
+   */
+  public function testCuratedBucketsAndCollapse(): void {
+    $parent = $this->makeNode('article', 'Collection head');
+    $org_term = $this->makeOrgTerm();
+
+    // Twelve archive children - past the threshold, title-sorted.
+    for ($i = 1; $i <= 12; $i++) {
+      $this->makeNode('archive', sprintf('Doc %02d', $i), [
+        'field_feature_parent' => $parent->id(),
+      ]);
+    }
+    // Classified articles: organisation, timeline, both, neither.
+    $this->makeNode('article', 'Org child', [
+      'field_feature_parent' => $parent->id(),
+      'field_tags' => [$org_term->id()],
+    ]);
+    $this->makeNode('article', 'Timeline child', [
+      'field_feature_parent' => $parent->id(),
+      'field_article_type' => ['target_id' => ConnectionsBuilder::TIMELINE_TYPE],
+    ]);
+    $this->makeNode('article', 'Both child', [
+      'field_feature_parent' => $parent->id(),
+      'field_tags' => [$org_term->id()],
+      'field_article_type' => ['target_id' => ConnectionsBuilder::TIMELINE_TYPE],
+    ]);
+    $this->makeNode('article', 'Plain child', [
+      'field_feature_parent' => $parent->id(),
+    ]);
+    // An unpublished child never counts.
+    $this->makeNode('archive', 'Hidden doc', [
+      'field_feature_parent' => $parent->id(),
+      'status' => 0,
+    ]);
+
+    $props = $this->builder->tabs($parent);
+
+    $archive = $this->tab($props, 'archive');
+    $this->assertSame(12, $archive['count']);
+    $this->assertCount(ConnectionsBuilder::THRESHOLD, $archive['items']);
+    $this->assertSame('12 ARCHIVE ITEMS', $archive['summary']['count_line']);
+    $this->assertSame('Browse the Collection head collection', $archive['summary']['cta']['label']);
+    $this->assertStringContainsString('collection=' . $parent->id(), $archive['summary']['cta']['href']);
+    // Title-ascending order.
+    $this->assertSame('Doc 01', $archive['items'][0]['label']);
+    $this->assertSame('Doc 10', $archive['items'][9]['label']);
+
+    // "Both child" appears under Organisations AND Timelines, as the old
+    // views did; "Plain child" only under Articles.
+    $orgs = $this->tab($props, 'organisations');
+    $this->assertSame(2, $orgs['count']);
+    $timelines = $this->tab($props, 'timelines');
+    $this->assertSame(2, $timelines['count']);
+    $articles = $this->tab($props, 'articles');
+    $this->assertSame(1, $articles['count']);
+    $this->assertSame('Plain child', $articles['items'][0]['label']);
+
+    // The hub pages the FULL archive list in rail order.
+    $page_0 = $this->builder->items($parent, 'archive', 0, 10);
+    $this->assertSame(12, $page_0['total']);
+    $this->assertSame(array_column($archive['items'], 'href'), array_column($page_0['items'], 'href'));
+    $page_1 = $this->builder->items($parent, 'archive', 1, 10);
+    $this->assertCount(2, $page_1['items']);
+    $this->assertSame('Doc 11', $page_1['items'][0]['label']);
+    $this->assertSame('Doc 12', $page_1['items'][1]['label']);
+    $this->assertSame([], $this->builder->items($parent, 'archive', 2, 10)['items']);
+
+    // An unpublished collection head renders no curated tabs at all.
+    $parent->setUnpublished()->save();
+    $this->builder->resetCache();
+    $this->assertSame([], $this->builder->tabs($parent));
+  }
+
+  /**
+   * A collapsed curated tab owns its slot; typed same-id items yield.
+   */
+  public function testCuratedSummaryOwnsSlot(): void {
+    $typed_ref = $this->makeNode('biography', 'Typed-only person');
+    $host = $this->makeNode('biography', 'Host', [
+      'field_people_related_tab' => [$typed_ref->id()],
+    ]);
+    for ($i = 1; $i <= 11; $i++) {
+      $this->makeNode('biography', "Child person $i", [
+        'field_feature_parent' => $host->id(),
+      ]);
+    }
+
+    $props = $this->builder->tabs($host);
+    $people = $this->tab($props, 'people');
+    // The curated summary replaces the typed tab wholesale.
+    $this->assertSame(11, $people['count']);
+    $this->assertSame('11 PEOPLE', $people['summary']['count_line']);
+    $this->assertArrayNotHasKey('cta', $people['summary']);
+
+    // The hub list is the curated collection - the typed-only ref is not in
+    // it (rail parity: the rail dropped it too).
+    $all = $this->builder->items($host, 'people', 0, 50);
+    $this->assertSame(11, $all['total']);
+    $this->assertCount(11, $all['items']);
+    $this->assertNotContains('Typed-only person', array_column($all['items'], 'label'));
+  }
+
+  /**
+   * Reverse gallery edges build the Galleries tab, paged for the hub.
+   */
+  public function testGalleryReverseTab(): void {
+    $bio = $this->makeNode('biography', 'Photographed person');
+    for ($i = 1; $i <= 12; $i++) {
+      $this->makeNode('image', "Photo $i", [
+        'field_people_related_tab' => [$bio->id()],
+        'created' => 1000000 + $i,
+      ]);
+    }
+
+    $props = $this->builder->tabs($bio);
+    $galleries = $this->tab($props, 'galleries');
+    $this->assertSame(12, $galleries['count']);
+    $this->assertCount(ConnectionsBuilder::THRESHOLD, $galleries['items']);
+    $this->assertSame('12 IMAGES', $galleries['summary']['count_line']);
+    // Newest first.
+    $this->assertSame('Photo 12', $galleries['items'][0]['label']);
+
+    $page_1 = $this->builder->items($bio, 'galleries', 1, 10);
+    $this->assertSame(12, $page_1['total']);
+    $this->assertCount(2, $page_1['items']);
+    $this->assertSame(['Photo 2', 'Photo 1'], array_column($page_1['items'], 'label'));
+  }
+
+  /**
+   * Inventory and totalCount agree with tabs() everywhere.
+   */
+  public function testCountParity(): void {
+    $parent = $this->makeNode('article', 'Head');
+    for ($i = 1; $i <= 12; $i++) {
+      $this->makeNode('archive', "Doc $i", ['field_feature_parent' => $parent->id()]);
+    }
+    $this->makeNode('biography', 'Child person', ['field_feature_parent' => $parent->id()]);
+
+    $props = $this->builder->tabs($parent);
+    $inventory = $this->builder->inventory($parent);
+    $this->assertSame(count($props['tabs']), count($inventory));
+    $sum = 0;
+    foreach ($props['tabs'] as $tab) {
+      $this->assertSame($tab['count'], $inventory[$tab['id']]['count']);
+      $this->assertSame($tab['label'], $inventory[$tab['id']]['label']);
+      $sum += $tab['count'];
+    }
+    $this->assertSame($sum, $this->builder->totalCount($parent));
+  }
+
+  /**
+   * Unknown tabs and empty records return empty, never errors.
+   */
+  public function testEmptyAndUnknown(): void {
+    $bare = $this->makeNode('event', 'No relations');
+    $this->assertSame([], $this->builder->tabs($bare));
+    $this->assertSame([], $this->builder->inventory($bare));
+    $this->assertSame(0, $this->builder->totalCount($bare));
+    $result = $this->builder->items($bare, 'people', 0, 10);
+    $this->assertSame(0, $result['total']);
+    $this->assertSame([], $result['items']);
+
+    $parent = $this->makeNode('article', 'Head');
+    $this->makeNode('archive', 'Doc', ['field_feature_parent' => $parent->id()]);
+    $this->assertSame(0, $this->builder->items($parent, 'bogus', 0, 10)['total']);
+    $this->assertSame([], $this->builder->items($parent, 'archive', -1, 10)['items']);
+    $this->assertSame([], $this->builder->items($parent, 'archive', 0, 0)['items']);
+  }
+
+}

--- a/webroot/themes/custom/saho/saho.theme
+++ b/webroot/themes/custom/saho/saho.theme
@@ -12,7 +12,6 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 use Drupal\Component\Utility\Html;
-use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Site\Settings;
 use Drupal\saho_tools\Schema\ProvenanceIds;
@@ -2045,8 +2044,7 @@ function saho_preprocess_node__biography(array &$variables) {
   }
   // Summary/abstract from the curator-written synopsis.
   $variables['record_summary'] = _saho_record_summary_props($node);
-  $variables['record_related'] = _saho_record_related_props($node);
-  _saho_record_related_cache_tags($variables);
+  _saho_record_related_assign($variables, $node);
   $variables['record_provenance'] = _saho_record_provenance_props($node);
   $variables['record_citation'] = _saho_record_citation_props($node);
   $variables['record_image'] = _saho_record_image_props($node, 'field_bio_pic');
@@ -2480,8 +2478,7 @@ function saho_preprocess_node__image(array &$variables): void {
     'Galleries' => $term_labels('field_gallery_tag'),
   ]);
 
-  $variables['record_related'] = _saho_record_related_props($node);
-  _saho_record_related_cache_tags($variables);
+  _saho_record_related_assign($variables, $node);
   $variables['record_citation'] = _saho_record_citation_props($node);
   $variables['record_image'] = _saho_record_image_props($node, 'field_image', 'field_source', '16 / 9');
   if ($variables['record_image'] === []) {
@@ -2914,8 +2911,7 @@ function _saho_record_header_props(array &$variables, NodeInterface $node, strin
  *   Image field candidates, first populated one wins.
  */
 function _saho_record_common_props(array &$variables, NodeInterface $node, array $image_fields): void {
-  $variables['record_related'] = _saho_record_related_props($node);
-  _saho_record_related_cache_tags($variables);
+  _saho_record_related_assign($variables, $node);
   $variables['record_provenance'] = _saho_record_provenance_props($node);
   $variables['record_citation'] = _saho_record_citation_props($node);
   $variables['record_image'] = [];
@@ -2944,7 +2940,14 @@ function _saho_record_common_props(array &$variables, NodeInterface $node, array
  */
 function _saho_record_related_cache_tags(array &$variables): void {
   // Image joins the set for the reverse Galleries tab (images referencing
-  // this record change what the tab shows).
+  // this record change what the tab shows). The list lives on the builder so
+  // the hub page depends on the identical set.
+  if (\Drupal::hasService('saho_connections.builder')) {
+    foreach (\Drupal::service('saho_connections.builder')->cacheTags() as $tag) {
+      $variables['#cache']['tags'][] = $tag;
+    }
+    return;
+  }
   foreach (['article', 'biography', 'place', 'archive', 'image'] as $child_bundle) {
     $variables['#cache']['tags'][] = 'node_list:' . $child_bundle;
   }
@@ -3144,428 +3147,33 @@ function _saho_record_meta_props(string $title, string $accent, array $rows): ar
  *   saho:saho-related-tabs props, or [] when there are no relations.
  */
 function _saho_record_related_props(NodeInterface $node): array {
-  $threshold = _saho_related_collapse_threshold();
-  $map = [
-    'field_people_related_tab' => ['id' => 'people', 'label' => 'People'],
-    'field_organizations_related_tab' => ['id' => 'organisations', 'label' => 'Organisations'],
-    'field_topics_related_tab' => ['id' => 'topics', 'label' => 'Topics'],
-    'field_timelines_related_tab' => ['id' => 'timelines', 'label' => 'Timelines'],
-  ];
-  $tabs = [];
-  $rerouted = [];
-  foreach ($map as $field => $tab) {
-    if (!$node->hasField($field) || $node->get($field)->isEmpty()) {
-      continue;
-    }
-    $items = [];
-    foreach ($node->get($field)->referencedEntities() as $ref) {
-      $item = _saho_record_related_item($ref);
-      if ($item === NULL) {
-        continue;
-      }
-      // The People tab must list people. field_people_related_tab's legacy
-      // config accepts article targets, and the sibling enrichment fills it
-      // with whole collections ("people-relation-capable" was the only typed
-      // field biographies carry) - so route every non-biography reference to
-      // the tab its actual bundle belongs on instead of mislabelling it.
-      // The other typed fields are article-target fields where the editor's
-      // field choice IS the classification; they pass through untouched.
-      if ($field === 'field_people_related_tab' && $item['type'] !== 'biography') {
-        $home = _saho_record_tab_for_bundle($item['type']);
-        $rerouted[$home['id']]['tab'] = $home;
-        $rerouted[$home['id']]['items'][] = $item;
-        continue;
-      }
-      $items[] = $item;
-    }
-    if ($items !== []) {
-      $tabs[$tab['id']] = $tab + ['count' => count($items), 'items' => $items];
-    }
-  }
-  foreach ($rerouted as $id => $bucket) {
-    if (!isset($tabs[$id])) {
-      $tabs[$id] = $bucket['tab'] + ['count' => 0, 'items' => []];
-    }
-    $seen = array_column($tabs[$id]['items'], 'href');
-    foreach ($bucket['items'] as $item) {
-      if (!in_array($item['href'], $seen, TRUE)) {
-        $tabs[$id]['items'][] = $item;
-      }
-    }
-    $tabs[$id]['count'] = count($tabs[$id]['items']);
-  }
-
-  // The curated feature-children (the legacy rail accordion) join the same
-  // cross-reference engine as tabs, per wireframes wf03/wf04: one engine,
-  // typed dots, counts. Same-id tabs merge and dedupe by href; a collapsed
-  // curated tab (collection summary) owns its slot wholesale - the whole
-  // point is that the full list never renders in-page.
-  $merged_tabs = _saho_record_curated_tabs($node);
-  $gallery_tab = _saho_record_gallery_tab($node);
-  if ($gallery_tab !== NULL) {
-    $merged_tabs[] = $gallery_tab;
-  }
-  foreach ($merged_tabs as $tab) {
-    $id = $tab['id'];
-    if (isset($tab['summary']) && isset($tabs[$id]['summary'])) {
-      // Two collapsed summaries for one slot cannot merge honestly; the
-      // curated one (first in) wins.
-      continue;
-    }
-    if (isset($tab['summary']) || !isset($tabs[$id])) {
-      $tabs[$id] = $tab;
-      continue;
-    }
-    $seen = array_column($tabs[$id]['items'], 'href');
-    foreach ($tab['items'] as $item) {
-      if (!in_array($item['href'], $seen, TRUE)) {
-        $tabs[$id]['items'][] = $item;
-      }
-    }
-    $tabs[$id]['count'] = count($tabs[$id]['items']);
-  }
-
-  // Past the threshold a tab gets a count line, but the typed *_related_tab
-  // sets are editorially curated, already fully loaded, and have no index page
-  // to defer to - so keep every item and let the panel scroll (the count line
-  // pins to the top), instead of stranding the reader at three rows with no
-  // way to reach the rest. Curated feature-children tabs keep their own
-  // count-plus-samples summary and browse CTA (set above), untouched here.
-  foreach ($tabs as $id => $tab) {
-    if (!isset($tab['summary']) && count($tab['items']) > $threshold) {
-      $tabs[$id]['summary'] = [
-        'count_line' => number_format($tab['count']) . ' ' . mb_strtoupper($tab['label']),
-      ];
-    }
-  }
-
-  $tabs = array_values($tabs);
-  return $tabs !== [] ? ['title' => 'Cross-references', 'tabs' => $tabs] : [];
-}
-
-/**
- * Maps a related item's bundle to the cross-reference tab it belongs on.
- *
- * Ids reuse the curated-tab slots so the same-id merge folds everything
- * into one tab per kind. Articles read as Topics (the dictionary's own
- * article -> topic kind mapping); unknown bundles land there too rather
- * than under People.
- *
- * @param string $bundle
- *   The referenced node's bundle.
- *
- * @return array
- *   ['id' => string, 'label' => string].
- */
-function _saho_record_tab_for_bundle(string $bundle): array {
-  return match ($bundle) {
-    'biography' => ['id' => 'people', 'label' => 'People'],
-    'place' => ['id' => 'places', 'label' => 'Places'],
-    'archive' => ['id' => 'archive', 'label' => 'Archive'],
-    'event' => ['id' => 'events', 'label' => 'Events'],
-    'image' => ['id' => 'galleries', 'label' => 'Galleries'],
-    default => ['id' => 'topics', 'label' => 'Topics'],
-  };
-}
-
-/**
- * Cross-reference lists past this length collapse to count + samples.
- *
- * "A rail is for apparatus; 20k records is a query": high-degree nodes
- * render a bounded collection summary, and the index page IS the list.
- */
-function _saho_related_collapse_threshold(): int {
-  return 10;
-}
-
-/**
- * Builds one related-tabs item from a referenced node, or NULL.
- *
- * @param mixed $ref
- *   The candidate entity.
- *
- * @return array|null
- *   Item props (label/href/note/type), or NULL when not viewable.
- */
-function _saho_record_related_item($ref): ?array {
-  $known_types = ['article', 'biography', 'place', 'archive', 'event', 'topic', 'image'];
-  if (!$ref instanceof NodeInterface || !$ref->access('view')) {
-    return NULL;
-  }
-  $note = '';
-  foreach (['field_synopsis', 'body'] as $note_field) {
-    if ($ref->hasField($note_field) && !$ref->get($note_field)->isEmpty()) {
-      $note = trim(html_entity_decode(strip_tags((string) $ref->get($note_field)->value), ENT_QUOTES | ENT_HTML5));
-      if ($note !== '') {
-        break;
-      }
-    }
-  }
-  return [
-    'label' => (string) $ref->label(),
-    'href' => $ref->toUrl()->toString(),
-    'note' => $note !== '' ? Unicode::truncate($note, 90, TRUE, TRUE) : '',
-    'type' => in_array($ref->bundle(), $known_types, TRUE) ? $ref->bundle() : 'article',
-  ];
-}
-
-/**
- * Builds cross-reference tabs from the curated feature_children views.
- *
- * These curated per-bundle child listings used to render as the rail
- * accordion; the Open Record design folds them into related-tabs.
- *
- * @param \Drupal\node\NodeInterface $node
- *   The record node.
- *
- * @return array
- *   Tabs keyed by id.
- */
-function _saho_record_curated_tabs(NodeInterface $node): array {
-  if (!in_array($node->bundle(), ['article', 'archive', 'biography', 'place'], TRUE)) {
+  // The builder lives in the saho_connections module so the hub page and the
+  // rail read one spec. hasService() guards the enable-order window during
+  // the deploy that ships the module.
+  if (!\Drupal::hasService('saho_connections.builder')) {
     return [];
   }
-  // Per-request memo: a record page can build its rail more than once.
-  static $memo = [];
-  $nid = (int) $node->id();
-  if (isset($memo[$nid])) {
-    return $memo[$nid];
-  }
-  // Parity with the retired feature_children views, whose parent-status
-  // filter meant an unpublished record rendered no curated tabs.
-  if (!$node->isPublished()) {
-    return $memo[$nid] = [];
-  }
-
-  // One indexed inventory query replaces the seven feature_children view
-  // executions (and their per-display COUNTs) this function used to run.
-  // The views' rendered output was discarded anyway - only each child's
-  // bundle plus two flags decide its bucket, mirroring the view displays:
-  // Organisations = article carrying term 51, Timelines = article with
-  // field_article_type 2985, Articles = article with neither (an article
-  // carrying both appears under Organisations AND Timelines, as the views
-  // did). Children are deduped across translations (default_langcode) and,
-  // unlike the views, counted only when published - the old totals silently
-  // included unpublished children the visitor could never see.
-  $rows = \Drupal::database()->query(
-    'SELECT DISTINCT c.nid, c.type, c.title, c.created,
-      (org.nid IS NOT NULL) AS is_org,
-      (tl.entity_id IS NOT NULL) AS is_timeline
-    FROM {node__field_feature_parent} p
-    INNER JOIN {node_field_data} c
-      ON c.nid = p.entity_id AND c.status = 1 AND c.default_langcode = 1
-    LEFT JOIN {taxonomy_index} org
-      ON org.nid = c.nid AND org.tid = :org_tid
-    LEFT JOIN {node__field_article_type} tl
-      ON tl.entity_id = c.nid AND tl.deleted = 0
-      AND tl.field_article_type_target_id = :timeline_type
-    WHERE p.field_feature_parent_target_id = :nid AND p.deleted = 0',
-    [
-      ':nid' => $nid,
-      // Term 51 "Organisations" and article-type 2985 "Timeline" - the two
-      // classifiers the feature_children displays filtered on.
-      ':org_tid' => 51,
-      ':timeline_type' => 2985,
-    ]
-  )->fetchAll();
-  if ($rows === []) {
-    return $memo[$nid] = [];
-  }
-
-  $buckets = [
-    'articles' => ['label' => 'Articles', 'rows' => []],
-    'people' => ['label' => 'People', 'rows' => []],
-    'places' => ['label' => 'Places', 'rows' => []],
-    'organisations' => ['label' => 'Organisations', 'rows' => []],
-    'timelines' => ['label' => 'Timelines', 'rows' => []],
-    'archive' => ['label' => 'Archive', 'rows' => []],
-  ];
-  foreach ($rows as $row) {
-    switch ($row->type) {
-      case 'biography':
-        $buckets['people']['rows'][] = $row;
-        break;
-
-      case 'place':
-        $buckets['places']['rows'][] = $row;
-        break;
-
-      case 'archive':
-        $buckets['archive']['rows'][] = $row;
-        break;
-
-      case 'article':
-        if ($row->is_org) {
-          $buckets['organisations']['rows'][] = $row;
-        }
-        if ($row->is_timeline) {
-          $buckets['timelines']['rows'][] = $row;
-        }
-        if (!$row->is_org && !$row->is_timeline) {
-          $buckets['articles']['rows'][] = $row;
-        }
-        break;
-    }
-  }
-
-  // Ordering parity: the Timelines/Archive views sorted the child title
-  // ascending; the other displays only sorted parent columns (constant per
-  // query), leaving child order undefined - newest-first is the
-  // deterministic replacement. Nid tiebreaks keep runs stable.
-  $by_title = static fn(object $a, object $b): int => strcasecmp($a->title, $b->title) ?: $a->nid <=> $b->nid;
-  $by_newest = static fn(object $a, object $b): int => $b->created <=> $a->created ?: $b->nid <=> $a->nid;
-  $threshold = _saho_related_collapse_threshold();
-
-  // Fetch one row past the collapse threshold per bucket (never an unbounded
-  // child list - the DISA head has 20k+); one loadMultiple covers every tab.
-  $slices = [];
-  $load_nids = [];
-  foreach ($buckets as $id => $bucket) {
-    if ($bucket['rows'] === []) {
-      continue;
-    }
-    usort($bucket['rows'], in_array($id, ['timelines', 'archive'], TRUE) ? $by_title : $by_newest);
-    $slice = array_slice($bucket['rows'], 0, $threshold + 1);
-    $slices[$id] = [
-      'label' => $bucket['label'],
-      'total' => count($bucket['rows']),
-      'nids' => array_map(static fn(object $row): int => (int) $row->nid, $slice),
-    ];
-    $load_nids = array_merge($load_nids, $slices[$id]['nids']);
-  }
-  $children = Node::loadMultiple(array_unique($load_nids));
-
-  $tabs = [];
-  foreach ($slices as $id => $spec) {
-    $items = [];
-    foreach ($spec['nids'] as $child_nid) {
-      $item = isset($children[$child_nid]) ? _saho_record_related_item($children[$child_nid]) : NULL;
-      if ($item !== NULL) {
-        $items[] = $item;
-      }
-    }
-    if ($items === []) {
-      continue;
-    }
-    $total = max($spec['total'], count($items));
-    if ($total > $threshold) {
-      // Collection summary: mono count line, then the bounded set of already
-      // loaded rows (up to the threshold) inside a scrollable panel, and one
-      // CTA to the pre-filtered index. The full list still lives on the index
-      // - we never load 20k rows into the rail - but a dead 3-row stub gave
-      // no sense of the collection, so surface as many as were cheaply
-      // fetched. Only the archive index exists today, so only the Archive tab
-      // gets the browse CTA.
-      $summary = [
-        'count_line' => number_format($total) . ' ' . ($id === 'archive' ? 'ARCHIVE ITEMS' : mb_strtoupper($spec['label'])),
-      ];
-      if ($id === 'archive') {
-        $summary['cta'] = [
-          'label' => 'Browse the ' . $node->label() . ' collection',
-          'href' => Url::fromUserInput('/archives', ['query' => ['collection' => $node->id()]])->toString(),
-        ];
-      }
-      $tabs[$id] = [
-        'id' => $id,
-        'label' => $spec['label'],
-        'count' => $total,
-        'items' => array_slice($items, 0, $threshold),
-        'summary' => $summary,
-      ];
-    }
-    else {
-      $tabs[$id] = [
-        'id' => $id,
-        'label' => $spec['label'],
-        'count' => $total,
-        'items' => $items,
-      ];
-    }
-  }
-
-  // Galleries parity: the block_7 display aggregated the record's OWN
-  // field_gallery_tag (no child in sight), so a gallery-tagged collection
-  // head surfaced itself as a single Galleries item. Quirk preserved
-  // verbatim - the tab still only appears when the record has children,
-  // exactly as the old has-children short-circuit guaranteed.
-  if ($node->hasField('field_gallery_tag') && !$node->get('field_gallery_tag')->isEmpty()) {
-    $self = _saho_record_related_item($node);
-    if ($self !== NULL) {
-      $tabs['galleries'] = [
-        'id' => 'galleries',
-        'label' => 'Galleries',
-        'count' => 1,
-        'items' => [$self],
-      ];
-    }
-  }
-
-  return $memo[$nid] = $tabs;
+  return \Drupal::service('saho_connections.builder')->tabs($node);
 }
 
 /**
- * Builds the reverse Galleries tab: images that reference this record.
+ * Assigns record_related, its cache tags, and the toolbar connections count.
  *
- * The image -> biography edges written by the saho_relations title-match
- * pipeline live on the IMAGE side (field_people_related_tab), so the
- * biography surfaces them at render time - one indexed COUNT when empty
- * (the common case), threshold+1 loads when not. Rolling back the image
- * edges empties this tab automatically.
+ * One call site per record preprocess keeps the pill count and the rail
+ * counts reading the same builder - they can never drift apart.
  *
+ * @param array $variables
+ *   The preprocess variables, by reference.
  * @param \Drupal\node\NodeInterface $node
  *   The record node.
- *
- * @return array|null
- *   A tab shaped like a curated tab (id 'galleries', so the same-id merge
- *   folds it into any existing Galleries tab), or NULL when no images
- *   reference this record.
  */
-function _saho_record_gallery_tab(NodeInterface $node): ?array {
-  // Phase A: biographies. Places follow once image.field_topics_related_tab
-  // accepts place targets.
-  if ($node->bundle() !== 'biography') {
-    return NULL;
+function _saho_record_related_assign(array &$variables, NodeInterface $node): void {
+  $variables['record_related'] = _saho_record_related_props($node);
+  _saho_record_related_cache_tags($variables);
+  if (isset($variables['record_toolbar']) && \Drupal::hasService('saho_connections.builder')) {
+    $variables['record_toolbar']['connections_count'] =
+      \Drupal::service('saho_connections.builder')->totalCount($node);
   }
-  $nid = (int) $node->id();
-  static $memo = [];
-  if (array_key_exists($nid, $memo)) {
-    return $memo[$nid];
-  }
-  $threshold = _saho_related_collapse_threshold();
-  $query = \Drupal::entityQuery('node')
-    ->condition('type', 'image')
-    ->condition('status', 1)
-    ->condition('field_people_related_tab', $nid)
-    ->accessCheck(FALSE);
-  $total = (int) (clone $query)->count()->execute();
-  if ($total === 0) {
-    return $memo[$nid] = NULL;
-  }
-  $image_nids = $query->sort('created', 'DESC')
-    ->range(0, $threshold + 1)
-    ->execute();
-  $items = [];
-  foreach (Node::loadMultiple($image_nids) as $image) {
-    $item = _saho_record_related_item($image);
-    if ($item !== NULL) {
-      $items[] = $item;
-    }
-  }
-  if ($items === []) {
-    return $memo[$nid] = NULL;
-  }
-  $tab = [
-    'id' => 'galleries',
-    'label' => 'Galleries',
-    'count' => max($total, count($items)),
-    'items' => $total > $threshold ? array_slice($items, 0, $threshold) : $items,
-  ];
-  if ($total > $threshold) {
-    $tab['summary'] = [
-      'count_line' => number_format($total) . ' IMAGES',
-    ];
-  }
-  return $memo[$nid] = $tab;
 }
 
 /**

--- a/webroot/themes/custom/saho/templates/content/node--archive.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--archive.html.twig
@@ -29,9 +29,7 @@
 
   {# The record toolbar rides directly under the key-field strip (R3 #476). #}
   {% if record_toolbar is defined %}
-    {{ include('saho:saho-record-toolbar', record_toolbar|merge({
-      connections_count: record_related.tabs is defined ? record_related.tabs|reduce((c, t) => c + t.count, 0) : 0,
-    }), with_context = false) }}
+    {{ include('saho:saho-record-toolbar', record_toolbar, with_context = false) }}
   {% endif %}
 
   <div class="saho-article-grid">

--- a/webroot/themes/custom/saho/templates/content/node--article.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--article.html.twig
@@ -32,9 +32,7 @@
 
   {# The record toolbar rides directly under the key-field strip (R3 #476). #}
   {% if record_toolbar is defined %}
-    {{ include('saho:saho-record-toolbar', record_toolbar|merge({
-      connections_count: record_related.tabs is defined ? record_related.tabs|reduce((c, t) => c + t.count, 0) : 0,
-    }), with_context = false) }}
+    {{ include('saho:saho-record-toolbar', record_toolbar, with_context = false) }}
   {% endif %}
 
   <div class="saho-article-grid">

--- a/webroot/themes/custom/saho/templates/content/node--biography.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--biography.html.twig
@@ -29,9 +29,7 @@
 
   {# The record toolbar rides directly under the key-field strip (R3 #476). #}
   {% if record_toolbar is defined %}
-    {{ include('saho:saho-record-toolbar', record_toolbar|merge({
-      connections_count: record_related.tabs is defined ? record_related.tabs|reduce((c, t) => c + t.count, 0) : 0,
-    }), with_context = false) }}
+    {{ include('saho:saho-record-toolbar', record_toolbar, with_context = false) }}
   {% endif %}
 
   <div class="saho-article-grid">

--- a/webroot/themes/custom/saho/templates/content/node--event.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--event.html.twig
@@ -32,9 +32,7 @@
 
   {# The record toolbar rides directly under the key-field strip (R3 #476). #}
   {% if record_toolbar is defined %}
-    {{ include('saho:saho-record-toolbar', record_toolbar|merge({
-      connections_count: record_related.tabs is defined ? record_related.tabs|reduce((c, t) => c + t.count, 0) : 0,
-    }), with_context = false) }}
+    {{ include('saho:saho-record-toolbar', record_toolbar, with_context = false) }}
   {% endif %}
 
   <div class="saho-article-grid">

--- a/webroot/themes/custom/saho/templates/content/node--image.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--image.html.twig
@@ -36,9 +36,7 @@
 
   {# The record toolbar rides directly under the key-field strip. #}
   {% if record_toolbar is defined %}
-    {{ include('saho:saho-record-toolbar', record_toolbar|merge({
-      connections_count: record_related.tabs is defined ? record_related.tabs|reduce((c, t) => c + t.count, 0) : 0,
-    }), with_context = false) }}
+    {{ include('saho:saho-record-toolbar', record_toolbar, with_context = false) }}
   {% endif %}
 
   <div class="saho-article-grid">

--- a/webroot/themes/custom/saho/templates/content/node--place.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--place.html.twig
@@ -32,9 +32,7 @@
 
   {# The record toolbar rides directly under the key-field strip (R3 #476). #}
   {% if record_toolbar is defined %}
-    {{ include('saho:saho-record-toolbar', record_toolbar|merge({
-      connections_count: record_related.tabs is defined ? record_related.tabs|reduce((c, t) => c + t.count, 0) : 0,
-    }), with_context = false) }}
+    {{ include('saho:saho-record-toolbar', record_toolbar, with_context = false) }}
   {% endif %}
 
   <div class="saho-article-grid">

--- a/webroot/themes/custom/saho/templates/content/node--upcomingevent.html.twig
+++ b/webroot/themes/custom/saho/templates/content/node--upcomingevent.html.twig
@@ -30,9 +30,7 @@
 
   {# The record toolbar rides directly under the key-field strip (R3 #476). #}
   {% if record_toolbar is defined %}
-    {{ include('saho:saho-record-toolbar', record_toolbar|merge({
-      connections_count: record_related.tabs is defined ? record_related.tabs|reduce((c, t) => c + t.count, 0) : 0,
-    }), with_context = false) }}
+    {{ include('saho:saho-record-toolbar', record_toolbar, with_context = false) }}
   {% endif %}
 
   <div class="saho-article-grid">


### PR DESCRIPTION
## Summary
PR 1 of 4 for the Connections hub work (entity pages currently show e.g. "People 487" but render only 10 with no route to the rest).

- New top-level `saho_connections` module with a `ConnectionsBuilder` service - the single source of truth for a record's cross-references (rail tabs, toolbar count, and the upcoming hub page's full paged lists).
- `_saho_record_related_props()` and friends in saho.theme become thin delegates (`hasService` guard covers the deploy enable-order window); the five ported functions are deleted.
- `connections_count` moves from a twig `reduce` in 7 node templates into PHP, sourced from `totalCount()`.
- `items()` exposes full ordered lists, paged, for the hub page (PR 2).

## Zero visual change - verification
- **Golden-master gate**: `record_related` + count dumped for one record per bundle (ANC 16528, Mandela 65300, place/archive/event/image/upcomingevent samples) before and after - **byte-identical JSON**.
- `totalCount()` == old twig reduce == inventory sum on all samples.
- `items()` walk of ANC people = 487 unique records; page 0 == the rail's 10-item sample.
- Playwright on local DDEV (1440x900 + 390x844): ANC + Mandela rails identical (tab counts, panel links, count lines, archive CTA, sticky pill).
- 6 new kernel tests (140 assertions); full custom suite green (234 tests); phpcs + drupal-check clean.

## Notes
- `core.extension.yml` edited surgically (no blind cex - local config drift).
- Deploy: module enables via config import; the theme guard keeps record pages alive mid-deploy.