### PR TITLE
feat(connections): per-record connections hub at /node/{nid}/connections

### DIFF
--- a/config/sync/block.block.saho_page_title.yml
+++ b/config/sync/block.block.saho_page_title.yml
@@ -23,4 +23,4 @@ visibility:
   request_path:
     id: request_path
     negate: true
-    pages: "<front>\r\n/art-culture\r\n/politics-society\r\n/biographies\r\n/places\r\n/timelines\r\n/africa\r\n/archives\r\n/featured\r\n/timeline"
+    pages: "<front>\r\n/art-culture\r\n/politics-society\r\n/biographies\r\n/places\r\n/timelines\r\n/africa\r\n/archives\r\n/featured\r\n/timeline\r\n/node/*/connections"

--- a/webroot/modules/custom/saho_connections/css/connections-hub.css
+++ b/webroot/modules/custom/saho_connections/css/connections-hub.css
@@ -1,0 +1,187 @@
+/* Connections hub: the register page behind the rail's bounded tabs.
+   Reuses the Open Record tokens already on :root (mono apparatus, oxblood
+   accent, typed dots) - same vocabulary as saho-related-tabs, own classes. */
+.saho-connections {
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: var(--space-4, 2rem) var(--gutter-page, 1rem) var(--space-8, 4rem);
+}
+
+.saho-connections__kicker {
+  margin: 0 0 0.35rem;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs, 0.75rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--saho-oxblood, #990000);
+}
+
+.saho-connections__title {
+  margin: 0 0 0.5rem;
+  font-family: var(--font-masthead, georgia, serif);
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  line-height: 1.12;
+}
+
+/* The title anchor keeps the theme's oxblood link color - deliberate. */
+.saho-connections__title a {
+  text-decoration: none;
+}
+
+.saho-connections__meta {
+  margin: 0 0 1.5rem;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs, 0.75rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--saho-ink-muted, #5d5e52);
+}
+
+.saho-connections__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding-bottom: 8px;
+  border-bottom: var(--bw-rule, 2px) solid var(--border-strong, #8e8a73);
+}
+
+.saho-connections__chips a.saho-connections__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 11px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  border: var(--bw-hair, 1px) solid var(--border-default, #bdb9a6);
+}
+
+/* Chip text lives in spans: the theme's a:not(...) link-color rule is
+   (0,5,1)-specific and unbeatable on the anchor itself - same pattern as
+   the reltabs component. */
+.saho-connections__chip-label {
+  color: var(--text-primary, #1b1c17);
+}
+
+.saho-connections__chips a.saho-connections__chip:hover .saho-connections__chip-label {
+  color: var(--saho-oxblood, #990000);
+}
+
+.saho-connections__chips a.saho-connections__chip.is-active {
+  background: var(--saho-oxblood, #990000);
+  border-color: var(--saho-oxblood, #990000);
+}
+
+.saho-connections__chips a.saho-connections__chip.is-active .saho-connections__chip-label {
+  color: var(--text-on-accent, #fbf3ee);
+}
+
+.saho-connections__chip-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--saho-ink-muted, #5d5e52);
+}
+
+.saho-connections__chips a.saho-connections__chip.is-active .saho-connections__chip-count {
+  color: rgb(255 255 255 / 80%);
+}
+
+.saho-connections__count-line {
+  margin: var(--space-2, 1rem) 0 0;
+  padding-bottom: var(--space-2, 1rem);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--saho-ink-muted, #5d5e52);
+  border-bottom: var(--bw-hair, 1px) solid var(--border-default, #bdb9a6);
+}
+
+.saho-connections__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.saho-connections__item {
+  border-bottom: var(--bw-hair, 1px) solid var(--border-default, #bdb9a6);
+}
+
+.saho-connections__list a.saho-connections__link {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 10px 0;
+  text-decoration: none;
+}
+
+.saho-connections__dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  background: var(--type-article, #990000);
+}
+
+.saho-connections__dot--biography {
+  background: var(--type-biography, #2d5016);
+}
+
+.saho-connections__dot--place {
+  background: var(--type-place, #3a4a64);
+}
+
+.saho-connections__dot--archive {
+  background: var(--type-archive, #8a6420);
+}
+
+.saho-connections__dot--event {
+  background: var(--type-event, #1b1c17);
+}
+
+.saho-connections__dot--topic {
+  background: var(--type-topic, #8b2331);
+}
+
+.saho-connections__dot--image {
+  background: var(--type-image, #6b4a2f);
+}
+
+.saho-connections__list .saho-connections__label {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary, #1b1c17);
+}
+
+.saho-connections__list a.saho-connections__link:hover .saho-connections__label {
+  color: var(--saho-oxblood, #990000);
+}
+
+.saho-connections__note {
+  display: block;
+  font-size: 12.5px;
+  color: var(--saho-ink-muted, #5d5e52);
+}
+
+.saho-connections__foot {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 2rem;
+  margin-top: var(--space-4, 2rem);
+  padding-top: var(--space-2, 1rem);
+  border-top: var(--bw-hair, 1px) solid var(--border-default, #bdb9a6);
+}
+
+.saho-connections .saho-connections__foot a {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--saho-oxblood, #990000);
+  text-decoration: none;
+}
+
+.saho-connections .saho-connections__foot a:hover {
+  color: var(--text-primary, #1b1c17);
+  text-decoration: underline;
+}

--- a/webroot/modules/custom/saho_connections/saho_connections.libraries.yml
+++ b/webroot/modules/custom/saho_connections/saho_connections.libraries.yml
@@ -1,0 +1,4 @@
+connections-hub:
+  css:
+    component:
+      css/connections-hub.css: {}

--- a/webroot/modules/custom/saho_connections/saho_connections.module
+++ b/webroot/modules/custom/saho_connections/saho_connections.module
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations for the SAHO connections hub.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_theme().
+ */
+function saho_connections_theme(): array {
+  return [
+    'saho_connections_hub' => [
+      'variables' => [
+        'record' => [],
+        'total' => 0,
+        'chips' => [],
+        'active' => [],
+        'items' => [],
+        'pager' => [],
+        'collection_url' => '',
+      ],
+    ],
+  ];
+}

--- a/webroot/modules/custom/saho_connections/saho_connections.routing.yml
+++ b/webroot/modules/custom/saho_connections/saho_connections.routing.yml
@@ -1,0 +1,12 @@
+saho_connections.hub:
+  path: '/node/{node}/connections'
+  defaults:
+    _controller: 'Drupal\saho_connections\Controller\ConnectionsHubController::page'
+    _title_callback: 'Drupal\saho_connections\Controller\ConnectionsHubController::title'
+  requirements:
+    _entity_access: 'node.view'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node

--- a/webroot/modules/custom/saho_connections/src/Controller/ConnectionsHubController.php
+++ b/webroot/modules/custom/saho_connections/src/Controller/ConnectionsHubController.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\saho_connections\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Pager\PagerManagerInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\saho_connections\ConnectionsBuilder;
+use Drupal\saho_connections\ConnectionsBuilderInterface;
+use Drupal\saho_refs\DisplayRefService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * The per-record connections hub: the full list behind the rail's counts.
+ *
+ * The rail shows "People 487" but renders a bounded sample; this page IS
+ * the list - one canonical URL per record, one connected-record type at a
+ * time (?tab=), 50 rows per page. Counts come from the same builder the
+ * rail reads, so the two surfaces can never disagree.
+ */
+final class ConnectionsHubController extends ControllerBase {
+
+  /**
+   * Record bundles that carry the Open Record apparatus.
+   *
+   * Everything else 404s: the hub must not mint an indexable URL for every
+   * node on the site.
+   */
+  private const RECORD_BUNDLES = [
+    'article',
+    'biography',
+    'place',
+    'archive',
+    'event',
+    'image',
+    'upcomingevent',
+  ];
+
+  /**
+   * Rows per page - dense ruled rows; ANC's 487 people = 10 pages.
+   */
+  private const PAGE_SIZE = 50;
+
+  public function __construct(
+    private readonly ConnectionsBuilderInterface $connections,
+    private readonly PagerManagerInterface $pagerManager,
+    private readonly RequestStack $requestStack,
+    private readonly DisplayRefService $displayRef,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('saho_connections.builder'),
+      $container->get('pager.manager'),
+      $container->get('request_stack'),
+      $container->get('saho_refs.display_ref'),
+    );
+  }
+
+  /**
+   * Page title: "Connections · <record label>".
+   */
+  public function title(NodeInterface $node): string {
+    return 'Connections · ' . $node->label();
+  }
+
+  /**
+   * Builds the hub page.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The record node.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function page(NodeInterface $node): array {
+    if (!in_array($node->bundle(), self::RECORD_BUNDLES, TRUE)) {
+      throw new NotFoundHttpException();
+    }
+    $inventory = $this->connections->inventory($node);
+    if ($inventory === []) {
+      throw new NotFoundHttpException();
+    }
+
+    // ?tab= is the one facet; anything not in the inventory falls back to
+    // the first tab, in rail order. (Bad values are 200s: every query-string
+    // variant of this route is noindexed anyway.) all()[...] rather than
+    // get(): InputBag::get() throws on array input (?tab[]=x), and scraper
+    // requests must degrade, not error.
+    $requested = $this->requestStack->getCurrentRequest()->query->all()['tab'] ?? NULL;
+    $tab_id = is_string($requested) && isset($inventory[$requested])
+      ? $requested
+      : array_key_first($inventory);
+
+    $total = $inventory[$tab_id]['count'];
+    $pager = $this->pagerManager->createPager($total, self::PAGE_SIZE);
+    $result = $this->connections->items($node, $tab_id, $pager->getCurrentPage(), self::PAGE_SIZE);
+
+    $hub_url = Url::fromRoute('saho_connections.hub', ['node' => $node->id()]);
+    $chips = [];
+    foreach ($inventory as $id => $info) {
+      $chips[] = [
+        'id' => $id,
+        'label' => $info['label'],
+        'count' => $info['count'],
+        'href' => $hub_url->setOption('query', ['tab' => $id])->toString(),
+        'active' => $id === $tab_id,
+      ];
+    }
+
+    $build = [
+      '#theme' => 'saho_connections_hub',
+      '#record' => [
+        'title' => $node->label(),
+        'href' => $node->toUrl()->toString(),
+        'type' => $node->bundle(),
+        'reference' => $this->displayRef->getRef($node),
+        'total' => $this->connections->totalCount($node),
+      ],
+      '#total' => $total,
+      '#chips' => $chips,
+      '#active' => [
+        'id' => $tab_id,
+        'label' => $result['label'],
+      ],
+      '#items' => $result['items'],
+      '#pager' => ['#type' => 'pager'],
+      // The archive tab defers to the richer faceted index as well.
+      '#collection_url' => $tab_id === 'archive' && $total > ConnectionsBuilder::THRESHOLD
+        ? Url::fromUserInput('/archives', ['query' => ['collection' => $node->id()]])->toString()
+        : '',
+      '#attached' => ['library' => ['saho_connections/connections-hub']],
+      '#cache' => [
+        'contexts' => [
+          'user.permissions',
+          'url.query_args:tab',
+          'url.query_args:page',
+        ],
+        'tags' => $node->getCacheTags(),
+      ],
+    ];
+    foreach ($this->connections->cacheTags() as $tag) {
+      $build['#cache']['tags'][] = $tag;
+    }
+    return $build;
+  }
+
+}

--- a/webroot/modules/custom/saho_connections/templates/saho-connections-hub.html.twig
+++ b/webroot/modules/custom/saho_connections/templates/saho-connections-hub.html.twig
@@ -1,0 +1,64 @@
+{#
+/**
+ * @file
+ * The per-record connections hub - the full list behind the rail's counts.
+ *
+ * Available variables:
+ * - record: title, href, type, reference, total (all connected records).
+ * - total: count for the active tab.
+ * - chips: type-selector links (id, label, count, href, active).
+ * - active: the selected tab (id, label).
+ * - items: rows (label, href, note, type).
+ * - pager: pager render array.
+ * - collection_url: /archives?collection= link for big archive tabs, or ''.
+ */
+#}
+<div class="saho-connections">
+  <header class="saho-connections__head">
+    <p class="saho-connections__kicker">Connections</p>
+    <h1 class="saho-connections__title">
+      <a href="{{ record.href }}">{{ record.title }}</a>
+    </h1>
+    <p class="saho-connections__meta">
+      {% if record.reference %}<span class="saho-connections__ref">{{ record.reference }}</span> ·{% endif %}
+      {{ record.total|number_format }} connected record{{ record.total == 1 ? '' : 's' }}
+    </p>
+  </header>
+
+  <nav class="saho-connections__chips" aria-label="{{ 'Connected record types'|t }}">
+    {% for chip in chips %}
+      <a href="{{ chip.href }}"
+         class="saho-connections__chip{{ chip.active ? ' is-active' : '' }}"
+         {% if chip.active %}aria-current="page"{% endif %}>
+        <span class="saho-connections__chip-label">{{ chip.label }}</span><span class="saho-connections__chip-count">{{ chip.count|number_format }}</span>
+      </a>
+    {% endfor %}
+  </nav>
+
+  <p class="saho-connections__count-line">{{ total|number_format }} {{ active.label|upper }}</p>
+
+  <ul class="saho-connections__list">
+    {% for item in items %}
+      <li class="saho-connections__item">
+        <a class="saho-connections__link" href="{{ item.href }}">
+          <span class="saho-connections__dot saho-connections__dot--{{ item.type|default('article') }}" aria-hidden="true"></span>
+          <span class="saho-connections__text">
+            <span class="saho-connections__label">{{ item.label }}</span>
+            {% if item.note %}
+              <span class="saho-connections__note">{{ item.note }}</span>
+            {% endif %}
+          </span>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+
+  {{ pager }}
+
+  <footer class="saho-connections__foot">
+    <a class="saho-connections__back" href="{{ record.href }}">&#8592; Back to {{ record.title }}</a>
+    {% if collection_url %}
+      <a class="saho-connections__browse" href="{{ collection_url }}">Browse the collection in the archive index &#8594;</a>
+    {% endif %}
+  </footer>
+</div>

--- a/webroot/modules/custom/saho_connections/tests/src/Kernel/ConnectionsHubControllerTest.php
+++ b/webroot/modules/custom/saho_connections/tests/src/Kernel/ConnectionsHubControllerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_connections\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\saho_connections\Controller\ConnectionsHubController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Tests the connections hub controller: chips, paging, guards.
+ *
+ * @group saho_connections
+ */
+final class ConnectionsHubControllerTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'node',
+    'taxonomy',
+    'saho_refs',
+    'saho_connections',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installSchema('node', ['node_access']);
+
+    foreach (['article', 'archive', 'biography', 'page'] as $bundle) {
+      NodeType::create(['type' => $bundle, 'name' => $bundle])->save();
+    }
+    FieldStorageConfig::create([
+      'field_name' => 'field_feature_parent',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'node'],
+    ])->save();
+    foreach (['article', 'archive', 'biography'] as $bundle) {
+      FieldConfig::create([
+        'field_name' => 'field_feature_parent',
+        'entity_type' => 'node',
+        'bundle' => $bundle,
+      ])->save();
+    }
+    // The curated inventory SQL joins this field's table unconditionally.
+    FieldStorageConfig::create([
+      'field_name' => 'field_article_type',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'taxonomy_term'],
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_article_type',
+      'entity_type' => 'node',
+      'bundle' => 'article',
+    ])->save();
+
+    $this->setUpCurrentUser(['uid' => 1]);
+    $this->container->get('router.builder')->rebuild();
+  }
+
+  /**
+   * Creates a published node.
+   */
+  private function makeNode(string $bundle, string $title, array $values = []): Node {
+    $node = Node::create($values + ['type' => $bundle, 'title' => $title, 'status' => 1]);
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * Builds a parent with 12 archive children and 1 biography child.
+   */
+  private function makeCollection(): Node {
+    $parent = $this->makeNode('article', 'Collection head');
+    for ($i = 1; $i <= 12; $i++) {
+      $this->makeNode('archive', sprintf('Doc %02d', $i), [
+        'field_feature_parent' => $parent->id(),
+      ]);
+    }
+    $this->makeNode('biography', 'Child person', [
+      'field_feature_parent' => $parent->id(),
+    ]);
+    return $parent;
+  }
+
+  /**
+   * Runs the controller with the given query parameters.
+   */
+  private function runPage(Node $node, array $query = []): array {
+    $request = Request::create('/node/' . $node->id() . '/connections', 'GET', $query);
+    $this->container->get('request_stack')->push($request);
+    try {
+      return ConnectionsHubController::create($this->container)->page($node);
+    }
+    finally {
+      $this->container->get('request_stack')->pop();
+    }
+  }
+
+  /**
+   * The hub renders chips and items matching the builder's inventory.
+   */
+  public function testHubStructure(): void {
+    $parent = $this->makeCollection();
+    $build = $this->runPage($node = $parent);
+
+    $this->assertSame('saho_connections_hub', $build['#theme']);
+    $this->assertSame('Collection head', $build['#record']['title']);
+    $this->assertSame(13, $build['#record']['total']);
+
+    $chips = array_column($build['#chips'], 'count', 'id');
+    $this->assertSame(['people' => 1, 'archive' => 12], $chips);
+
+    // Default tab = first inventory entry (rail order: people first).
+    $this->assertSame('people', $build['#active']['id']);
+    $this->assertCount(1, $build['#items']);
+    $this->assertSame(1, $build['#total']);
+    $this->assertSame('', $build['#collection_url']);
+
+    // Cache metadata: host node tags + the builder's node_list set.
+    $this->assertContains('node:' . $node->id(), $build['#cache']['tags']);
+    $this->assertContains('node_list:archive', $build['#cache']['tags']);
+    $this->assertContains('url.query_args:tab', $build['#cache']['contexts']);
+  }
+
+  /**
+   * The archive tab pages the full list and links the archive index.
+   */
+  public function testArchiveTab(): void {
+    $parent = $this->makeCollection();
+    $build = $this->runPage($parent, ['tab' => 'archive']);
+
+    $this->assertSame('archive', $build['#active']['id']);
+    $this->assertSame(12, $build['#total']);
+    $this->assertCount(12, $build['#items']);
+    $this->assertStringContainsString('collection=' . $parent->id(), $build['#collection_url']);
+    // Chips carry hub URLs with tab preselection.
+    foreach ($build['#chips'] as $chip) {
+      $this->assertStringContainsString('/node/' . $parent->id() . '/connections?tab=' . $chip['id'], $chip['href']);
+    }
+  }
+
+  /**
+   * A bogus ?tab= falls back to the default tab, never errors.
+   */
+  public function testBogusTabFallsBack(): void {
+    $parent = $this->makeCollection();
+    $build = $this->runPage($parent, ['tab' => 'bogus']);
+    $this->assertSame('people', $build['#active']['id']);
+    // Array abuse also falls back (the flood subscriber caps it upstream).
+    $build = $this->runPage($parent, ['tab' => ['a', 'b']]);
+    $this->assertSame('people', $build['#active']['id']);
+  }
+
+  /**
+   * Non-record bundles and records without connections 404.
+   */
+  public function testGuards(): void {
+    $page = $this->makeNode('page', 'About us');
+    try {
+      $this->runPage($page);
+      $this->fail('Non-record bundle should 404.');
+    }
+    catch (NotFoundHttpException) {
+    }
+
+    $bare = $this->makeNode('article', 'No relations');
+    try {
+      $this->runPage($bare);
+      $this->fail('A record without connections should 404.');
+    }
+    catch (NotFoundHttpException) {
+    }
+  }
+
+  /**
+   * The title callback names the record.
+   */
+  public function testTitle(): void {
+    $parent = $this->makeCollection();
+    $this->assertSame(
+      'Connections · Collection head',
+      ConnectionsHubController::create($this->container)->title($parent)
+    );
+  }
+
+}

--- a/webroot/modules/custom/saho_performance/src/EventSubscriber/FacetFloodSubscriber.php
+++ b/webroot/modules/custom/saho_performance/src/EventSubscriber/FacetFloodSubscriber.php
@@ -26,14 +26,23 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class FacetFloodSubscriber implements EventSubscriberInterface {
 
   /**
-   * Route name of the classroom deck browse page.
+   * Facet parameters counted per protected route.
+   *
+   * Keyed by route name; the value lists the exposed filter identifiers
+   * whose selected values count toward the cap on that route.
    */
-  protected const CLASSROOM_ROUTE = 'view.classroom_presentations.page_1';
-
-  /**
-   * Exposed filter identifiers whose selected values are counted.
-   */
-  protected const FACET_PARAMS = ['caps_topic', 'grade'];
+  protected const ROUTE_FACET_PARAMS = [
+    // /classroom - hub page; the crawler pack moved here once the edge rule
+    // challenged /classroom/presentations (2026-07-24, ~1.5k
+    // resource_type[]/subject[] combinations in two hours).
+    'view.classroom.page_1' => ['caps_topic', 'grade', 'resource_type', 'subject'],
+    // /classroom/presentations - deck browse page.
+    'view.classroom_presentations.page_1' => ['caps_topic', 'grade', 'resource_type', 'subject'],
+    // /node/{nid}/connections - the per-record connections hub. Legitimate
+    // requests carry at most scalar ?tab= and ?page=; array abuse
+    // (tab[]=a&tab[]=b&...) is the same enumeration shape.
+    'saho_connections.hub' => ['tab', 'page'],
+  ];
 
   /**
    * Maximum total selected facet values before the request is rejected.
@@ -78,13 +87,14 @@ class FacetFloodSubscriber implements EventSubscriberInterface {
    *   The request event.
    */
   public function onRequest(RequestEvent $event) {
+    $route_name = $this->routeMatch->getRouteName();
     if (!$event->isMainRequest()
-      || $this->routeMatch->getRouteName() !== static::CLASSROOM_ROUTE) {
+      || !isset(static::ROUTE_FACET_PARAMS[$route_name])) {
       return;
     }
 
     $selected = 0;
-    foreach (static::FACET_PARAMS as $param) {
+    foreach (static::ROUTE_FACET_PARAMS[$route_name] as $param) {
       $values = $event->getRequest()->query->all()[$param] ?? [];
       $selected += is_array($values) ? count($values) : 1;
     }

--- a/webroot/modules/custom/saho_performance/src/EventSubscriber/SeoRobotsSubscriber.php
+++ b/webroot/modules/custom/saho_performance/src/EventSubscriber/SeoRobotsSubscriber.php
@@ -49,8 +49,16 @@ class SeoRobotsSubscriber implements EventSubscriberInterface {
    * /search, and the target of a 20k-URL scraper sweep on 2026-07-24.
    */
   protected const NOINDEX_FILTERED_ROUTES = [
+    // /classroom - hub page; the crawler pack moved here once the edge
+    // rule challenged /classroom/presentations (2026-07-24, ~1.5k
+    // resource_type[]/subject[] combinations in two hours).
+    'view.classroom.page_1',
     // /classroom/presentations - deck browse page with facet checkboxes.
     'view.classroom_presentations.page_1',
+    // /node/{nid}/connections - the per-record connections hub. The bare
+    // page is a deliberate internal-linking asset; its ?tab=/?page=
+    // variants are working views of the same list.
+    'saho_connections.hub',
   ];
 
   /**

--- a/webroot/modules/custom/saho_performance/tests/src/Unit/FacetFloodSubscriberTest.php
+++ b/webroot/modules/custom/saho_performance/tests/src/Unit/FacetFloodSubscriberTest.php
@@ -120,4 +120,46 @@ class FacetFloodSubscriberTest extends UnitTestCase {
     ));
   }
 
+  /**
+   * @covers ::onRequest
+   */
+  public function testClassroomHubSweepIsRejected(): void {
+    // The 2026-07-24 follow-up sweep: resource_type[] x subject[] on the
+    // /classroom hub once the deck browse page got challenged.
+    $params = [];
+    foreach (range(1, 6) as $i) {
+      $params[] = "resource_type%5BType$i%5D=Type$i";
+    }
+    foreach (range(1, 4) as $i) {
+      $params[] = "subject%5BSubject$i%5D=Subject$i";
+    }
+    $response = $this->runFor('view.classroom.page_1', '/classroom?' . implode('&', $params));
+    $this->assertNotNull($response);
+    $this->assertSame(400, $response->getStatusCode());
+    // A realistic narrowing passes.
+    $this->assertNull($this->runFor(
+      'view.classroom.page_1',
+      '/classroom?resource_type%5BWorksheet%5D=Worksheet&subject%5BHistory%5D=History'
+    ));
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testConnectionsHubArrayAbuseIsRejected(): void {
+    // Legitimate hub requests carry scalar ?tab= and ?page=.
+    $this->assertNull($this->runFor(
+      'saho_connections.hub',
+      '/node/16528/connections?tab=people&page=3'
+    ));
+    // Array enumeration over the same params is the scraper shape.
+    $abuse = implode('&', array_map(
+      static fn(int $i): string => "tab%5B%5D=t$i",
+      range(1, 9)
+    ));
+    $response = $this->runFor('saho_connections.hub', '/node/16528/connections?' . $abuse);
+    $this->assertNotNull($response);
+    $this->assertSame(400, $response->getStatusCode());
+  }
+
 }

--- a/webroot/modules/custom/saho_performance/tests/src/Unit/SeoRobotsSubscriberTest.php
+++ b/webroot/modules/custom/saho_performance/tests/src/Unit/SeoRobotsSubscriberTest.php
@@ -114,4 +114,41 @@ class SeoRobotsSubscriberTest extends UnitTestCase {
     );
   }
 
+  /**
+   * @covers ::onResponse
+   */
+  public function testFilteredClassroomHubGetsNoindex(): void {
+    $request = Request::create('/classroom?resource_type%5BWorksheet%5D=Worksheet');
+    $this->assertSame(
+      'noindex, follow',
+      $this->runFor('view.classroom.page_1', $this->htmlResponse(), $request)
+    );
+    $this->assertNull(
+      $this->runFor('view.classroom.page_1', $this->htmlResponse(), Request::create('/classroom'))
+    );
+  }
+
+  /**
+   * @covers ::onResponse
+   */
+  public function testConnectionsHubVariantsGetNoindexBarePageStaysIndexable(): void {
+    // The bare hub is a deliberate internal-linking asset.
+    $this->assertNull(
+      $this->runFor('saho_connections.hub', $this->htmlResponse(), Request::create('/node/16528/connections'))
+    );
+    // Every query variant (?tab=, ?page=, both) is a working view of the
+    // same list - noindex, follow.
+    foreach ([
+      '/node/16528/connections?tab=people',
+      '/node/16528/connections?page=3',
+      '/node/16528/connections?tab=archive&page=12',
+    ] as $uri) {
+      $this->assertSame(
+        'noindex, follow',
+        $this->runFor('saho_connections.hub', $this->htmlResponse(), Request::create($uri)),
+        "$uri should be de-indexed."
+      );
+    }
+  }
+
 }

--- a/webroot/modules/custom/saho_tools/saho_tools.module
+++ b/webroot/modules/custom/saho_tools/saho_tools.module
@@ -240,20 +240,26 @@ function saho_tools_preprocess_html(&$variables) {
     if ($node instanceof NodeInterface) {
       // Invalidate the cached page (and its embedded JSON-LD) on node edit.
       $variables['#cache']['tags'] = Cache::mergeTags($variables['#cache']['tags'] ?? [], $node->getCacheTags());
-      $canonical_url = $node->toUrl('canonical')->setAbsolute()->toString();
 
-      // Add canonical link to head.
-      $variables['#attached']['html_head'][] = [
-        [
-          '#type' => 'html_tag',
-          '#tag' => 'link',
-          '#attributes' => [
-            'rel' => 'canonical',
-            'href' => $canonical_url,
+      // Add canonical link to head - but only on the node's own canonical
+      // route. Sub-routes carrying a {node} parameter (the connections hub
+      // at /node/N/connections, previews, revisions) are distinct documents;
+      // pointing their canonical at the node page would de-index them.
+      // They fall through to Metatag's [current-page:url] self-canonical.
+      if (\Drupal::routeMatch()->getRouteName() === 'entity.node.canonical') {
+        $canonical_url = $node->toUrl('canonical')->setAbsolute()->toString();
+        $variables['#attached']['html_head'][] = [
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'link',
+            '#attributes' => [
+              'rel' => 'canonical',
+              'href' => $canonical_url,
+            ],
           ],
-        ],
-        'canonical_url',
-      ];
+          'canonical_url',
+        ];
+      }
 
       // 2. Node-specific schema.
       $node_schema = $schema_service->generateSchemaForNode($node);


### PR DESCRIPTION
## Summary
PR 3 of 4 (stacked on #554 -> #553; merge in order). The core deliverable: entity pages said "People 487" but rendered 10 with no route to the other 477 - this page IS the list.

- **Route** `/node/{nid}/connections` (`_entity_access: node.view`, entity:node param, bundle-gated to the 7 record types, 404 when a record has no connections).
- **Page**: mono CONNECTIONS kicker, Caslon record title linking back, `REF · N CONNECTED RECORDS`, one chip per connected type with counts, 50 ruled rows/page with typed dots + notes, standard pager, foot links (back to record; archive tab also links `/archives?collection=NID`). `?tab=` is the only facet, server-rendered; bogus/array values fall back to the default tab (InputBag `all()` - no scalar-input 500s).
- **Counts can't drift**: chips, count line, totals all read the PR-#553 `ConnectionsBuilder` - the same spec the rail renders.

## SEO (post-scraper-incident rules)
- `SeoRobotsSubscriber`: bare hub indexable; every `?tab=`/`?page=` variant gets `X-Robots-Tag: noindex, follow` (the classroom shape).
- `FacetFloodSubscriber`: consts generalized to a route=>params map (classroom behavior bit-identical - tests untouched and passing); hub array abuse (9x `tab[]=`) answers 400. **Also folds in the unshipped /classroom hub coverage** from the 2026-07-24 follow-up sweep - the dangling `seo/classroom-facet-backstop` branch commit (ad52587ae) is now superseded and the branch can be deleted.
- `saho_tools_preprocess_html()` canonical emission gated to `entity.node.canonical` - previously ANY route with a {node} param (hub, previews, revisions) emitted a canonical pointing at the node page, which would have kept the hub out of the index forever. Record-page canonicals verified unchanged.
- Page-title block visibility: `/node/*/connections` added to the hidden list (template carries the header), the /featured pattern.

## Verification
- 9 new PHPUnit cases (hub kernel tests + subscriber cases); full custom suite green (243 tests, 1,659 assertions); phpcs + drupal-check clean.
- Live headers on DDEV: bare hub 200 + no robots header + self-canonical; `?tab=people` -> `noindex, follow`; 9x `tab[]=` -> 400; classroom + record pages byte-identical behavior.
- Playwright desktop 1440 + mobile 390: chips render (active chip label needed a span - the theme's (0,5,1) `a:not(...)` link rule is unbeatable on anchors), `?tab=people&page=9` shows exactly the last 37 of 487 people, archive tab shows 708 across 15 pages + archive-index link.