### PR TITLE
feat(reltabs): pin a 'View all N ...' hub exit to every cross-reference tab

### DIFF
--- a/webroot/modules/custom/saho_connections/src/ConnectionsBuilder.php
+++ b/webroot/modules/custom/saho_connections/src/ConnectionsBuilder.php
@@ -274,6 +274,17 @@ final class ConnectionsBuilder implements ConnectionsBuilderInterface {
       }
     }
 
+    // Every tab gets a hub exit: the rail is a bounded sample, the hub page
+    // IS the list. Pinned to the panel foot by the component.
+    foreach ($tabs as $id => $tab) {
+      $tabs[$id]['cta'] = [
+        'label' => $tab['count'] > 1
+          ? 'View all ' . number_format($tab['count']) . ' ' . $this->ctaNoun($id, $tab['label'])
+          : 'View in the connections register',
+        'href' => Url::fromRoute('saho_connections.hub', ['node' => $nid], ['query' => ['tab' => $id]])->toString(),
+      ];
+    }
+
     $spec = ['tabs' => []];
     foreach ($tabs as $id => $tab) {
       $spec['tabs'][$id] = $sources[$id] + ['props' => $tab];
@@ -613,6 +624,29 @@ final class ConnectionsBuilder implements ConnectionsBuilderInterface {
       'note' => $note !== '' ? Unicode::truncate($note, 90, TRUE, TRUE) : '',
       'type' => in_array($ref->bundle(), $known_types, TRUE) ? $ref->bundle() : 'article',
     ];
+  }
+
+  /**
+   * The noun for a tab's "View all N ..." hub exit.
+   *
+   * Matches the count-line vocabulary: the archive tab counts ARCHIVE
+   * ITEMS, the galleries tab counts IMAGES; every other tab's label
+   * lowercases cleanly.
+   *
+   * @param string $id
+   *   The tab id.
+   * @param string $label
+   *   The tab label.
+   *
+   * @return string
+   *   A plural noun phrase.
+   */
+  private function ctaNoun(string $id, string $label): string {
+    return match ($id) {
+      'archive' => 'archive items',
+      'galleries' => 'images',
+      default => mb_strtolower($label),
+    };
   }
 
   /**

--- a/webroot/modules/custom/saho_connections/tests/src/Kernel/ConnectionsBuilderTest.php
+++ b/webroot/modules/custom/saho_connections/tests/src/Kernel/ConnectionsBuilderTest.php
@@ -121,6 +121,8 @@ final class ConnectionsBuilderTest extends KernelTestBase {
 
     // Admin current user: relatedItem() honours access('view').
     $this->setUpCurrentUser(['uid' => 1]);
+    // The per-tab hub CTAs generate saho_connections.hub URLs.
+    $this->container->get('router.builder')->rebuild();
 
     $this->builder = $this->container->get('saho_connections.builder');
   }
@@ -234,6 +236,13 @@ final class ConnectionsBuilderTest extends KernelTestBase {
     $this->assertSame('12 ARCHIVE ITEMS', $archive['summary']['count_line']);
     $this->assertSame('Browse the Collection head collection', $archive['summary']['cta']['label']);
     $this->assertStringContainsString('collection=' . $parent->id(), $archive['summary']['cta']['href']);
+    // Every tab carries a hub exit; nouns match the count-line vocabulary.
+    $this->assertSame('View all 12 archive items', $archive['cta']['label']);
+    $this->assertStringContainsString('/node/' . $parent->id() . '/connections?tab=archive', $archive['cta']['href']);
+    $this->assertSame('View all 2 organisations', $this->tab($props, 'organisations')['cta']['label']);
+    // Single-item tabs get the neutral label ("View all 1 articles" reads
+    // wrong).
+    $this->assertSame('View in the connections register', $this->tab($props, 'articles')['cta']['label']);
     // Title-ascending order.
     $this->assertSame('Doc 01', $archive['items'][0]['label']);
     $this->assertSame('Doc 10', $archive['items'][9]['label']);
@@ -310,6 +319,7 @@ final class ConnectionsBuilderTest extends KernelTestBase {
     $this->assertSame(12, $galleries['count']);
     $this->assertCount(ConnectionsBuilder::THRESHOLD, $galleries['items']);
     $this->assertSame('12 IMAGES', $galleries['summary']['count_line']);
+    $this->assertSame('View all 12 images', $galleries['cta']['label']);
     // Newest first.
     $this->assertSame('Photo 12', $galleries['items'][0]['label']);
 

--- a/webroot/themes/custom/saho/components/navigation/saho-related-tabs/saho-related-tabs.component.yml
+++ b/webroot/themes/custom/saho/components/navigation/saho-related-tabs/saho-related-tabs.component.yml
@@ -22,6 +22,15 @@ props:
             type: string
           count:
             type: integer
+          cta:
+            type: object
+            title: 'Hub exit (View all N ...)'
+            description: 'Pinned to the panel foot on every tab; links the connections hub with this tab preselected. Omit the key entirely when absent - never pass null.'
+            properties:
+              label:
+                type: string
+              href:
+                type: string
           summary:
             type: object
             title: 'Collection summary (bounded high-degree tab)'

--- a/webroot/themes/custom/saho/components/navigation/saho-related-tabs/saho-related-tabs.css
+++ b/webroot/themes/custom/saho/components/navigation/saho-related-tabs/saho-related-tabs.css
@@ -136,13 +136,21 @@
   border-bottom: var(--bw-hair) solid var(--border-default);
   list-style: none;
 }
-.saho-reltabs__summary-cta {
-  margin-top: var(--space-2);
-  padding-top: var(--space-2);
+/* The panel's exits: the hub link (every tab) plus the archive index link
+   (collection tabs). Sticky-bottom mirror of the sticky-top count line, so
+   the way out never scrolls out of the 480px box. */
+.saho-reltabs__cta {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-2) 0;
+  background: var(--surface-card);
   border-top: var(--bw-hair) solid var(--border-default);
-  list-style: none;
 }
-.saho-reltabs__summary-cta a {
+.saho-reltabs__cta-link {
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: var(--ls-label);
@@ -150,7 +158,7 @@
   text-decoration: none;
   color: var(--saho-oxblood, #990000);
 }
-.saho-reltabs__summary-cta a:hover {
+.saho-reltabs__cta-link:hover {
   color: var(--text-primary);
   text-decoration: underline;
 }

--- a/webroot/themes/custom/saho/components/navigation/saho-related-tabs/saho-related-tabs.twig
+++ b/webroot/themes/custom/saho/components/navigation/saho-related-tabs/saho-related-tabs.twig
@@ -39,12 +39,21 @@
             </a>
           </li>
         {% endfor %}
-        {% if t.summary and t.summary.cta %}
-          <li class="saho-reltabs__summary-cta">
-            <a href="{{ t.summary.cta.href }}">{{ t.summary.cta.label }} &#8594;</a>
-          </li>
-        {% endif %}
       </ul>
+      {# The exits pin to the panel's bottom edge (sticky, mirroring the
+         sticky-top count line) so they never scroll out of the 480px box:
+         the hub link on every tab, plus the archive index link when the
+         builder provides one. #}
+      {% if t.cta or (t.summary and t.summary.cta) %}
+        <div class="saho-reltabs__cta">
+          {% if t.cta %}
+            <a class="saho-reltabs__cta-link" href="{{ t.cta.href }}">{{ t.cta.label }} &#8594;</a>
+          {% endif %}
+          {% if t.summary and t.summary.cta %}
+            <a class="saho-reltabs__cta-link" href="{{ t.summary.cta.href }}">{{ t.summary.cta.label }} &#8594;</a>
+          {% endif %}
+        </div>
+      {% endif %}
     </div>
   {% endfor %}
 </section>


### PR DESCRIPTION
## Summary
PR 4 of 4 (stacked on #555 -> #554 -> #553; merge in order). Closes the loop: every rail tab now links its full list.

- `ConnectionsBuilder::tabs()` adds a `cta` to every tab: "View all 487 people ->" linking `/node/{nid}/connections?tab=people`. Nouns match the count-line vocabulary (`archive items`, `images`); single-item tabs get a neutral "View in the connections register".
- New top-level `tabs[].cta` prop in the SDC schema (key omitted when absent - SDC 11.4 validation).
- The CTA renders in a `.saho-reltabs__cta` bar AFTER the list, `position: sticky; bottom: 0` - the mirror of the sticky-top count line - so the exit never scrolls out of the 480px panel. The archive tab's `/archives?collection=` link moves into the same bar as a second exit (the old `__summary-cta` `<li>` scrolled away with the list).

## Verification (Playwright, local DDEV)
- ANC article: all 7 tabs carry their exit (People 487 / Topics 12 / Articles 42 / Places 4 / Organisations 7 / Timelines 18 / Archive 708 + collection link).
- Sticky check: with the people panel scrolled to 200px, the CTA's boundingRect stays inside the panel box.
- Links land on the hub with the right tab preselected (#555's kernel tests cover the ?tab= handling).
- Kernel tests extended (CTA labels/hrefs, noun special cases); saho_connections suite green (11 tests, 235 assertions); phpcs + biome clean. Component CSS/twig are source files - no build step.