### PR TITLE
fix(toolbar): constant-height mobile row - kill the stick-transition jank

### DIFF
--- a/webroot/themes/custom/saho/components/content/saho-record-toolbar/saho-record-toolbar.css
+++ b/webroot/themes/custom/saho/components/content/saho-record-toolbar/saho-record-toolbar.css
@@ -69,14 +69,30 @@
   text-transform: none;
 }
 
-/* The mobile pill: while stuck below 768px the toolbar collapses from the
-   wrapped multi-row stack to one compact row - REF, Cite, and a prominent
-   "Connections · N". Permanent link and Share are deliberate low-frequency
-   acts the reader scrolls up for; display:none takes them out of the tab
-   order honestly. At rest the toolbar renders exactly as before. */
+/* The mobile pill row: below 768px the toolbar is ONE constant-height
+   swipeable row at every scroll position (the decade-strip pattern). The
+   stuck flip must never change the toolbar's flow height - v2.3.0
+   collapsed a wrapped multi-row stack down to one row on stick, and every
+   crossing was a 0.12+ layout shift felt as a scroll hitch on phones.
+   While stuck, Permanent link and Share hide (width-only change inside
+   the scrollable row; display:none keeps the tab order honest) and
+   "Connections · N" takes the accent - REF appears via the base rule. */
 @media (max-width: 47.9375rem) {
-  .saho-record-toolbar.is-stuck .saho-record-toolbar__actions {
+  .saho-record-toolbar__actions {
     flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .saho-record-toolbar__action {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  /* Connections leads the swipeable row - it is the toolbar's star action
+     on a phone; Permanent link and Share sit past the right edge. */
+  .saho-record-toolbar__actions [data-saho-connections] {
+    order: -1;
   }
 
   .saho-record-toolbar.is-stuck [data-saho-permanent-link],

--- a/webroot/themes/custom/saho/components/content/saho-record-toolbar/saho-record-toolbar.js
+++ b/webroot/themes/custom/saho/components/content/saho-record-toolbar/saho-record-toolbar.js
@@ -22,10 +22,12 @@
   };
   const headerOffset = () => headerHeight() + displaceTop();
   const publishHeaderHeight = () => {
-    document.documentElement.style.setProperty(
-      '--saho-header-height',
-      `${Math.round(headerHeight())}px`
-    );
+    const next = `${Math.round(headerHeight())}px`;
+    const root = document.documentElement;
+    // Same-value writes still dirty styles page-wide - skip them.
+    if (root.style.getPropertyValue('--saho-header-height') !== next) {
+      root.style.setProperty('--saho-header-height', next);
+    }
   };
 
   Drupal.behaviors.sahoRecordToolbar = {
@@ -55,11 +57,24 @@
         observe();
 
         let resizeTimer;
+        let lastWidth = window.innerWidth;
+        let lastOffset = Math.ceil(headerOffset());
         window.addEventListener('resize', () => {
           clearTimeout(resizeTimer);
           resizeTimer = setTimeout(() => {
+            // Phones fire resize for every URL-bar show/hide during scroll;
+            // only a width change can alter the header's height. Rebuild the
+            // observer only when the offset really moved.
+            if (window.innerWidth === lastWidth) {
+              return;
+            }
+            lastWidth = window.innerWidth;
             publishHeaderHeight();
-            observe();
+            const offset = Math.ceil(headerOffset());
+            if (offset !== lastOffset) {
+              lastOffset = offset;
+              observe();
+            }
           }, 250);
         });
 


### PR DESCRIPTION
## Summary
User-reported on-device: scrolling turns rough exactly at the toolbar's sticky transition on phones (not reproducible visually in desktop browsers).

**Root cause, measured with Playwright layout-shift instrumentation at 390x844:** the v2.3.0 stuck state collapsed the toolbar's flow height (~95-138px wrapped -> ~50px row). Every is-stuck flip shifted all content below by that delta: **0.12-0.14 layout shift per crossing** (Google's 'good' budget for an entire page load is 0.10), and readers cross the threshold constantly near the top of an article. Desktop repaints too fast to feel it, which is why it only showed on real phones.

## Fix
- Below 768px the toolbar is ONE constant-height (50.7px) swipeable row at every scroll position - the chronology decade-strip pattern. `Connections - N` leads the row (star action, always visible at rest); Permanent link + Share sit past the right edge.
- Sticking now only restyles row contents: REF appears, Permanent/Share hide (width-only, inside the scrollable row), Connections takes the oxblood accent. **Measured shift per crossing: 0.12-0.14 -> 0.0048** (residual = internal horizontal button swap; total over 8 crossings 1.19 -> 0.038).
- Resize-handler hardening for phone URL-bar churn: height-only resizes ignored (width tracked), `--saho-header-height` rewritten only when changed (same-value root-var writes dirty styles page-wide), IntersectionObserver rebuilt only when the offset actually moved.

## Verification
- Before/after with identical instrumentation (8 threshold crossings): heights 94.7/50.7 -> 50.7/50.7; CLS table in the measurements above.
- Stuck adjacency re-verified (toolbar top == header bottom incl. admin-toolbar displacement); at-rest row shows Connections first at x=42.
- Desktop untouched (all changes inside the <48rem media block + JS guards). Component CSS/JS are source files - no build. biome clean.