### PR TITLE
fix(footer): remove the SAHO Board Members link

### DIFF
--- a/webroot/themes/custom/saho/components/page-footer/page-footer.twig
+++ b/webroot/themes/custom/saho/components/page-footer/page-footer.twig
@@ -76,7 +76,6 @@
       <h2 class="saho-footer__col-title">About SAHO</h2>
       <ul class="saho-footer__links">
         <li><a href="/about-us">About us</a></li>
-        <li><a href="/about-us#saho-board-members">SAHO Board Members</a></li>
         <li><a href="/partners">Partners</a></li>
         <li><a href="/funders">Funders</a></li>
         <li><a href="/contact-us">Contact us</a></li>


### PR DESCRIPTION
Fixes #547.

Omar asked for the Board Members entry to go: many board members resigned, and the link's `/about-us#saho-board-members` anchor has no target anyway.

Checked "anywhere else it might be displayed" as the issue asks: the hardcoded footer line in `page-footer.twig` was the only occurrence - no menu_link_content rows, no block content, no other templates mention it, and the only "board member" text on /about-us was the footer itself. Verified 0 occurrences site-wide on local after removal.

Twig-only change - no build, no config.