### PR TITLE
feat(seo): 301 language-prefix duplicates to English + x-default hreflang for classroom decks

### DIFF
--- a/config/sync/saho_performance.settings.yml
+++ b/config/sync/saho_performance.settings.yml
@@ -1,0 +1,6 @@
+enable_css_removal: true
+aggressive_css_minify: true
+critical_css_size: 14000
+enable_monitoring: true
+enable_preload_hints: true
+language_redirect_enabled: true

--- a/webroot/modules/custom/saho_classroom/saho_classroom.module
+++ b/webroot/modules/custom/saho_classroom/saho_classroom.module
@@ -268,6 +268,57 @@ function saho_classroom_node_view(array &$build, EntityInterface $node, $display
 }
 
 /**
+ * Implements hook_page_attachments().
+ *
+ * Completes the hreflang cluster on translated deck pages with x-default.
+ * Core content_translation already emits one hreflang alternate per
+ * viewable translation on canonical entity routes, but never x-default -
+ * without it Google has no designated fallback for the ~10 language
+ * variants of each deck. Points at the default-language (English) URL.
+ * Untranslated nodes get nothing extra (their prefixed variants 301 away).
+ */
+function saho_classroom_page_attachments(array &$attachments): void {
+  $route_match = \Drupal::routeMatch();
+  if ($route_match->getRouteName() !== 'entity.node.canonical') {
+    return;
+  }
+  $node = $route_match->getParameter('node');
+  if (!$node instanceof NodeInterface) {
+    return;
+  }
+
+  $attachments['#cache']['tags'] = Cache::mergeTags(
+    $attachments['#cache']['tags'] ?? [],
+    $node->getCacheTags()
+  );
+
+  $default = $node->getUntranslated();
+  if (count($node->getTranslationLanguages()) < 2 || !$default->isPublished()) {
+    return;
+  }
+
+  $generated = $default->toUrl('canonical', [
+    'absolute' => TRUE,
+    'language' => $default->language(),
+  ])->toString(TRUE);
+  $attachments['#attached']['html_head_link'][] = [
+    [
+      'rel' => 'alternate',
+      'hreflang' => 'x-default',
+      'href' => $generated->getGeneratedUrl(),
+    ],
+  ];
+  $attachments['#cache']['tags'] = Cache::mergeTags(
+    $attachments['#cache']['tags'],
+    $generated->getCacheTags()
+  );
+  $attachments['#cache']['contexts'] = array_merge(
+    $attachments['#cache']['contexts'] ?? [],
+    $generated->getCacheContexts()
+  );
+}
+
+/**
  * Adds a strip under a presentation deck linking back to its origin article.
  *
  * The reverse of the teacher CTA on legacy articles: learners and teachers

--- a/webroot/modules/custom/saho_performance/config/install/saho_performance.settings.yml
+++ b/webroot/modules/custom/saho_performance/config/install/saho_performance.settings.yml
@@ -1,0 +1,6 @@
+enable_css_removal: true
+aggressive_css_minify: true
+critical_css_size: 14000
+enable_monitoring: true
+enable_preload_hints: true
+language_redirect_enabled: true

--- a/webroot/modules/custom/saho_performance/config/schema/saho_performance.schema.yml
+++ b/webroot/modules/custom/saho_performance/config/schema/saho_performance.schema.yml
@@ -1,0 +1,22 @@
+saho_performance.settings:
+  type: config_object
+  label: 'SAHO Performance settings'
+  mapping:
+    enable_css_removal:
+      type: boolean
+      label: 'Enable unused CSS removal'
+    aggressive_css_minify:
+      type: boolean
+      label: 'Aggressive CSS minification'
+    critical_css_size:
+      type: integer
+      label: 'Critical CSS size limit (bytes)'
+    enable_monitoring:
+      type: boolean
+      label: 'Enable performance monitoring'
+    enable_preload_hints:
+      type: boolean
+      label: 'Enable preload hints'
+    language_redirect_enabled:
+      type: boolean
+      label: 'Redirect untranslated language-prefixed URLs to English'

--- a/webroot/modules/custom/saho_performance/saho_performance.install
+++ b/webroot/modules/custom/saho_performance/saho_performance.install
@@ -27,6 +27,25 @@ function saho_performance_install() {
 }
 
 /**
+ * Seed saho_performance.settings so the full object exists in active config.
+ */
+function saho_performance_update_10001() {
+  // config/install never runs for an already-installed module, and the
+  // settings form only writes keys it knows about - so seed every key
+  // (form defaults) plus the new language-redirect kill-switch. Existing
+  // form-saved values win via ?? on each key.
+  $config = \Drupal::configFactory()->getEditable('saho_performance.settings');
+  $config
+    ->set('enable_css_removal', $config->get('enable_css_removal') ?? TRUE)
+    ->set('aggressive_css_minify', $config->get('aggressive_css_minify') ?? TRUE)
+    ->set('critical_css_size', $config->get('critical_css_size') ?? 14000)
+    ->set('enable_monitoring', $config->get('enable_monitoring') ?? TRUE)
+    ->set('enable_preload_hints', $config->get('enable_preload_hints') ?? TRUE)
+    ->set('language_redirect_enabled', $config->get('language_redirect_enabled') ?? TRUE)
+    ->save();
+}
+
+/**
  * Implements hook_uninstall().
  */
 function saho_performance_uninstall() {

--- a/webroot/modules/custom/saho_performance/saho_performance.services.yml
+++ b/webroot/modules/custom/saho_performance/saho_performance.services.yml
@@ -10,6 +10,12 @@ services:
     tags:
       - { name: event_subscriber }
 
+  saho_performance.language_prefix_redirect_subscriber:
+    class: Drupal\saho_performance\EventSubscriber\LanguagePrefixRedirectSubscriber
+    arguments: ['@current_route_match', '@config.factory']
+    tags:
+      - { name: event_subscriber }
+
   saho_performance.facet_flood_subscriber:
     class: Drupal\saho_performance\EventSubscriber\FacetFloodSubscriber
     arguments: ['@current_route_match']

--- a/webroot/modules/custom/saho_performance/src/EventSubscriber/LanguagePrefixRedirectSubscriber.php
+++ b/webroot/modules/custom/saho_performance/src/EventSubscriber/LanguagePrefixRedirectSubscriber.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\saho_performance\EventSubscriber;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Routing\LocalRedirectResponse;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Redirects language-prefixed URLs of untranslated content to English.
+ *
+ * The site enables 11 languages via URL path prefixes, but only classroom
+ * presentation nodes carry real translations. Every other page renders
+ * identical English content under all 10 non-English prefixes - each
+ * self-canonical, so Google sees a 10x site mirror and piles the copies
+ * into "Crawled - currently not indexed". No frontend navigation links to
+ * prefixed URLs, so redirecting them breaks nothing.
+ *
+ * The redirect target is simply the request path minus the prefix: inbound
+ * processing is strip-prefix-then-resolve-alias, so that IS the English URL
+ * for the same resource, and a prefixless request never re-enters the
+ * redirect branch (the default language has an empty prefix) - loop-proof
+ * by construction. The one legitimate prefixed 200 - a published node
+ * translation on its canonical route - passes through untouched, as do
+ * admin routes (node edit / translation overview run in the admin theme,
+ * so they all carry _admin_route).
+ *
+ * Kill-switch: saho_performance.settings:language_redirect_enabled (the
+ * config cache tag rides every 301, so unticking it invalidates cached
+ * redirects without a deploy).
+ */
+final class LanguagePrefixRedirectSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly RouteMatchInterface $routeMatch,
+    private readonly ConfigFactoryInterface $configFactory,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    // Priority 31: after RouterListener (32) so the route and its upcast
+    // node parameter exist, but before redirect.route_normalizer (30) so a
+    // prefixed alias 301s straight to the English alias in a single hop.
+    // setResponse() stops propagation, so later REQUEST subscribers never
+    // see redirected requests.
+    return [KernelEvents::REQUEST => ['onRequest', 31]];
+  }
+
+  /**
+   * Redirects prefixed requests for untranslated content to English.
+   */
+  public function onRequest(RequestEvent $event): void {
+    $request = $event->getRequest();
+    if (!$event->isMainRequest() || !$request->isMethodSafe()) {
+      return;
+    }
+    $settings = $this->configFactory->get('saho_performance.settings');
+    if (!$settings->get('language_redirect_enabled')) {
+      return;
+    }
+
+    // Match the first path segment against the same prefix map the language
+    // negotiator uses. The default language's empty prefix drops out, so a
+    // hit means the URL carried a real non-English prefix.
+    $negotiation = $this->configFactory->get('language.negotiation');
+    $prefixes = array_filter($negotiation->get('url.prefixes') ?? []);
+    $segments = explode('/', ltrim($request->getPathInfo(), '/'), 2);
+    $langcode = array_search($segments[0], $prefixes, TRUE);
+    if ($langcode === FALSE) {
+      return;
+    }
+
+    // Editor and translation UIs (node edit, delete, translation overview)
+    // all run as admin routes and pass through untouched.
+    $route = $this->routeMatch->getRouteObject();
+    if ($route === NULL || $route->getOption('_admin_route')) {
+      return;
+    }
+
+    // The canonical node page is the only URL whose prefixed variant can be
+    // a distinct document: a real published translation (classroom decks).
+    // Sub-routes with a node parameter (/node/N/connections) render English
+    // UI identical to their unprefixed twin and still redirect.
+    if ($this->routeMatch->getRouteName() === 'entity.node.canonical') {
+      $node = $this->routeMatch->getParameter('node');
+      if ($node instanceof ContentEntityInterface && $node->hasTranslation($langcode)) {
+        $translation = $node->getTranslation($langcode);
+        if (!$translation instanceof EntityPublishedInterface || $translation->isPublished()) {
+          return;
+        }
+      }
+    }
+
+    // Same URL minus the prefix ('/zu' becomes '/'), query string intact.
+    $target = $request->getBasePath() . '/' . ($segments[1] ?? '');
+    $query_string = $request->getQueryString();
+    if ($query_string !== NULL) {
+      $target .= '?' . $query_string;
+    }
+
+    $response = new LocalRedirectResponse($target, 301);
+    $response->addCacheableDependency(
+      (new CacheableMetadata())
+        ->addCacheContexts(['url.path', 'url.query_args'])
+        ->addCacheableDependency($settings)
+        ->addCacheableDependency($negotiation)
+        ->setCacheMaxAge(86400)
+    );
+    $event->setResponse($response);
+  }
+
+}

--- a/webroot/modules/custom/saho_performance/src/Form/PerformanceSettingsForm.php
+++ b/webroot/modules/custom/saho_performance/src/Form/PerformanceSettingsForm.php
@@ -123,6 +123,18 @@ class PerformanceSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('enable_preload_hints') ?? TRUE,
     ];
 
+    $form['seo'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('SEO'),
+    ];
+
+    $form['seo']['language_redirect_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Redirect untranslated language-prefixed URLs to English'),
+      '#description' => $this->t('301 requests like /nso/people/foo to /people/foo when no translation exists in that language. Published node translations (classroom decks) are served as-is. Unticking invalidates all cached redirects immediately.'),
+      '#default_value' => $config->get('language_redirect_enabled') ?? TRUE,
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -136,6 +148,7 @@ class PerformanceSettingsForm extends ConfigFormBase {
       ->set('critical_css_size', $form_state->getValue('critical_css_size'))
       ->set('enable_monitoring', $form_state->getValue('enable_monitoring'))
       ->set('enable_preload_hints', $form_state->getValue('enable_preload_hints'))
+      ->set('language_redirect_enabled', (bool) $form_state->getValue('language_redirect_enabled'))
       ->save();
 
     // Clear CSS cache to apply changes.

--- a/webroot/modules/custom/saho_performance/tests/src/Kernel/LanguagePrefixRedirectSubscriberTest.php
+++ b/webroot/modules/custom/saho_performance/tests/src/Kernel/LanguagePrefixRedirectSubscriberTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_performance\Kernel;
+
+use Drupal\Core\Routing\RouteObjectInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Real-entity coverage for the language-prefix redirect.
+ *
+ * The decision matrix lives in the unit test; this covers the two cases a
+ * mock cannot honestly fake - a real upcast node with a real translation
+ * passing through, and a real untranslated node redirecting.
+ *
+ * @group saho_performance
+ */
+final class LanguagePrefixRedirectSubscriberTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'node',
+    'language',
+    'content_translation',
+    'saho_performance',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['language', 'saho_performance']);
+
+    ConfigurableLanguage::createFromLangcode('zu')->save();
+    $this->config('language.negotiation')
+      ->set('url.prefixes', ['en' => '', 'zu' => 'zu'])
+      ->save();
+
+    NodeType::create(['type' => 'presentation', 'name' => 'Presentation'])->save();
+    $this->container->get('content_translation.manager')
+      ->setEnabled('node', 'presentation', TRUE);
+  }
+
+  /**
+   * Runs the subscriber for a path + upcast node, returns the Location.
+   */
+  private function redirectFor(string $path, NodeInterface $node): ?string {
+    $request = Request::create($path);
+    $request->attributes->set(RouteObjectInterface::ROUTE_NAME, 'entity.node.canonical');
+    $request->attributes->set(RouteObjectInterface::ROUTE_OBJECT, new Route('/node/{node}'));
+    $request->attributes->set('node', $node);
+
+    $request_stack = $this->container->get('request_stack');
+    $request_stack->push($request);
+    try {
+      $event = new RequestEvent(
+        $this->container->get('http_kernel'),
+        $request,
+        HttpKernelInterface::MAIN_REQUEST
+      );
+      $this->container->get('saho_performance.language_prefix_redirect_subscriber')
+        ->onRequest($event);
+      $response = $event->getResponse();
+      return $response ? $response->headers->get('Location') : NULL;
+    }
+    finally {
+      $request_stack->pop();
+    }
+  }
+
+  /**
+   * A real published translation on its canonical route passes through.
+   */
+  public function testRealTranslationPassesThrough(): void {
+    $node = Node::create(['type' => 'presentation', 'title' => 'English deck']);
+    $node->addTranslation('zu', ['title' => 'Zulu deck']);
+    $node->save();
+
+    $this->assertNull($this->redirectFor('/zu/classroom/grade-4/zulu-deck', $node));
+  }
+
+  /**
+   * A real untranslated node under a prefix 301s to the unprefixed URL.
+   */
+  public function testUntranslatedNodeRedirects(): void {
+    $node = Node::create(['type' => 'presentation', 'title' => 'English only']);
+    $node->save();
+
+    $this->assertSame(
+      '/classroom/grade-4/english-only',
+      $this->redirectFor('/zu/classroom/grade-4/english-only', $node)
+    );
+  }
+
+}

--- a/webroot/modules/custom/saho_performance/tests/src/Unit/LanguagePrefixRedirectSubscriberTest.php
+++ b/webroot/modules/custom/saho_performance/tests/src/Unit/LanguagePrefixRedirectSubscriberTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\saho_performance\Unit;
+
+use Drupal\Core\Cache\Context\CacheContextsManager;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\NodeInterface;
+use Drupal\saho_performance\EventSubscriber\LanguagePrefixRedirectSubscriber;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Tests the language-prefix duplicate redirect decision matrix.
+ *
+ * The no-redirect cases are the guard against breaking real content: the
+ * unprefixed site, editor admin routes, and published node translations
+ * (classroom decks) must always pass through untouched.
+ *
+ * @coversDefaultClass \Drupal\saho_performance\EventSubscriber\LanguagePrefixRedirectSubscriber
+ * @group saho_performance
+ */
+class LanguagePrefixRedirectSubscriberTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    // Cache::mergeContexts() validates context tokens through the global
+    // container - stub the validator so cacheable 301s can be built.
+    $cache_contexts_manager = $this->createMock(CacheContextsManager::class);
+    $cache_contexts_manager->method('assertValidTokens')->willReturn(TRUE);
+    $container = new ContainerBuilder();
+    $container->set('cache_contexts_manager', $cache_contexts_manager);
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Runs the subscriber for a request/route and returns the Location header.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The incoming request.
+   * @param string $route_name
+   *   The matched route name.
+   * @param \Symfony\Component\Routing\Route|null $route
+   *   The route object; NULL simulates an unrouted request.
+   * @param \Drupal\node\NodeInterface|null $node
+   *   The upcast node parameter, if any.
+   * @param bool $enabled
+   *   The kill-switch state.
+   * @param int $request_type
+   *   Main or sub request.
+   *
+   * @return string|null
+   *   The redirect target, or NULL when the request passes through.
+   */
+  private function runFor(
+    Request $request,
+    string $route_name = 'entity.node.canonical',
+    ?Route $route = new Route('/'),
+    ?NodeInterface $node = NULL,
+    bool $enabled = TRUE,
+    int $request_type = HttpKernelInterface::MAIN_REQUEST,
+  ): ?string {
+    $route_match = $this->createMock(RouteMatchInterface::class);
+    $route_match->method('getRouteName')->willReturn($route_name);
+    $route_match->method('getRouteObject')->willReturn($route);
+    $route_match->method('getParameter')->with('node')->willReturn($node);
+
+    $event = new RequestEvent(
+      $this->createMock(HttpKernelInterface::class),
+      $request,
+      $request_type
+    );
+
+    $subscriber = new LanguagePrefixRedirectSubscriber($route_match, $this->configFactory($enabled));
+    $subscriber->onRequest($event);
+
+    $response = $event->getResponse();
+    if ($response === NULL) {
+      return NULL;
+    }
+    $this->assertSame(301, $response->getStatusCode());
+    return $response->headers->get('Location');
+  }
+
+  /**
+   * Builds a config factory serving real immutable config objects.
+   *
+   * Real ImmutableConfig (not stubs) so the subscriber's dot-notation get()
+   * and cacheable-dependency merging run for real.
+   */
+  private function configFactory(bool $enabled): ConfigFactoryInterface {
+    $storage = $this->createMock(StorageInterface::class);
+    $dispatcher = $this->createMock(EventDispatcherInterface::class);
+    $typed = $this->createMock(TypedConfigManagerInterface::class);
+
+    $settings = new ImmutableConfig('saho_performance.settings', $storage, $dispatcher, $typed);
+    $settings->initWithData(['language_redirect_enabled' => $enabled]);
+
+    $negotiation = new ImmutableConfig('language.negotiation', $storage, $dispatcher, $typed);
+    $negotiation->initWithData([
+      'url' => [
+        'prefixes' => [
+          'en' => '',
+          'af' => 'af',
+          'zu' => 'zu',
+          'xh' => 'xh',
+          'nso' => 'nso',
+        ],
+      ],
+    ]);
+
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')->willReturnMap([
+      ['saho_performance.settings', $settings],
+      ['language.negotiation', $negotiation],
+    ]);
+    return $factory;
+  }
+
+  /**
+   * Mocks a node whose zu translation exists with the given publish state.
+   */
+  private function translatedNode(bool $published): NodeInterface {
+    $translation = $this->createMock(NodeInterface::class);
+    $translation->method('isPublished')->willReturn($published);
+
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasTranslation')->with('zu')->willReturn(TRUE);
+    $node->method('getTranslation')->with('zu')->willReturn($translation);
+    return $node;
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testPrefixedAliasRedirectsToUnprefixed(): void {
+    $this->assertSame(
+      '/people/solomon-kalushi-mahlangu',
+      $this->runFor(Request::create('/nso/people/solomon-kalushi-mahlangu'))
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testQueryStringIsPreserved(): void {
+    $this->assertSame(
+      '/search?search_api_fulltext=x',
+      $this->runFor(Request::create('/zu/search?search_api_fulltext=x'), 'view.saho_global_search.page_1')
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testBarePrefixRedirectsToFrontPage(): void {
+    $this->assertSame('/', $this->runFor(Request::create('/zu')));
+    $this->assertSame('/', $this->runFor(Request::create('/zu/')));
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testUntranslatedNodeRedirects(): void {
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasTranslation')->willReturn(FALSE);
+    $this->assertSame(
+      '/people/florence-elizabeth-mnumzana',
+      $this->runFor(Request::create('/xh/people/florence-elizabeth-mnumzana'), 'entity.node.canonical', new Route('/'), $node)
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testPublishedTranslationIsSpared(): void {
+    $this->assertNull(
+      $this->runFor(Request::create('/zu/classroom/grade-4/some-deck'), 'entity.node.canonical', new Route('/'), $this->translatedNode(TRUE))
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testUnpublishedTranslationStillRedirects(): void {
+    $this->assertSame(
+      '/classroom/grade-4/some-deck',
+      $this->runFor(Request::create('/zu/classroom/grade-4/some-deck'), 'entity.node.canonical', new Route('/'), $this->translatedNode(FALSE))
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testNodeSubRouteRedirectsEvenForTranslatedNode(): void {
+    // /node/N/connections renders English UI identical to its unprefixed
+    // twin - the translation exception applies to the canonical route only.
+    $this->assertSame(
+      '/node/16528/connections',
+      $this->runFor(Request::create('/zu/node/16528/connections'), 'saho_connections.hub', new Route('/'), $this->translatedNode(TRUE))
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testUnprefixedPathPassesThrough(): void {
+    $this->assertNull($this->runFor(Request::create('/people/solomon-kalushi-mahlangu')));
+    $this->assertNull($this->runFor(Request::create('/')));
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testUnknownFirstSegmentDoesNotMatchPrefixes(): void {
+    // 'peoples' must not fuzzy-match any prefix.
+    $this->assertNull($this->runFor(Request::create('/peoples/x')));
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testUnsafeMethodPassesThrough(): void {
+    $this->assertNull($this->runFor(Request::create('/zu/people/x', 'POST')));
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testSubRequestPassesThrough(): void {
+    $this->assertNull(
+      $this->runFor(Request::create('/zu/people/x'), 'entity.node.canonical', new Route('/'), NULL, TRUE, HttpKernelInterface::SUB_REQUEST)
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testAdminRoutePassesThrough(): void {
+    $route = new Route('/node/{node}/edit');
+    $route->setOption('_admin_route', TRUE);
+    $this->assertNull(
+      $this->runFor(Request::create('/zu/node/1/edit'), 'entity.node.edit_form', $route)
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testUnroutedRequestPassesThrough(): void {
+    $this->assertNull($this->runFor(Request::create('/zu/people/x'), '', NULL));
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testKillSwitchDisablesRedirects(): void {
+    $this->assertNull(
+      $this->runFor(Request::create('/nso/people/x'), 'entity.node.canonical', new Route('/'), NULL, FALSE)
+    );
+  }
+
+}


### PR DESCRIPTION
## Why

GSC "Crawled - currently not indexed" is filling with language-prefixed URLs (`/nso/people/...`, `/xh/archive/...` - 434 rows, validation failed 7/25). The site enables 11 languages via URL path prefixes, but only classroom presentation decks carry real translations (~41 decks x ~10 languages). Everything else renders identical English content under all 10 non-English prefixes, each variant self-canonical - a 10x site mirror. Once Googlebot enters any prefixed URL, every internal link preserves the prefix, so the whole mirror gets crawled. The sitemap was already clean (en-only); this is SEO recovery Phase 3 (hreflang/translations).

## What

**`LanguagePrefixRedirectSubscriber`** (saho_performance, REQUEST priority 31 - after routing, before `redirect.route_normalizer` so prefixed aliases 301 in a single hop):
- 301s any language-prefixed URL to the same path minus the prefix (query string preserved, `/zu/` -> `/`). Loop-proof by construction: the target has no prefix, and unprefixed requests never enter the redirect branch.
- Spared: published node translations on `entity.node.canonical` (the classroom decks), admin routes (`_admin_route` covers all editor/translation UIs), unsafe methods, sub-requests.
- Cacheable 301 (max-age 86400) carrying the config cache tags of `saho_performance.settings` + `language.negotiation`.
- Kill-switch checkbox on the performance settings form: unticking invalidates every cached 301 instantly via the config tag - no deploy, no cache clear (verified locally).

Config plumbing: first schema file for `saho_performance.settings` (all six keys), `config/install` defaults, `saho_performance_update_10001()` seeds active config, exported `config/sync/saho_performance.settings.yml`.

**x-default hreflang** (saho_classroom): core `content_translation` already emits per-translation hreflang alternates on canonical entity routes but never `x-default`; a small `hook_page_attachments()` adds it, pointing at the English deck URL.

## Testing

- 14 unit tests (full decision matrix incl. negative guards) + 2 kernel tests (real translation passes through, real untranslated node redirects). Full custom suite: 259 tests, 0 failures.
- phpcs (Drupal, CI flags) clean; drupal-check clean for touched code.
- Local curl matrix verified: prefixed alias 301, bare prefix -> `/`, query preserved, translated deck 200 with bidirectional hreflang cluster + single x-default, English pages untouched, `/zu/node/N/connections` 301s, POST not redirected, kill-switch flips live.

## Deploy notes

- `drush updb` required (update 10001).
- Purge Cloudflare after deploy so cached prefixed 200s are replaced by the 301s.
- GSC follow-up: restart validation on "Crawled - currently not indexed"; the language-prefix rows should drain over the following weeks while the ~400 translated deck URLs stay 200.