### PR TITLE
perf(statistics): precompute popular searches, covering index, bot filter

### DIFF
--- a/webroot/modules/custom/saho_statistics/saho_statistics.install
+++ b/webroot/modules/custom/saho_statistics/saho_statistics.install
@@ -79,6 +79,7 @@ function saho_statistics_schema() {
       'timestamp' => ['timestamp'],
       'uid' => ['uid'],
       'index_id' => ['index_id'],
+      'popular_searches' => ['timestamp', 'result_count', ['query_text', 191]],
     ],
   ];
 

--- a/webroot/modules/custom/saho_statistics/saho_statistics.module
+++ b/webroot/modules/custom/saho_statistics/saho_statistics.module
@@ -132,20 +132,20 @@ function saho_statistics_entity_update(EntityInterface $entity) {
  * drupalSettings so the search modal can render live data instead of
  * hardcoded chips. Falls back gracefully to an empty array so the Twig
  * fallback chips remain visible if no data exists yet.
+ *
+ * The list is precomputed hourly in saho_statistics_cron() and stored in
+ * state, so this hook never queries the database. The previous cache-based
+ * implementation ran a multi-second GROUP BY over saho_search_queries on
+ * every cache miss, which stampeded under load whenever Redis evicted the
+ * entry (2026-07-31 production incident).
  */
 function saho_statistics_page_attachments(array &$attachments) {
-  $cid = 'saho_statistics:popular_searches';
-  $cache = \Drupal::cache()->get($cid);
-
-  if ($cache) {
-    $popular = $cache->data;
-  }
-  else {
-    $popular = _saho_statistics_get_popular_searches(8);
-    // Cache for 15 minutes so trending topics stay reasonably fresh.
-    \Drupal::cache()->set($cid, $popular, \Drupal::time()->getRequestTime() + 900);
+  // The search modal only renders on the public-facing theme.
+  if (\Drupal::service('router.admin_context')->isAdminRoute()) {
+    return;
   }
 
+  $popular = \Drupal::state()->get('saho_statistics.popular_searches', []);
   $attachments['#attached']['drupalSettings']['sahoSearch']['popularSearches'] = $popular;
 }
 
@@ -274,5 +274,14 @@ function saho_statistics_cron() {
       '@count' => $deleted,
       '@days' => $retention_days,
     ]);
+  }
+
+  // Rebuild the popular-searches list at most once per hour. The GROUP BY
+  // over the full table is too slow for the request path, so cron is the
+  // only place it runs; hook_page_attachments() reads the state value.
+  $last_build = \Drupal::state()->get('saho_statistics.popular_searches_last_build', 0);
+  if (($now - $last_build) >= 3600) {
+    \Drupal::state()->set('saho_statistics.popular_searches', _saho_statistics_get_popular_searches(8));
+    \Drupal::state()->set('saho_statistics.popular_searches_last_build', $now);
   }
 }

--- a/webroot/modules/custom/saho_statistics/saho_statistics.post_update.php
+++ b/webroot/modules/custom/saho_statistics/saho_statistics.post_update.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the SAHO Statistics module.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Adds a covering index for the popular-searches query and seeds the state.
+ *
+ * During the 2026-07-31 production incident the popular-searches query
+ * (GROUP BY over saho_search_queries) showed up in the PHP-FPM slowlog as a
+ * full table scan with a temporary table and filesort (~3-4s over 252k rows).
+ * The 90-day window matches essentially the whole table (retention is also
+ * 90 days), so selectivity cannot help; a covering index on
+ * (timestamp, result_count, query_text) lets MySQL satisfy the query with an
+ * index-only scan instead of reading full rows.
+ *
+ * The query itself now only runs from cron, which stores the result in the
+ * saho_statistics.popular_searches state entry. Seed that entry here so the
+ * search modal has live chips immediately after deploy instead of waiting up
+ * to an hour for the first cron rebuild.
+ */
+function saho_statistics_post_update_popular_searches_covering_index(&$sandbox = NULL): string {
+  $schema = \Drupal::database()->schema();
+  $added = FALSE;
+
+  if (!$schema->indexExists('saho_search_queries', 'popular_searches')) {
+    \Drupal::moduleHandler()->loadInclude('saho_statistics', 'install');
+    $spec = saho_statistics_schema()['saho_search_queries'];
+    $schema->addIndex(
+      'saho_search_queries',
+      'popular_searches',
+      ['timestamp', 'result_count', ['query_text', 191]],
+      $spec
+    );
+    $added = TRUE;
+  }
+
+  \Drupal::state()->set('saho_statistics.popular_searches', _saho_statistics_get_popular_searches(8));
+  \Drupal::state()->set('saho_statistics.popular_searches_last_build', \Drupal::time()->getRequestTime());
+
+  return $added
+    ? 'Added the popular_searches covering index and seeded the precomputed popular-searches list.'
+    : 'The popular_searches index already existed; seeded the precomputed popular-searches list.';
+}

--- a/webroot/modules/custom/saho_statistics/src/EventSubscriber/SearchQueryTracker.php
+++ b/webroot/modules/custom/saho_statistics/src/EventSubscriber/SearchQueryTracker.php
@@ -21,6 +21,16 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class SearchQueryTracker implements EventSubscriberInterface {
 
   /**
+   * Case-insensitive User-Agent pattern identifying crawlers and scrapers.
+   *
+   * Searches performed by bots are not user intent and would dominate the
+   * popular-searches analytics (honest bots alone accounted for thousands of
+   * requests per log sample during the 2026-07-31 incident). Names sourced
+   * from .htaccess-bot-blocking and the saho_tools robots.txt list.
+   */
+  protected const BOT_UA_PATTERN = '/bot|crawl|spider|slurp|scrape|python-requests|go-http-client|httpclient|curl|wget|petalbot|bytespider|bytedance|baiduspider|sogou|yandex|semrush|ahrefs|mj12|blexbot/i';
+
+  /**
    * The database connection.
    *
    * @var \Drupal\Core\Database\Connection
@@ -104,6 +114,12 @@ class SearchQueryTracker implements EventSubscriberInterface {
       return;
     }
 
+    // Skip crawlers and scrapers - their searches are not user intent and
+    // inflate both the table and the popular-searches analytics built on it.
+    if ($this->isBotRequest()) {
+      return;
+    }
+
     $query = $event->getQuery();
 
     // Only track queries that originate from a real Views search page. The
@@ -169,6 +185,29 @@ class SearchQueryTracker implements EventSubscriberInterface {
       // Clean up temporary storage.
       unset($this->tempStorage[$query_id]);
     }
+  }
+
+  /**
+   * Determines whether the current request comes from a known bot.
+   *
+   * An absent or empty User-Agent is also treated as a bot: every real
+   * browser sends one, while primitive scrapers frequently omit it.
+   *
+   * @return bool
+   *   TRUE if the request has no User-Agent or a bot-like one.
+   */
+  protected function isBotRequest(): bool {
+    $request = $this->requestStack->getCurrentRequest();
+    if (!$request) {
+      return FALSE;
+    }
+
+    $user_agent = (string) $request->headers->get('User-Agent', '');
+    if ($user_agent === '') {
+      return TRUE;
+    }
+
+    return (bool) preg_match(static::BOT_UA_PATTERN, $user_agent);
   }
 
   /**

--- a/webroot/modules/custom/saho_statistics/tests/src/Kernel/EventSubscriber/SearchQueryTrackerTest.php
+++ b/webroot/modules/custom/saho_statistics/tests/src/Kernel/EventSubscriber/SearchQueryTrackerTest.php
@@ -9,6 +9,7 @@ use Drupal\search_api\Event\ProcessingResultsEvent;
 use Drupal\search_api\Event\SearchApiEvents;
 use Drupal\search_api\Query\Query;
 use Drupal\search_api\Query\ResultSet;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests search query tracking functionality.
@@ -336,6 +337,127 @@ class SearchQueryTrackerTest extends KernelTestBase {
       ->fetchField();
 
     $this->assertEquals(1, $count, 'Recent queries are retained.');
+  }
+
+  /**
+   * Tests that bot searches are not tracked.
+   *
+   * Bots hitting /search were inserting hundreds of rows per hour into
+   * saho_search_queries (2026-07-31 incident), polluting the analytics the
+   * popular-searches feature is built on.
+   */
+  public function testBotQueriesNotTracked() {
+    $index = $this->createMock(Index::class);
+    $index->method('id')->willReturn('test_index');
+
+    $query = $this->createMock(Query::class);
+    $query->method('getKeys')->willReturn('bot search');
+    $query->method('getIndex')->willReturn($index);
+    $query->method('getOption')->willReturn('saho_global_search');
+    $query->method('getConditionGroup')->willReturn($this->createMock('Drupal\search_api\Query\ConditionGroupInterface'));
+
+    $request_stack = $this->container->get('request_stack');
+
+    // A crawler User-Agent must not produce a row.
+    $bot_request = Request::create('/search');
+    $bot_request->headers->set('User-Agent', 'Mozilla/5.0 (compatible; Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)');
+    $request_stack->push($bot_request);
+
+    $this->eventDispatcher->dispatch(new QueryPreExecuteEvent($query), SearchApiEvents::QUERY_PRE_EXECUTE);
+
+    $results = $this->createMock(ResultSet::class);
+    $results->method('getResultCount')->willReturn(12);
+    $results->method('getQuery')->willReturn($query);
+    $this->eventDispatcher->dispatch(new ProcessingResultsEvent($results), SearchApiEvents::PROCESSING_RESULTS);
+
+    $request_stack->pop();
+
+    $count = $this->database->select('saho_search_queries', 's')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $count, 'Bot searches are not tracked.');
+
+    // An empty User-Agent is also treated as a bot.
+    $empty_ua_request = Request::create('/search');
+    $empty_ua_request->headers->remove('User-Agent');
+    $request_stack->push($empty_ua_request);
+
+    $this->eventDispatcher->dispatch(new QueryPreExecuteEvent($query), SearchApiEvents::QUERY_PRE_EXECUTE);
+    $this->eventDispatcher->dispatch(new ProcessingResultsEvent($results), SearchApiEvents::PROCESSING_RESULTS);
+
+    $request_stack->pop();
+
+    $count = $this->database->select('saho_search_queries', 's')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $count, 'Searches without a User-Agent are not tracked.');
+
+    // A regular browser User-Agent still produces a row.
+    $browser_request = Request::create('/search');
+    $browser_request->headers->set('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36');
+    $request_stack->push($browser_request);
+
+    $this->eventDispatcher->dispatch(new QueryPreExecuteEvent($query), SearchApiEvents::QUERY_PRE_EXECUTE);
+    $this->eventDispatcher->dispatch(new ProcessingResultsEvent($results), SearchApiEvents::PROCESSING_RESULTS);
+
+    $request_stack->pop();
+
+    $count = $this->database->select('saho_search_queries', 's')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(1, $count, 'Browser searches are still tracked.');
+  }
+
+  /**
+   * Tests that cron precomputes the popular-searches state value.
+   *
+   * The GROUP BY over saho_search_queries only runs from cron; the render
+   * path reads the saho_statistics.popular_searches state entry. Covers the
+   * JSON-encoded Search API keys decoding, the >=5-results and >=2-searches
+   * thresholds, and ordering by search count.
+   */
+  public function testCronBuildsPopularSearches() {
+    $now = \Drupal::time()->getRequestTime();
+    $json_keys = json_encode(['#conjunction' => 'AND', 0 => 'nelson', 1 => 'mandela']);
+
+    $rows = [
+      // Three searches for "nelson mandela" (JSON-encoded keys shape).
+      ['query_text' => $json_keys, 'result_count' => 20, 'timestamp' => $now - 100],
+      ['query_text' => $json_keys, 'result_count' => 20, 'timestamp' => $now - 200],
+      ['query_text' => $json_keys, 'result_count' => 20, 'timestamp' => $now - 300],
+      // Two searches for a plain-text legacy query.
+      ['query_text' => 'apartheid', 'result_count' => 15, 'timestamp' => $now - 400],
+      ['query_text' => 'apartheid', 'result_count' => 15, 'timestamp' => $now - 500],
+      // Only one search: below the >=2 threshold, must be excluded.
+      ['query_text' => 'one-off typo', 'result_count' => 9, 'timestamp' => $now - 600],
+      // Two searches but too few results: below the >=5 threshold.
+      ['query_text' => 'obscure', 'result_count' => 1, 'timestamp' => $now - 700],
+      ['query_text' => 'obscure', 'result_count' => 1, 'timestamp' => $now - 800],
+    ];
+    foreach ($rows as $row) {
+      $this->database->insert('saho_search_queries')
+        ->fields($row + ['index_id' => 'test', 'uid' => 0])
+        ->execute();
+    }
+
+    saho_statistics_cron();
+
+    $popular = \Drupal::state()->get('saho_statistics.popular_searches');
+    $this->assertIsArray($popular);
+    $this->assertCount(2, $popular, 'Only queries meeting both thresholds are included.');
+
+    $this->assertEquals('Nelson Mandela', $popular[0]['label'], 'JSON keys are decoded and the most-searched query ranks first.');
+    $this->assertEquals('/search?search_api_fulltext=' . rawurlencode('Nelson Mandela'), $popular[0]['url']);
+    $this->assertEquals('Apartheid', $popular[1]['label'], 'Plain-text legacy rows are title-cased.');
+
+    // A second cron run within the hour must not rebuild (throttle).
+    \Drupal::state()->set('saho_statistics.popular_searches', [['label' => 'Sentinel', 'url' => '/x']]);
+    saho_statistics_cron();
+    $popular = \Drupal::state()->get('saho_statistics.popular_searches');
+    $this->assertEquals('Sentinel', $popular[0]['label'], 'Rebuild is throttled to once per hour.');
   }
 
 }


### PR DESCRIPTION
## Context (2026-07-31 production incident)

The FPM slowlog showed `_saho_statistics_get_popular_searches()` full-scanning `saho_search_queries` (~3-4s over 252k rows: `type=ALL, Using temporary; Using filesort`) from `hook_page_attachments()`. The 15-minute cache entry was evicted constantly by the Redis eviction storm, and with no stampede protection every concurrent worker re-ran the query on each miss.

## Changes

- **`hook_page_attachments()` no longer touches the database.** It reads `saho_statistics.popular_searches` from state (chainedfast-backed, eviction-immune) and skips admin routes.
- **The GROUP BY runs only from cron**, at most hourly (same state-throttle idiom as the daycount reset).
- **New post_update** adds a covering index `(timestamp, result_count, query_text(191))` - the 90-day window matches the whole table (retention is also 90d), so an index-only scan is the win, not selectivity. It also seeds the state entry so search-modal chips survive the deploy without waiting for cron.
- **`SearchQueryTracker` skips bot/empty User-Agents.** Bots were inserting 250-1,400 analytics rows per hour, inflating the very table the slow query scans. Forged-browser scrapers are Cloudflare's job; this stops honest bots.

## Tests

- `testBotQueriesNotTracked` - bot UA and empty UA skipped, browser UA still tracked.
- `testCronBuildsPopularSearches` - JSON-keys decoding, >=5-results / >=2-searches thresholds, ordering, hourly throttle.
- 9/9 kernel tests green; phpcs (CI flags) and drupal-check clean.

## Deploy notes

Run `drush updb -y` (adds index + seeds state), then `drush cr`. Acceptance: no `saho_statistics` frames in the FPM slowlog over 24h.