### PR TITLE
fix(htaccess): static 403 error document + targeted origin scraper blocks

### DIFF
--- a/.htaccess.custom
+++ b/.htaccess.custom
@@ -95,9 +95,27 @@ RewriteRule ^(.+)\.(jpe?g|png)$ $1.webp [T=image/webp,E=accept:1,L]
   FallbackResource /index.php
 </IfModule>
 
+# Serve 403s from a static file. cPanel defines ErrorDocument 403 /403.shtml;
+# without the file the error subrequest falls through the front controller
+# into Drupal, whose response status (301/404) then REPLACES the 403 - which
+# silently neutralized every [F] rule below during the 2026-07-31 incident.
+ErrorDocument 403 /403.shtml
+
 # Various rewrite rules.
 <IfModule mod_rewrite.c>
   RewriteEngine on
+
+  # Scraper mitigation (2026-07-31 incident): a distributed fleet walks the
+  # faceted /classroom URL space on the language-prefixed variants at
+  # ~1,700 req/min. Only the prefixed variants are blocked - the English
+  # /classroom facets stay functional for real users; Cloudflare WAF
+  # challenges handle the remainder at the edge.
+  RewriteCond %{QUERY_STRING} !^$
+  RewriteRule ^[a-z]{2,3}/classroom - [F,L]
+
+  # Malformed JSON-LD @id parses: /LANG/ref/R-0123456. (trailing dot) is
+  # never a valid URL and each hit costs a full Drupal 404 bootstrap.
+  RewriteRule ^([a-z]{2,3}/)?ref/[A-Z]-[0-9]+\.$ - [F,L]
 
   # Set "protossl" to "s" if we were accessed via https://.  This is used later
   # if you enable "www." stripping or enforcement, in order to ensure that

--- a/webroot/403.shtml
+++ b/webroot/403.shtml
@@ -1,0 +1,1 @@
+<html><head><title>403 Forbidden</title></head><body><h1>403 Forbidden</h1></body></html>


### PR DESCRIPTION
## Context (2026-07-31 production incident)

Every `.htaccess` `[F]` rule on prod was silently inert: cPanel defines `ErrorDocument 403 /403.shtml`, the file didn't exist, so the error subrequest fell through the front controller into Drupal - which handled the ORIGINAL URI (PHP's `REQUEST_URI` survives internal redirects) and replaced the 403 with its own 301/404, at a full PHP bootstrap per request. This is why the scraper fleet (~1,700 req/min of faceted `/LANG/classroom` walks) produced the mysterious 301 storm (82% of all requests) instead of being blocked.

Hand-creating `403.shtml` on prod instantly turned the storm into static 403s (load 5 -> 2). This PR makes that permanent - `webroot/.htaccess` is scaffold-generated from `.htaccess.custom` on every `composer install`, so without this the next deploy would re-open the hole.

## Changes

- **`webroot/403.shtml`** (new, tracked): static 90-byte error document; makes every `[F]` rule terminate without PHP.
- **`.htaccess.custom`**: explicit `ErrorDocument 403 /403.shtml` + two targeted blocks:
  - query-string requests to language-prefixed `/classroom` variants (`/ss/`, `/ve/`, `/ts/`, ... = ~97% of the storm). English `/classroom` facets keep working for real users; Cloudflare WAF challenges cover the rest.
  - malformed `/LANG/ref/R-0123456.` URLs (trailing-dot JSON-LD `@id` parses) - never valid, each hit was a full Drupal 404 bootstrap (~15/min).

## Verified locally (DDEV apache-fpm)

| URL | Status |
|---|---|
| `/ss/classroom?x=1`, `/xh/classroom?type=lesson` | **403 static** |
| `/classroom?type=lesson` | 200 (facets intact) |
| `/xh/ref/R-0123456.`, `/ref/B-0080413.` | **403 static** |
| `/ss/classroom` (no query), homepage | 301 / 200 (unchanged) |

## Deploy notes

`composer install` regenerates `webroot/.htaccess` with these rules and intentionally replaces today's broader hand-added prod rule (which also blocked English facets). The hand-created `403.shtml` on prod is overwritten by the identical tracked file.