### PR TITLE
chore(composer): honest constraint floor for patched file_entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "drupal/facets": "^3.0",
         "drupal/field_display_toggle": "^1.0",
         "drupal/field_group": "^4.0",
-        "drupal/file_entity": "^2.5",
+        "drupal/file_entity": "~2.5.0",
         "drupal/fontawesome": "^3.0",
         "drupal/geofield": "^10.3",
         "drupal/geolocation": "^4.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87edce72f600d8a57a02a5afa4b09089",
+    "content-hash": "edadb59ad16b2aa0c5efd3daba4e763d",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## Problem

The `Validate Composer` CI job (prefer-stable and prefer-lowest) fails on **every PR**, including ones that touch no PHP at all (#564):

```
No available patcher was able to apply patch
patches/file_entity-drupal11.4-currentuser-type.patch to drupal/file_entity
```

The job resolves dependencies fresh, so `^2.5` pulls the new file_entity **2.8.0**, where the patch no longer applies. The lock (and prod) are on 2.5.0, where it does.

## Fix

Pin `drupal/file_entity` to `~2.5.0` - the version the patch actually targets - per the house rule that version-specific patches need honest constraint floors. Lock refresh is hash-only; the installed version does not change and the patch still applies (verified locally: `FileImageResponsiveFormatter` has the typed `$currentUser`/`$imageStyleStorage` properties).

## Follow-up (separate, considered PR)

file_entity 8.x-2.8 removed the untyped property redeclarations upstream, so an upgrade to `^2.8` can drop the patch entirely. That's a 3-minor upgrade of a content-critical contrib module and deserves its own testing pass, not a ride-along on a CI fix.

## Note

Merge this first, then rebase / 'Update branch' on #563 and #564 to turn their Validate Composer legs green.